### PR TITLE
Xcode .gitignore is at the wrong location and does not ignore build folder and files

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -130,6 +130,7 @@ if [[ $USE_SHARED = 1 ]]; then
 else
     # Copy in the CordovaLib directory.
     mkdir -p "$PROJECT_PATH/CordovaLib/CordovaLib.xcodeproj"
+    cp "$R/.gitignore" "$PROJECT_PATH/"
     cp -r "$BINDIR/../CordovaLib/Classes" "$PROJECT_PATH/CordovaLib"
     cp "$BINDIR/../CordovaLib/VERSION" "$PROJECT_PATH/CordovaLib"
     cp "$BINDIR/../CordovaLib/cordova.js" "$PROJECT_PATH/CordovaLib"


### PR DESCRIPTION
The current iOS gitignore is inside the Xcode project, thus not affecting the build folder and other generated content. This fix moves it to the root so it will properly ignore the defined directories.
