### PR TITLE
Specify device family in command-line params

### DIFF
--- a/bin/templates/project/cordova/emulate
+++ b/bin/templates/project/cordova/emulate
@@ -34,9 +34,11 @@ XCODEPROJ=$( ls "$PROJECT_PATH" | grep .xcodeproj  )
 PROJECT_NAME=$(basename "$XCODEPROJ" .xcodeproj)
 
 APP_PATH=$1
+DEVICE_FAMILY=$2
 
 if [ $# -lt 1 ]; then
 	APP_PATH="$PROJECT_PATH/build/$PROJECT_NAME.app"
+	DEVICE_FAMILY=iphone
 fi
 
 if [ ! -d "$APP_PATH" ]; then
@@ -51,7 +53,7 @@ fi
 
 # launch using ios-sim
 if which ios-sim >/dev/null; then
-    ios-sim launch "$APP_PATH" --stderr "$CORDOVA_PATH/console.log" --stdout "$CORDOVA_PATH/console.log" &
+    ios-sim launch "$APP_PATH" --family "$DEVICE_FAMILY" --stderr "$CORDOVA_PATH/console.log" --stdout "$CORDOVA_PATH/console.log" &
 else
     echo -e '\033[31mError: ios-sim was not found. Please download, build and install version 1.4 or greater from https://github.com/phonegap/ios-sim into your path. Or "brew install ios-sim" using homebrew: http://mxcl.github.com/homebrew/\033[m'; exit 1;
 fi


### PR DESCRIPTION
This might not be the best approach to doing it but it ought to be supported as there doesn't appear to be another way of emulating a project in anything other than the default iPhone.
