### PR TITLE
[CB-3458] remove all_load dependency. Use force load instead

### DIFF
--- a/bin/templates/project/__TESTING__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__TESTING__.xcodeproj/project.pbxproj
@@ -544,7 +544,8 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-all_load",
+          "-force_load",
+          "${TARGET_BUILD_DIR}/libCordova.a",
 					"-Obj-C",
 				);
 				SDKROOT = iphoneos;
@@ -584,7 +585,8 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-all_load",
+          "-force_load",
+          "${TARGET_BUILD_DIR}/libCordova.a",
 					"-Obj-C",
 				);
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Jira issue tracker: https://issues.apache.org/jira/browse/CB-3458?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel&focusedCommentId=13664675#comment-13664675

all_load is bad practice and breaks other SDKs with Objective-C categories. Here is a description of the problem and why all-load is bad:
http://stackoverflow.com/questions/2906147/what-does-the-all-load-linker-flag-do
