### PR TITLE
[CB-2235] Fixed file transfer whitelisting.

### DIFF
--- a/CordovaLib/Classes/CDVFileTransfer.m
+++ b/CordovaLib/Classes/CDVFileTransfer.m
@@ -87,7 +87,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
 {
     [req setValue:@"XMLHttpRequest" forHTTPHeaderField:@"X-Requested-With"];
 
-    NSString* userAgent = [[self.webView request] valueForHTTPHeaderField:@"User-Agent"];
+    NSString* userAgent = [self.commandDelegate userAgent];
     if (userAgent) {
         [req setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     }


### PR DESCRIPTION
The user agent sometimes being set to nil in iOS6 eventually led to the whitelist regex checks being skipped.  Setting the user agent from the command delegate fixes this.
