### PR TITLE
Allow the start page to be loaded from a file URL

### DIFF
--- a/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/Classes/CDVViewController.m
@@ -204,6 +204,9 @@
         appURL = [NSURL URLWithString:self.startPage];
     } else if ([self.wwwFolderName rangeOfString:@"://"].location != NSNotFound) {
         appURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@", self.wwwFolderName, self.startPage]];
+    } else if ([self.wwwFolderName hasPrefix:@"/"]) {
+        // wwwFolderName is an absolute file path
+        appURL = [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@", self.wwwFolderName, self.startPage]];
     } else {
         // CB-3005 strip parameters from start page to check if page exists in resources
         NSURL* startURL = [NSURL URLWithString:self.startPage];


### PR DESCRIPTION
This change allows the start page to be loaded from any location
inside the app (e.g the Documents or Caches directory). Currently
it can only load the start page from the app's bundle directory.
Because [NSURL urlWithString:...] does not work with file URLS,
there needs to be a mechanism to specify that wwwFolderName is a
file URL.
