### PR TITLE
[CB-4539] Cannot create CDVViewController in Storyboard

### DIFF
--- a/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/Classes/CDVViewController.m
@@ -94,6 +94,13 @@
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    [self __init];
+    return self;
+}
+
 - (id)init
 {
     self = [super init];


### PR DESCRIPTION
Implemented `initWithCoder:` method to call `__init` like other init methods. This will be called when the ViewController is used in a storyboard.
