### PR TITLE
[CB-5258] use exit library

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -10,6 +10,7 @@
   }],
   "dependencies" : {
 		"coffee-script" : "1.1.2",
+		"exit": "0.1.1",
 		"nodeunit" : "0.5.3"
   }
 }

--- a/bin/update
+++ b/bin/update
@@ -19,6 +19,7 @@
        under the License.
 */
 var shell = require('shelljs'),
+    exit  = require('exit'),
     path  = require('path'),
     fs    = require('fs'),
     ROOT    = path.join(__dirname, '..');
@@ -71,7 +72,7 @@ if (require.main === module) {
         var args = process.argv;
         if (args.length < 3 || (args[2] == '--help' || args[2] == '-h')) {
             console.log('Usage: ' + path.relative(process.cwd(), path.join(__dirname, 'update')) + ' <path_to_project>');
-            process.exit(1);
+            exit(1);
         } else {
             exports.updateProject(args[2]);
         }


### PR DESCRIPTION
On Windows, if you have pending bits in pipes and you exit, they
generally do not get delivered.

To avoid this, you need to change process.exit() to something
which actually ensures that buffers are flushed before it exits,
this is handled by the 'exit' module/function.
