### PR TITLE
[CB-861] Header support for FileTransfer download

### DIFF
--- a/CordovaLib/Classes/CDVFileTransfer.m
+++ b/CordovaLib/Classes/CDVFileTransfer.m
@@ -351,8 +351,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     NSString* sourceUrl = [command.arguments objectAtIndex:0];
     NSString* filePath = [command.arguments objectAtIndex:1];
     BOOL trustAllHosts = [[command.arguments objectAtIndex:2 withDefault:[NSNumber numberWithBool:YES]] boolValue]; // allow self-signed certs
-    NSDictionary* headers = [command.arguments objectAtIndex:3 withDefault:nil];
-    NSString* objectId = [command.arguments objectAtIndex:4];
+    NSString* objectId = [command.arguments objectAtIndex:3];
+    NSDictionary* headers = [command.arguments objectAtIndex:4 withDefault:nil];
 
     // return unsupported result for assets-library URLs
     if ([filePath hasPrefix:kCDVAssetsLibraryPrefix]) {
@@ -398,7 +398,6 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     delegate.objectId = objectId;
     delegate.source = sourceUrl;
     delegate.target = filePath;
-//    delegate.headers = headers;
     delegate.trustAllHosts = trustAllHosts;
 
     delegate.connection = [NSURLConnection connectionWithRequest:req delegate:delegate];


### PR DESCRIPTION
Added support for an optional options object as the final arg. Currently only handles the options.headers object (as per the issue).

`FileTransfer.download(source, target, successCallback, errorCallback, trustAllHosts, options)`

This is needed for using FileTransfer.download with Basic Authentication, etc. Sadly since Android 2.x doesn't support XHR2, this is needed in FileTransfer.

I have only added support to Android and iOS (see other PR's). It might be that the JS args need to be in a different order or handled differently so that it doesn't impact the other platforms. I am hoping I can get advice on that from someone.

If there is anything else I need to do, just let me know.

//cc @agrieve - for suggesting I do this myself
