### PR TITLE
[CB-3576] Privately signed https links don't work in InAppBrowser

### DIFF
--- a/CordovaLib/Classes/CDVInAppBrowser.h
+++ b/CordovaLib/Classes/CDVInAppBrowser.h
@@ -38,7 +38,7 @@
 
 @end
 
-@interface CDVInAppBrowserViewController : UIViewController <UIWebViewDelegate>{
+@interface CDVInAppBrowserViewController : UIViewController <UIWebViewDelegate, NSURLConnectionDataDelegate>{
     @private
     NSString* _userAgent;
     NSString* _prevUserAgent;
@@ -57,6 +57,8 @@
 @property (nonatomic, weak) id <CDVScreenOrientationDelegate> orientationDelegate;
 @property (nonatomic, weak) CDVInAppBrowser* navigationDelegate;
 @property (nonatomic) NSURL* currentURL;
+@property (nonatomic, weak) NSURLRequest* urlRequest;
+@property (nonatomic, assign) BOOL validateSsl;
 
 - (void)close;
 - (void)navigateTo:(NSURL*)url;
@@ -83,6 +85,7 @@
 @property (nonatomic, assign) BOOL keyboarddisplayrequiresuseraction;
 @property (nonatomic, assign) BOOL suppressesincrementalrendering;
 @property (nonatomic, assign) BOOL hidden;
+@property (nonatomic, assign) BOOL validatessl;
 
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;
 


### PR DESCRIPTION
Privately signed https links don't work in InAppBrowser and are blocked
by default on the InAppBrowser. A new option 'validatessl' has been
added that can be specified while
launching the InAppBrowser:

window.open(url, '_blank', 'location=yes,validatessl=no');

Default value of 'validatessl' is 'yes'. This will allow users to ignore
SSL certificate errors caused while opening self-signed https URLs
