### PR TITLE
CB-2674: Add prompt to Notification API for iOS

### DIFF
--- a/CordovaLib/Classes/CDVNotification.h
+++ b/CordovaLib/Classes/CDVNotification.h
@@ -26,6 +26,7 @@
 
 - (void)alert:(CDVInvokedUrlCommand*)command;
 - (void)confirm:(CDVInvokedUrlCommand*)command;
+- (void)prompt:(CDVInvokedUrlCommand*)command;
 - (void)vibrate:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/CordovaLib/Classes/CDVNotification.m
+++ b/CordovaLib/Classes/CDVNotification.m
@@ -20,16 +20,28 @@
 #import "CDVNotification.h"
 #import "NSDictionary+Extensions.h"
 
+#define DIALOG_TYPE_ALERT @"alert"
+#define DIALOG_TYPE_PROMPT @"prompt"
+
 @implementation CDVNotification
 
-- (void)showDialogWithMessage:(NSString*)message title:(NSString*)title buttons:(NSArray*)buttons callbackId:(NSString*)callbackId
+/*
+ * showDialogWithMessage - Common method to instantiate the alert view for alert, confirm, and prompt notifications.
+ * Parameters:
+ *  message       The alert view message.
+ *  title         The alert view title.
+ *  buttons       The array of customized strings for the buttons.
+ *  callbackId    The commmand callback id.
+ *  dialogType    The type of alert view [alert | prompt].
+ */
+- (void)showDialogWithMessage:(NSString*)message title:(NSString*)title buttons:(NSArray*)buttons callbackId:(NSString*)callbackId dialogType:(NSString*)dialogType
 {
     CDVAlertView* alertView = [[CDVAlertView alloc]
             initWithTitle:title
-                  message:message
-                 delegate:self
-        cancelButtonTitle:nil
-        otherButtonTitles:nil];
+            message:message
+            delegate:self
+            cancelButtonTitle:nil
+            otherButtonTitles:nil];
 
     alertView.callbackId = callbackId;
 
@@ -37,6 +49,10 @@
 
     for (int n = 0; n < count; n++) {
         [alertView addButtonWithTitle:[buttons objectAtIndex:n]];
+    }
+
+    if ([dialogType isEqualToString:DIALOG_TYPE_PROMPT]) {
+        alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
     }
 
     [alertView show];
@@ -59,7 +75,7 @@
         buttons = NSLocalizedString(@"OK", @"OK");
     }
 
-    [self showDialogWithMessage:message title:title buttons:@[buttons] callbackId:callbackId];
+    [self showDialogWithMessage:message title:title buttons:@[buttons] callbackId:callbackId dialogType:DIALOG_TYPE_ALERT];
 }
 
 - (void)confirm:(CDVInvokedUrlCommand*)command
@@ -79,18 +95,51 @@
         buttons = @[NSLocalizedString(@"OK", @"OK"), NSLocalizedString(@"Cancel", @"Cancel")];
     }
 
-    [self showDialogWithMessage:message title:title buttons:buttons callbackId:callbackId];
+    [self showDialogWithMessage:message title:title buttons:buttons callbackId:callbackId dialogType:DIALOG_TYPE_ALERT];
+}
+
+- (void)prompt:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = command.callbackId;
+    NSArray* arguments = command.arguments;
+    int argc = [arguments count];
+    
+    NSString* message = argc > 0 ? [arguments objectAtIndex:0] : nil;
+    NSString* title = argc > 1 ? [arguments objectAtIndex:1] : nil;
+    NSArray* buttons = argc > 2 ? [arguments objectAtIndex:2] : nil;
+    
+    if (!message) {
+        title = NSLocalizedString(@"Prompt message", @"Prompt message");
+    }
+    if (!title) {
+        title = NSLocalizedString(@"Prompt", @"Prompt");
+    }
+    if (!buttons) {
+        buttons = @[NSLocalizedString(@"OK", @"OK"), NSLocalizedString(@"Cancel", @"Cancel")];
+    }
+    [self showDialogWithMessage:message title:title buttons:buttons callbackId:callbackId dialogType:DIALOG_TYPE_PROMPT];
 }
 
 /**
- Callback invoked when an alert dialog's buttons are clicked.
- Passes the index + label back to JS
- */
+  * Callback invoked when an alert dialog's buttons are clicked.
+  */
 - (void)alertView:(UIAlertView*)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
 {
     CDVAlertView* cdvAlertView = (CDVAlertView*)alertView;
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:++buttonIndex];
+    CDVPluginResult* result;
 
+    // Determine what gets returned to JS based on the alert view type.
+    if (alertView.alertViewStyle == UIAlertViewStyleDefault) {
+        // For alert and confirm, return button index as int back to JS.
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:++buttonIndex];
+    }else {
+        // For prompt, return button index and input text back to JS.
+        NSString* value0 = [[alertView textFieldAtIndex:0] text];
+        NSMutableDictionary* info = [NSMutableDictionary dictionaryWithCapacity:3];
+        [info setValue:[NSNumber numberWithInt: ++buttonIndex] forKey:@"buttonIndex"];
+        [info setValue:value0 ? value0 : [NSNull null] forKey:@"input1"];
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:info];
+    }    
     [self.commandDelegate sendPluginResult:result callbackId:cdvAlertView.callbackId];
 }
 


### PR DESCRIPTION
- initial implementation of native notification prompt corresponding to JS added in CB-2679
