### PR TITLE
renaming "build" from gitignore as one of cli scripts is named build

### DIFF
--- a/bin/templates/project/__TESTING__/.gitignore
+++ b/bin/templates/project/__TESTING__/.gitignore
@@ -2,5 +2,5 @@
 *.perspectivev3
 *.pbxuser
 .DS_Store
-build
+build/
 www/phonegap.js


### PR DESCRIPTION
Line 144 from bin/create copy this file to PROJECT_PATH where also reside cordova/build and cordova/build.xcconfig that get ignored when using git in a cordova project.
