### PR TITLE
[CB-3507] Fix -Obj-C is not a real linker flag in template

### DIFF
--- a/bin/templates/project/__TESTING__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__TESTING__.xcodeproj/project.pbxproj
@@ -545,7 +545,7 @@
 					CoreMedia,
 					"-weak-lSystem",
 					"-all_load",
-					"-Obj-C",
+					"-ObjC",
 				);
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = NO;
@@ -585,7 +585,7 @@
 					CoreMedia,
 					"-weak-lSystem",
 					"-all_load",
-					"-Obj-C",
+					"-ObjC",
 				);
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = NO;


### PR DESCRIPTION
Project template for 'other linker flags' has -Obj-C, which is incorrect because that flag does not exist. The correct linker flag is -ObjC. Simple Fix.

https://issues.apache.org/jira/browse/CB-3507
