### PR TITLE
IOS fix slow contact access due to photos temp file generation

### DIFF
--- a/CordovaLib/Classes/CDVContact.m
+++ b/CordovaLib/Classes/CDVContact.m
@@ -1311,13 +1311,12 @@ static NSDictionary* org_apache_cordova_contacts_defaultFields = nil;
         // get the temp directory path
         NSString* docsPath = [NSTemporaryDirectory ()stringByStandardizingPath];
         NSError* err = nil;
-        NSFileManager* fileMgr = [[NSFileManager alloc] init];
-        // generate unique file name
-        NSString* filePath;
-        int i = 1;
-        do {
-            filePath = [NSString stringWithFormat:@"%@/photo_%03d.jpg", docsPath, i++];
-        } while ([fileMgr fileExistsAtPath:filePath]);
+        NSString* filePath = [NSString stringWithFormat:@"%@/photo_XXXXX", docsPath];
+        char template[filePath.length + 1];
+        strcpy(template, [filePath cStringUsingEncoding:NSASCIIStringEncoding]);
+        char* filename = mktemp(template);
+        filePath = [NSString stringWithCString:filename encoding:NSASCIIStringEncoding];
+
         // save file
         if ([data writeToFile:filePath options:NSAtomicWrite error:&err]) {
             photos = [NSMutableArray arrayWithCapacity:1];


### PR DESCRIPTION
"Do-while test if tmp file exists" costs a lot. Use mktemp instead to generate photo tmp file.

Before (300 contacts with pictures):
5minutes

After:
10 seconds

NB: I made also a pull-request on phonegap central repository : https://github.com/phonegap/phonegap/pull/19
I figured out after that this repo would be the right place.
