### PR TITLE
Changed viewWillDisappear to viewDidDisappear because frame not resized sometimes.

### DIFF
--- a/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/Classes/CDVViewController.m
@@ -117,9 +117,9 @@
              object:nil];
 }
 
-- (void)viewWillDisappear:(BOOL)animated
+- (void)viewDidDisappear:(BOOL)animated
 {
-    [super viewWillDisappear:animated];
+    [super viewDidDisappear:animated];
 
     NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
     [nc removeObserver:self name:UIKeyboardWillShowNotification object:nil];


### PR DESCRIPTION
If navigator.camera.getPicture called while virtual keyboad is shown - frame still have wrong size because viewWillDisappear remove observers before keyboard close. This commit fixed that bug.
