### PR TITLE
CDVViewController: Fix KeyboardShrinksView on iOS 7

### DIFF
--- a/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/Classes/CDVViewController.m
@@ -138,9 +138,11 @@
     CGRect newFrame = self.view.bounds;
     if (showEvent) {
         newFrame.size.height -= keyboardFrame.size.height;
+        self.webView.scrollView.contentInset = UIEdgeInsetsMake(0, 0, -keyboardFrame.size.height, 0);
+    } else {
+        self.webView.scrollView.contentInset = UIEdgeInsetsMake(0, 0, 0, 0);
     }
     self.webView.frame = newFrame;
-    self.webView.scrollView.contentInset = UIEdgeInsetsMake(0, 0, -keyboardFrame.size.height, 0);
 }
 
 - (void)printDeprecationNotice


### PR DESCRIPTION
I was updating my App to iOS 7 and Cordova 3.0.0 when I noticed that KeyboardShrinksView does not properly reset the WebView when hiding the keyboard. I have a tab bar positioned absolutely (left: 0, right: 0, bottom: 0) and it didn't show up again after hiding the keyboard.

I did not use KeyboardShrinksView on iOS 6 or with any prior Cordova Version so I don't know if this problem already existed before.

Please let me know if I need to make any changes to this pull requests - preliminary tests show this works fine for me!
