### PR TITLE
[CB-4567] fix issue: "Benchmarks" ->"AutoBench" crashed on iOS

### DIFF
--- a/CordovaLib/Classes/CDVCommandQueue.m
+++ b/CordovaLib/Classes/CDVCommandQueue.m
@@ -102,19 +102,21 @@
 
             // Iterate over and execute all of the commands.
             for (NSArray* jsonEntry in commandBatch) {
-                CDVInvokedUrlCommand* command = [CDVInvokedUrlCommand commandFromJson:jsonEntry];
-                CDV_EXEC_LOG(@"Exec(%@): Calling %@.%@", command.callbackId, command.className, command.methodName);
+                @autoreleasepool {
+                    CDVInvokedUrlCommand* command = [CDVInvokedUrlCommand commandFromJson:jsonEntry];
+                    CDV_EXEC_LOG(@"Exec(%@): Calling %@.%@", command.callbackId, command.className, command.methodName);
 
-                if (![self execute:command]) {
-#ifdef DEBUG
-                        NSString* commandJson = [jsonEntry JSONString];
-                        static NSUInteger maxLogLength = 1024;
-                        NSString* commandString = ([commandJson length] > maxLogLength) ?
-                            [NSString stringWithFormat:@"%@[...]", [commandJson substringToIndex:maxLogLength]] :
-                            commandJson;
+                    if (![self execute:command]) {
+    #ifdef DEBUG
+                            NSString* commandJson = [jsonEntry JSONString];
+                            static NSUInteger maxLogLength = 1024;
+                            NSString* commandString = ([commandJson length] > maxLogLength) ?
+                                [NSString stringWithFormat:@"%@[...]", [commandJson substringToIndex:maxLogLength]] :
+                                commandJson;
 
-                        DLog(@"FAILED pluginJSON = %@", commandString);
-#endif
+                            DLog(@"FAILED pluginJSON = %@", commandString);
+    #endif
+                    }
                 }
             }
         }


### PR DESCRIPTION
The problem seems to be that a lot of autoreleased objects fill up the
memory waiting to be released. So a solution is to add autorelease pool
scope to collect autoreleased objects and release them sooner.

FYI:http://stackoverflow.com/questions/13396560/cant-allocate-region-mal
loc-error-when-running-millions-of-iterations-of-loop
