### PR TITLE
[CB-3175] Remove the deprectation code for the plugin notation

### DIFF
--- a/CordovaLib/Classes/CDVConfigParser.m
+++ b/CordovaLib/Classes/CDVConfigParser.m
@@ -50,19 +50,6 @@
 {
     if ([elementName isEqualToString:@"preference"]) {
         settings[attributeDict[@"name"]] = attributeDict[@"value"];
-    } else if ([elementName isEqualToString:@"plugin"]) {
-        NSString* name = [attributeDict[@"name"] lowercaseString];
-        pluginsDict[name] = attributeDict[@"value"];
-        if ([@"true" isEqualToString : attributeDict[@"onload"]]) {
-            [self.startupPluginNames addObject:name];
-        }
-        NSLog(@"\nUse of the <plugin> tag has been deprecated. Use a <feature> tag instead. Change:\n"
-            @"    <plugin name=\"%@\" value=\"%@\" />\n"
-            @"To:\n"
-            @"    <feature name=\"%@\">\n"
-            @"        <param name=\"ios-package\" value=\"%@\" />\n"
-            @"    </feature>\n"
-            , attributeDict[@"name"], attributeDict[@"value"], attributeDict[@"name"], attributeDict[@"value"]);
     } else if ([elementName isEqualToString:@"feature"]) { // store feature name to use with correct parameter set
         featureName = [attributeDict[@"name"] lowercaseString];
     } else if ((featureName != nil) && [elementName isEqualToString:@"param"]) {


### PR DESCRIPTION
- The plugin notation in the config.xml it not yet supported from
  cordova 3.0.x and does not need to be handle anymore
