### PR TITLE
* is a right-to-left associative operator

### DIFF
--- a/CordovaLib/Classes/CDVCommandDelegate.h
+++ b/CordovaLib/Classes/CDVCommandDelegate.h
@@ -26,7 +26,7 @@
 
 @protocol CDVCommandDelegate <NSObject>
 
-@property (nonatomic, readonly) NSDictionary* settings;
+@property (nonatomic, readonly) NSDictionary *settings;
 
 - (NSString*)pathForResource:(NSString*)resourcepath;
 - (id)getCommandInstance:(NSString*)pluginName;

--- a/CordovaLib/Classes/CDVCommandDelegateImpl.h
+++ b/CordovaLib/Classes/CDVCommandDelegateImpl.h
@@ -25,9 +25,9 @@
 
 @interface CDVCommandDelegateImpl : NSObject <CDVCommandDelegate>{
     @private
-    __weak CDVViewController* _viewController;
+    __weak CDVViewController *_viewController;
     @protected
-    __weak CDVCommandQueue* _commandQueue;
+    __weak CDVCommandQueue *_commandQueue;
     BOOL _delayResponses;
 }
 - (id)initWithViewController:(CDVViewController*)viewController;

--- a/CordovaLib/Classes/CDVCommandDelegateImpl.m
+++ b/CordovaLib/Classes/CDVCommandDelegateImpl.m
@@ -37,14 +37,14 @@
 
 - (NSString*)pathForResource:(NSString*)resourcepath
 {
-    NSBundle* mainBundle = [NSBundle mainBundle];
-    NSMutableArray* directoryParts = [NSMutableArray arrayWithArray:[resourcepath componentsSeparatedByString:@"/"]];
-    NSString* filename = [directoryParts lastObject];
+    NSBundle *mainBundle = [NSBundle mainBundle];
+    NSMutableArray *directoryParts = [NSMutableArray arrayWithArray:[resourcepath componentsSeparatedByString:@"/"]];
+    NSString *filename = [directoryParts lastObject];
 
     [directoryParts removeLastObject];
 
-    NSString* directoryPartsJoined = [directoryParts componentsJoinedByString:@"/"];
-    NSString* directoryStr = _viewController.wwwFolderName;
+    NSString *directoryPartsJoined = [directoryParts componentsJoinedByString:@"/"];
+    NSString *directoryStr = _viewController.wwwFolderName;
 
     if ([directoryPartsJoined length] > 0) {
         directoryStr = [NSString stringWithFormat:@"%@/%@", _viewController.wwwFolderName, [directoryParts componentsJoinedByString:@"/"]];
@@ -63,7 +63,7 @@
 - (void)evalJsHelper2:(NSString*)js
 {
     CDV_EXEC_LOG(@"Exec: evalling: %@", [js substringToIndex:MIN([js length], 160)]);
-    NSString* commandsJSON = [_viewController.webView stringByEvaluatingJavaScriptFromString:js];
+    NSString *commandsJSON = [_viewController.webView stringByEvaluatingJavaScriptFromString:js];
     if ([commandsJSON length] > 0) {
         CDV_EXEC_LOG(@"Exec: Retrieved new exec messages by chaining.");
     }
@@ -103,9 +103,9 @@
     }
     int status = [result.status intValue];
     BOOL keepCallback = [result.keepCallback boolValue];
-    NSString* argumentsAsJSON = [result argumentsAsJSON];
+    NSString *argumentsAsJSON = [result argumentsAsJSON];
 
-    NSString* js = [NSString stringWithFormat:@"cordova.require('cordova/exec').nativeCallback('%@',%d,%@,%d)", callbackId, status, argumentsAsJSON, keepCallback];
+    NSString *js = [NSString stringWithFormat:@"cordova.require('cordova/exec').nativeCallback('%@',%d,%@,%d)", callbackId, status, argumentsAsJSON, keepCallback];
 
     [self evalJsHelper:js];
 }

--- a/CordovaLib/Classes/CDVCommandQueue.m
+++ b/CordovaLib/Classes/CDVCommandQueue.m
@@ -30,8 +30,8 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
 
 @interface CDVCommandQueue () {
     NSInteger _lastCommandQueueFlushRequestId;
-    __weak CDVViewController* _viewController;
-    NSMutableArray* _queue;
+    __weak CDVViewController *_viewController;
+    NSMutableArray *_queue;
     NSTimeInterval _startExecutionTime;
 }
 @end
@@ -67,13 +67,13 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
 - (void)enqueueCommandBatch:(NSString*)batchJSON
 {
     if ([batchJSON length] > 0) {
-        NSMutableArray* commandBatchHolder = [[NSMutableArray alloc] init];
+        NSMutableArray *commandBatchHolder = [[NSMutableArray alloc] init];
         [_queue addObject:commandBatchHolder];
         if ([batchJSON length] < JSON_SIZE_FOR_MAIN_THREAD) {
             [commandBatchHolder addObject:[batchJSON JSONObject]];
         } else {
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^() {
-                    NSMutableArray* result = [batchJSON JSONObject];
+                    NSMutableArray *result = [batchJSON JSONObject];
                     @synchronized(commandBatchHolder) {
                         [commandBatchHolder addObject:result];
                     }
@@ -110,7 +110,7 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
 - (void)fetchCommandsFromJs
 {
     // Grab all the queued commands from the JS side.
-    NSString* queuedCommandsJSON = [_viewController.webView stringByEvaluatingJavaScriptFromString:
+    NSString *queuedCommandsJSON = [_viewController.webView stringByEvaluatingJavaScriptFromString:
         @"cordova.require('cordova/exec').nativeFetchMessages()"];
 
     CDV_EXEC_LOG(@"Exec: Flushed JS->native queue (hadCommands=%d).", [queuedCommandsJSON length] > 0);
@@ -127,8 +127,8 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
         _startExecutionTime = [NSDate timeIntervalSinceReferenceDate];
 
         while ([_queue count] > 0) {
-            NSMutableArray* commandBatchHolder = _queue[0];
-            NSMutableArray* commandBatch = nil;
+            NSMutableArray *commandBatchHolder = _queue[0];
+            NSMutableArray *commandBatch = nil;
             @synchronized(commandBatchHolder) {
                 // If the next-up command is still being decoded, wait for it.
                 if ([commandBatchHolder count] == 0) {
@@ -140,18 +140,18 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
             while ([commandBatch count] > 0) {
                 @autoreleasepool {
                     // Execute the commands one-at-a-time.
-                    NSArray* jsonEntry = [commandBatch dequeue];
+                    NSArray *jsonEntry = [commandBatch dequeue];
                     if ([commandBatch count] == 0) {
                         [_queue removeObjectAtIndex:0];
                     }
-                    CDVInvokedUrlCommand* command = [CDVInvokedUrlCommand commandFromJson:jsonEntry];
+                    CDVInvokedUrlCommand *command = [CDVInvokedUrlCommand commandFromJson:jsonEntry];
                     CDV_EXEC_LOG(@"Exec(%@): Calling %@.%@", command.callbackId, command.className, command.methodName);
 
                     if (![self execute:command]) {
 #ifdef DEBUG
-                            NSString* commandJson = [jsonEntry JSONString];
+                            NSString *commandJson = [jsonEntry JSONString];
                             static NSUInteger maxLogLength = 1024;
-                            NSString* commandString = ([commandJson length] > maxLogLength) ?
+                            NSString *commandString = ([commandJson length] > maxLogLength) ?
                                 [NSString stringWithFormat:@"%@[...]", [commandJson substringToIndex:maxLogLength]] :
                                 commandJson;
 
@@ -181,7 +181,7 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
     }
 
     // Fetch an instance of this class
-    CDVPlugin* obj = [_viewController.commandDelegate getCommandInstance:command.className];
+    CDVPlugin *obj = [_viewController.commandDelegate getCommandInstance:command.className];
 
     if (!([obj isKindOfClass:[CDVPlugin class]])) {
         NSLog(@"ERROR: Plugin '%@' not found, or is not a CDVPlugin. Check your plugin mapping in config.xml.", command.className);
@@ -190,7 +190,7 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
     BOOL retVal = YES;
     double started = [[NSDate date] timeIntervalSince1970] * 1000.0;
     // Find the proper selector to call.
-    NSString* methodName = [NSString stringWithFormat:@"%@:", command.methodName];
+    NSString *methodName = [NSString stringWithFormat:@"%@:", command.methodName];
     SEL normalSelector = NSSelectorFromString(methodName);
     if ([obj respondsToSelector:normalSelector]) {
         // [obj performSelector:normalSelector withObject:command];

--- a/CordovaLib/Classes/CDVConfigParser.h
+++ b/CordovaLib/Classes/CDVConfigParser.h
@@ -19,13 +19,13 @@
 
 @interface CDVConfigParser : NSObject <NSXMLParserDelegate>
 {
-    NSString* featureName;
+    NSString *featureName;
 }
 
-@property (nonatomic, readonly, strong) NSMutableDictionary* pluginsDict;
-@property (nonatomic, readonly, strong) NSMutableDictionary* settings;
-@property (nonatomic, readonly, strong) NSMutableArray* whitelistHosts;
-@property (nonatomic, readonly, strong) NSMutableArray* startupPluginNames;
-@property (nonatomic, readonly, strong) NSString* startPage;
+@property (nonatomic, readonly, strong) NSMutableDictionary *pluginsDict;
+@property (nonatomic, readonly, strong) NSMutableDictionary *settings;
+@property (nonatomic, readonly, strong) NSMutableArray *whitelistHosts;
+@property (nonatomic, readonly, strong) NSMutableArray *startupPluginNames;
+@property (nonatomic, readonly, strong) NSString *startPage;
 
 @end

--- a/CordovaLib/Classes/CDVConfigParser.m
+++ b/CordovaLib/Classes/CDVConfigParser.m
@@ -21,11 +21,11 @@
 
 @interface CDVConfigParser ()
 
-@property (nonatomic, readwrite, strong) NSMutableDictionary* pluginsDict;
-@property (nonatomic, readwrite, strong) NSMutableDictionary* settings;
-@property (nonatomic, readwrite, strong) NSMutableArray* whitelistHosts;
-@property (nonatomic, readwrite, strong) NSMutableArray* startupPluginNames;
-@property (nonatomic, readwrite, strong) NSString* startPage;
+@property (nonatomic, readwrite, strong) NSMutableDictionary *pluginsDict;
+@property (nonatomic, readwrite, strong) NSMutableDictionary *settings;
+@property (nonatomic, readwrite, strong) NSMutableArray *whitelistHosts;
+@property (nonatomic, readwrite, strong) NSMutableArray *startupPluginNames;
+@property (nonatomic, readwrite, strong) NSString *startPage;
 
 @end
 
@@ -56,7 +56,7 @@
     } else if ([elementName isEqualToString:@"feature"]) { // store feature name to use with correct parameter set
         featureName = [attributeDict[@"name"] lowercaseString];
     } else if ((featureName != nil) && [elementName isEqualToString:@"param"]) {
-        NSString* paramName = [attributeDict[@"name"] lowercaseString];
+        NSString *paramName = [attributeDict[@"name"] lowercaseString];
         id value = attributeDict[@"value"];
         if ([paramName isEqualToString:@"ios-package"]) {
             pluginsDict[featureName] = value;

--- a/CordovaLib/Classes/CDVInvokedUrlCommand.h
+++ b/CordovaLib/Classes/CDVInvokedUrlCommand.h
@@ -20,16 +20,16 @@
 #import <Foundation/Foundation.h>
 
 @interface CDVInvokedUrlCommand : NSObject {
-    NSString* _callbackId;
-    NSString* _className;
-    NSString* _methodName;
-    NSArray* _arguments;
+    NSString *_callbackId;
+    NSString *_className;
+    NSString *_methodName;
+    NSArray *_arguments;
 }
 
-@property (nonatomic, readonly) NSArray* arguments;
-@property (nonatomic, readonly) NSString* callbackId;
-@property (nonatomic, readonly) NSString* className;
-@property (nonatomic, readonly) NSString* methodName;
+@property (nonatomic, readonly) NSArray *arguments;
+@property (nonatomic, readonly) NSString *callbackId;
+@property (nonatomic, readonly) NSString *className;
+@property (nonatomic, readonly) NSString *methodName;
 
 + (CDVInvokedUrlCommand*)commandFromJson:(NSArray*)jsonEntry;
 

--- a/CordovaLib/Classes/CDVInvokedUrlCommand.m
+++ b/CordovaLib/Classes/CDVInvokedUrlCommand.m
@@ -36,10 +36,10 @@
 - (id)initFromJson:(NSArray*)jsonEntry
 {
     id tmp = [jsonEntry objectAtIndex:0];
-    NSString* callbackId = tmp == [NSNull null] ? nil : tmp;
-    NSString* className = [jsonEntry objectAtIndex:1];
-    NSString* methodName = [jsonEntry objectAtIndex:2];
-    NSMutableArray* arguments = [jsonEntry objectAtIndex:3];
+    NSString *callbackId = tmp == [NSNull null] ? nil : tmp;
+    NSString *className = [jsonEntry objectAtIndex:1];
+    NSString *methodName = [jsonEntry objectAtIndex:2];
+    NSMutableArray *arguments = [jsonEntry objectAtIndex:3];
 
     return [self initWithArguments:arguments
                         callbackId:callbackId
@@ -65,19 +65,19 @@
 
 - (void)massageArguments
 {
-    NSMutableArray* newArgs = nil;
+    NSMutableArray *newArgs = nil;
 
     for (NSUInteger i = 0, count = [_arguments count]; i < count; ++i) {
         id arg = [_arguments objectAtIndex:i];
         if (![arg isKindOfClass:[NSDictionary class]]) {
             continue;
         }
-        NSDictionary* dict = arg;
-        NSString* type = [dict objectForKey:@"CDVType"];
+        NSDictionary *dict = arg;
+        NSString *type = [dict objectForKey:@"CDVType"];
         if (!type || ![type isEqualToString:@"ArrayBuffer"]) {
             continue;
         }
-        NSString* data = [dict objectForKey:@"data"];
+        NSString *data = [dict objectForKey:@"data"];
         if (!data) {
             continue;
         }

--- a/CordovaLib/Classes/CDVJSON.m
+++ b/CordovaLib/Classes/CDVJSON.m
@@ -24,8 +24,8 @@
 
 - (NSString*)JSONString
 {
-    NSError* error = nil;
-    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:self
+    NSError *error = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self
                                                        options:NSJSONWritingPrettyPrinted
                                                          error:&error];
 
@@ -43,8 +43,8 @@
 
 - (NSString*)JSONString
 {
-    NSError* error = nil;
-    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:self
+    NSError *error = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self
                                                        options:NSJSONWritingPrettyPrinted
                                                          error:&error];
 
@@ -62,7 +62,7 @@
 
 - (id)JSONObject
 {
-    NSError* error = nil;
+    NSError *error = nil;
     id object = [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding]
                                                 options:NSJSONReadingMutableContainers
                                                   error:&error];

--- a/CordovaLib/Classes/CDVLocalStorage.h
+++ b/CordovaLib/Classes/CDVLocalStorage.h
@@ -24,7 +24,7 @@
 
 @interface CDVLocalStorage : CDVPlugin
 
-@property (nonatomic, readonly, strong) NSMutableArray* backupInfo;
+@property (nonatomic, readonly, strong) NSMutableArray *backupInfo;
 
 - (BOOL)shouldBackup;
 - (BOOL)shouldRestore;
@@ -40,9 +40,9 @@
 
 @interface CDVBackupInfo : NSObject
 
-@property (nonatomic, copy) NSString* original;
-@property (nonatomic, copy) NSString* backup;
-@property (nonatomic, copy) NSString* label;
+@property (nonatomic, copy) NSString *original;
+@property (nonatomic, copy) NSString *backup;
+@property (nonatomic, copy) NSString *label;
 
 - (BOOL)shouldBackup;
 - (BOOL)shouldRestore;

--- a/CordovaLib/Classes/CDVLocalStorage.m
+++ b/CordovaLib/Classes/CDVLocalStorage.m
@@ -22,7 +22,7 @@
 
 @interface CDVLocalStorage ()
 
-@property (nonatomic, readwrite, strong) NSMutableArray* backupInfo;  // array of CDVBackupInfo objects
+@property (nonatomic, readwrite, strong) NSMutableArray *backupInfo;  // array of CDVBackupInfo objects
 @property (nonatomic, readwrite, weak) id <UIWebViewDelegate> webviewDelegate;
 
 @end
@@ -55,11 +55,11 @@
 
      And between these three, there are various migration paths, most of which only consider 2 of the 3, which is why this helper is based on 2 locations and has a notion of "direction".
      */
-    NSMutableArray* backupInfo = [NSMutableArray arrayWithCapacity:3];
+    NSMutableArray *backupInfo = [NSMutableArray arrayWithCapacity:3];
 
-    NSString* original;
-    NSString* backup;
-    CDVBackupInfo* backupItem;
+    NSString *original;
+    NSString *backup;
+    CDVBackupInfo *backupItem;
 
     // ////////// LOCALSTORAGE
 
@@ -106,10 +106,10 @@
 + (NSMutableArray*)createBackupInfoWithCloudBackup:(BOOL)cloudBackup
 {
     // create backup info from backup folder to caches folder
-    NSString* appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString* appDocumentsFolder = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString* cacheFolder = [appLibraryFolder stringByAppendingPathComponent:@"Caches"];
-    NSString* backupsFolder = [appDocumentsFolder stringByAppendingPathComponent:@"Backups"];
+    NSString *appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    NSString *appDocumentsFolder = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    NSString *cacheFolder = [appLibraryFolder stringByAppendingPathComponent:@"Caches"];
+    NSString *backupsFolder = [appDocumentsFolder stringByAppendingPathComponent:@"Backups"];
 
     // create the backups folder, if needed
     [[NSFileManager defaultManager] createDirectoryAtPath:backupsFolder withIntermediateDirectories:YES attributes:nil error:nil];
@@ -123,7 +123,7 @@
 {
     NSAssert(IsAtLeastiOSVersion(@"5.1"), @"Cannot mark files for NSURLIsExcludedFromBackupKey on iOS less than 5.1");
 
-    NSError* error = nil;
+    NSError *error = nil;
     BOOL success = [URL setResourceValue:[NSNumber numberWithBool:skip] forKey:NSURLIsExcludedFromBackupKey error:&error];
     if (!success) {
         NSLog(@"Error excluding %@ from backup %@", [URL lastPathComponent], error);
@@ -131,12 +131,12 @@
     return success;
 }
 
-+ (BOOL)copyFrom:(NSString*)src to:(NSString*)dest error:(NSError* __autoreleasing*)error
++ (BOOL)copyFrom:(NSString*)src to:(NSString*)dest error:(NSError *__autoreleasing*)error
 {
-    NSFileManager* fileManager = [NSFileManager defaultManager];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
 
     if (![fileManager fileExistsAtPath:src]) {
-        NSString* errorString = [NSString stringWithFormat:@"%@ file does not exist.", src];
+        NSString *errorString = [NSString stringWithFormat:@"%@ file does not exist.", src];
         if (error != NULL) {
             (*error) = [NSError errorWithDomain:kCDVLocalStorageErrorDomain
                                            code:kCDVLocalStorageFileOperationError
@@ -149,7 +149,7 @@
     // generate unique filepath in temp directory
     CFUUIDRef uuidRef = CFUUIDCreate(kCFAllocatorDefault);
     CFStringRef uuidString = CFUUIDCreateString(kCFAllocatorDefault, uuidRef);
-    NSString* tempBackup = [[NSTemporaryDirectory() stringByAppendingPathComponent:(__bridge NSString*)uuidString] stringByAppendingPathExtension:@"bak"];
+    NSString *tempBackup = [[NSTemporaryDirectory() stringByAppendingPathComponent:(__bridge NSString*)uuidString] stringByAppendingPathExtension:@"bak"];
     CFRelease(uuidString);
     CFRelease(uuidRef);
 
@@ -190,7 +190,7 @@
 
 - (BOOL)shouldBackup
 {
-    for (CDVBackupInfo* info in self.backupInfo) {
+    for (CDVBackupInfo *info in self.backupInfo) {
         if ([info shouldBackup]) {
             return YES;
         }
@@ -201,7 +201,7 @@
 
 - (BOOL)shouldRestore
 {
-    for (CDVBackupInfo* info in self.backupInfo) {
+    for (CDVBackupInfo *info in self.backupInfo) {
         if ([info shouldRestore]) {
             return YES;
         }
@@ -213,13 +213,13 @@
 /* copy from webkitDbLocation to persistentDbLocation */
 - (void)backup:(CDVInvokedUrlCommand*)command
 {
-    NSString* callbackId = command.callbackId;
+    NSString *callbackId = command.callbackId;
 
-    NSError* __autoreleasing error = nil;
-    CDVPluginResult* result = nil;
-    NSString* message = nil;
+    NSError *__autoreleasing error = nil;
+    CDVPluginResult *result = nil;
+    NSString *message = nil;
 
-    for (CDVBackupInfo* info in self.backupInfo) {
+    for (CDVBackupInfo *info in self.backupInfo) {
         if ([info shouldBackup]) {
             [[self class] copyFrom:info.original to:info.backup error:&error];
 
@@ -245,11 +245,11 @@
 /* copy from persistentDbLocation to webkitDbLocation */
 - (void)restore:(CDVInvokedUrlCommand*)command
 {
-    NSError* __autoreleasing error = nil;
-    CDVPluginResult* result = nil;
-    NSString* message = nil;
+    NSError *__autoreleasing error = nil;
+    CDVPluginResult *result = nil;
+    NSString *message = nil;
 
-    for (CDVBackupInfo* info in self.backupInfo) {
+    for (CDVBackupInfo *info in self.backupInfo) {
         if ([info shouldRestore]) {
             [[self class] copyFrom:info.backup to:info.original error:&error];
 
@@ -278,12 +278,12 @@
 
 + (void)__verifyAndFixDatabaseLocations
 {
-    NSBundle* mainBundle = [NSBundle mainBundle];
-    NSString* bundlePath = [[mainBundle bundlePath] stringByDeletingLastPathComponent];
-    NSString* bundleIdentifier = [[mainBundle infoDictionary] objectForKey:@"CFBundleIdentifier"];
-    NSString* appPlistPath = [bundlePath stringByAppendingPathComponent:[NSString stringWithFormat:@"Library/Preferences/%@.plist", bundleIdentifier]];
+    NSBundle *mainBundle = [NSBundle mainBundle];
+    NSString *bundlePath = [[mainBundle bundlePath] stringByDeletingLastPathComponent];
+    NSString *bundleIdentifier = [[mainBundle infoDictionary] objectForKey:@"CFBundleIdentifier"];
+    NSString *appPlistPath = [bundlePath stringByAppendingPathComponent:[NSString stringWithFormat:@"Library/Preferences/%@.plist", bundleIdentifier]];
 
-    NSMutableDictionary* appPlistDict = [NSMutableDictionary dictionaryWithContentsOfFile:appPlistPath];
+    NSMutableDictionary *appPlistDict = [NSMutableDictionary dictionaryWithContentsOfFile:appPlistPath];
     BOOL modified = [[self class] __verifyAndFixDatabaseLocationsWithAppPlistDict:appPlistDict
                                                                        bundlePath:bundlePath
                                                                       fileManager:[NSFileManager defaultManager]];
@@ -299,23 +299,23 @@
                                              bundlePath:(NSString*)bundlePath
                                             fileManager:(NSFileManager*)fileManager
 {
-    NSString* libraryCaches = @"Library/Caches";
-    NSString* libraryWebKit = @"Library/WebKit";
+    NSString *libraryCaches = @"Library/Caches";
+    NSString *libraryWebKit = @"Library/WebKit";
 
-    NSArray* keysToCheck = [NSArray arrayWithObjects:
+    NSArray *keysToCheck = [NSArray arrayWithObjects:
         @"WebKitLocalStorageDatabasePathPreferenceKey",
         @"WebDatabaseDirectory",
         nil];
 
     BOOL dirty = NO;
 
-    for (NSString* key in keysToCheck) {
-        NSString* value = [appPlistDict objectForKey:key];
+    for (NSString *key in keysToCheck) {
+        NSString *value = [appPlistDict objectForKey:key];
         // verify key exists, and path is in app bundle, if not - fix
         if ((value != nil) && ![value hasPrefix:bundlePath]) {
             // the pathSuffix to use may be wrong - OTA upgrades from < 5.1 to 5.1 do keep the old path Library/WebKit,
             // while Xcode synced ones do change the storage location to Library/Caches
-            NSString* newBundlePath = [bundlePath stringByAppendingPathComponent:libraryCaches];
+            NSString *newBundlePath = [bundlePath stringByAppendingPathComponent:libraryCaches];
             if (![fileManager fileExistsAtPath:newBundlePath]) {
                 newBundlePath = [bundlePath stringByAppendingPathComponent:libraryWebKit];
             }
@@ -334,10 +334,10 @@
         return;
     }
 
-    NSString* appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString* appDocumentsFolder = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    NSString *appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    NSString *appDocumentsFolder = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
 
-    NSMutableArray* backupInfo = [NSMutableArray arrayWithCapacity:0];
+    NSMutableArray *backupInfo = [NSMutableArray arrayWithCapacity:0];
 
     if ([backupType isEqualToString:@"cloud"]) {
         // We would like to restore old backups/caches databases to the new destination (nested in lib folder)
@@ -348,9 +348,9 @@
         [backupInfo addObjectsFromArray:[self createBackupInfoWithTargetDir:[appLibraryFolder stringByAppendingPathComponent:@"Caches"] backupDir:appLibraryFolder targetDirNests:NO backupDirNests:YES rename:NO]];
     }
 
-    NSFileManager* manager = [NSFileManager defaultManager];
+    NSFileManager *manager = [NSFileManager defaultManager];
 
-    for (CDVBackupInfo* info in backupInfo) {
+    for (CDVBackupInfo *info in backupInfo) {
         if ([manager fileExistsAtPath:info.backup]) {
             if ([info shouldRestore]) {
                 NSLog(@"Restoring old webstorage backup. From: '%@' To: '%@'.", info.backup, info.original);
@@ -369,8 +369,8 @@
 
 - (void)onResignActive
 {
-    UIDevice* device = [UIDevice currentDevice];
-    NSNumber* exitsOnSuspend = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationExitsOnSuspend"];
+    UIDevice *device = [UIDevice currentDevice];
+    NSNumber *exitsOnSuspend = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationExitsOnSuspend"];
 
     BOOL isMultitaskingSupported = [device respondsToSelector:@selector(isMultitaskingSupported)] && [device isMultitaskingSupported];
 
@@ -388,7 +388,7 @@
                 backgroundTaskID = UIBackgroundTaskInvalid;
                 NSLog(@"Background task to backup WebSQL/LocalStorage expired.");
             }];
-        CDVLocalStorage __weak* weakSelf = self;
+        CDVLocalStorage __weak *weakSelf = self;
         [self.commandDelegate runInBackground:^{
             [weakSelf backup:nil];
 
@@ -419,14 +419,14 @@
 
 - (BOOL)file:(NSString*)aPath isNewerThanFile:(NSString*)bPath
 {
-    NSFileManager* fileManager = [NSFileManager defaultManager];
-    NSError* __autoreleasing error = nil;
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *__autoreleasing error = nil;
 
-    NSDictionary* aPathAttribs = [fileManager attributesOfItemAtPath:aPath error:&error];
-    NSDictionary* bPathAttribs = [fileManager attributesOfItemAtPath:bPath error:&error];
+    NSDictionary *aPathAttribs = [fileManager attributesOfItemAtPath:aPath error:&error];
+    NSDictionary *bPathAttribs = [fileManager attributesOfItemAtPath:bPath error:&error];
 
-    NSDate* aPathModDate = [aPathAttribs objectForKey:NSFileModificationDate];
-    NSDate* bPathModDate = [bPathAttribs objectForKey:NSFileModificationDate];
+    NSDate *aPathModDate = [aPathAttribs objectForKey:NSFileModificationDate];
+    NSDate *bPathModDate = [bPathAttribs objectForKey:NSFileModificationDate];
 
     if ((nil == aPathModDate) && (nil == bPathModDate)) {
         return NO;
@@ -437,7 +437,7 @@
 
 - (BOOL)item:(NSString*)aPath isNewerThanItem:(NSString*)bPath
 {
-    NSFileManager* fileManager = [NSFileManager defaultManager];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
 
     BOOL aPathIsDir = NO, bPathIsDir = NO;
     BOOL aPathExists = [fileManager fileExistsAtPath:aPath isDirectory:&aPathIsDir];
@@ -456,12 +456,12 @@
     // we get the files in aPath, and see if it is newer than the file in bPath
     // (it is newer if it doesn't exist in bPath) if we encounter the FIRST file that is newer,
     // we return YES
-    NSDirectoryEnumerator* directoryEnumerator = [fileManager enumeratorAtPath:aPath];
-    NSString* path;
+    NSDirectoryEnumerator *directoryEnumerator = [fileManager enumeratorAtPath:aPath];
+    NSString *path;
 
     while ((path = [directoryEnumerator nextObject])) {
-        NSString* aPathFile = [aPath stringByAppendingPathComponent:path];
-        NSString* bPathFile = [bPath stringByAppendingPathComponent:path];
+        NSString *aPathFile = [aPath stringByAppendingPathComponent:path];
+        NSString *bPathFile = [bPath stringByAppendingPathComponent:path];
 
         BOOL isNewer = [self file:aPathFile isNewerThanFile:bPathFile];
         if (isNewer) {

--- a/CordovaLib/Classes/CDVPlugin.h
+++ b/CordovaLib/Classes/CDVPlugin.h
@@ -23,15 +23,15 @@
 #import "NSMutableArray+QueueAdditions.h"
 #import "CDVCommandDelegate.h"
 
-extern NSString* const CDVPageDidLoadNotification;
-extern NSString* const CDVPluginHandleOpenURLNotification;
-extern NSString* const CDVPluginResetNotification;
-extern NSString* const CDVLocalNotification;
+extern NSString *const CDVPageDidLoadNotification;
+extern NSString *const CDVPluginHandleOpenURLNotification;
+extern NSString *const CDVPluginResetNotification;
+extern NSString *const CDVLocalNotification;
 
 @interface CDVPlugin : NSObject {}
 
-@property (nonatomic, weak) UIWebView* webView;
-@property (nonatomic, weak) UIViewController* viewController;
+@property (nonatomic, weak) UIWebView *webView;
+@property (nonatomic, weak) UIViewController *viewController;
 @property (nonatomic, weak) id <CDVCommandDelegate> commandDelegate;
 
 @property (readonly, assign) BOOL hasPendingOperation;

--- a/CordovaLib/Classes/CDVPlugin.m
+++ b/CordovaLib/Classes/CDVPlugin.m
@@ -19,10 +19,10 @@
 
 #import "CDVPlugin.h"
 
-NSString* const CDVPageDidLoadNotification = @"CDVPageDidLoadNotification";
-NSString* const CDVPluginHandleOpenURLNotification = @"CDVPluginHandleOpenURLNotification";
-NSString* const CDVPluginResetNotification = @"CDVPluginResetNotification";
-NSString* const CDVLocalNotification = @"CDVLocalNotification";
+NSString *const CDVPageDidLoadNotification = @"CDVPageDidLoadNotification";
+NSString *const CDVPluginHandleOpenURLNotification = @"CDVPluginHandleOpenURLNotification";
+NSString *const CDVPluginResetNotification = @"CDVPluginResetNotification";
+NSString *const CDVLocalNotification = @"CDVLocalNotification";
 
 @interface CDVPlugin ()
 
@@ -93,7 +93,7 @@ NSString* const CDVLocalNotification = @"CDVLocalNotification";
     // override to handle urls sent to your app
     // register your url schemes in your App-Info.plist
 
-    NSURL* url = [notification object];
+    NSURL *url = [notification object];
 
     if ([url isKindOfClass:[NSURL class]]) {
         /* Do your thing! */
@@ -146,7 +146,7 @@ NSString* const CDVLocalNotification = @"CDVLocalNotification";
 // default implementation does nothing, ideally, we are not registered for notification if we aren't going to do anything.
 // - (void)didReceiveLocalNotification:(NSNotification *)notification
 // {
-//    // UILocalNotification* localNotification = [notification object]; // get the payload as a LocalNotification
+//    // UILocalNotification *localNotification = [notification object]; // get the payload as a LocalNotification
 // }
 
 @end

--- a/CordovaLib/Classes/CDVPluginResult.h
+++ b/CordovaLib/Classes/CDVPluginResult.h
@@ -34,9 +34,9 @@ typedef enum {
 
 @interface CDVPluginResult : NSObject {}
 
-@property (nonatomic, strong, readonly) NSNumber* status;
+@property (nonatomic, strong, readonly) NSNumber *status;
 @property (nonatomic, strong, readonly) id message;
-@property (nonatomic, strong)           NSNumber* keepCallback;
+@property (nonatomic, strong)           NSNumber *keepCallback;
 // This property can be used to scope the lifetime of another object. For example,
 // Use it to store the associated NSData when `message` is created using initWithBytesNoCopy.
 @property (nonatomic, strong) id associatedObject;

--- a/CordovaLib/Classes/CDVPluginResult.m
+++ b/CordovaLib/Classes/CDVPluginResult.m
@@ -31,9 +31,9 @@
 @implementation CDVPluginResult
 @synthesize status, message, keepCallback, associatedObject;
 
-static NSArray* org_apache_cordova_CommandStatusMsgs;
+static NSArray *org_apache_cordova_CommandStatusMsgs;
 
-id messageFromArrayBuffer(NSData* data)
+id messageFromArrayBuffer(NSData *data)
 {
     return @{
                @"CDVType" : @"ArrayBuffer",
@@ -49,9 +49,9 @@ id massageMessage(id message)
     return message;
 }
 
-id messageFromMultipart(NSArray* theMessages)
+id messageFromMultipart(NSArray *theMessages)
 {
-    NSMutableArray* messages = [NSMutableArray arrayWithArray:theMessages];
+    NSMutableArray *messages = [NSMutableArray arrayWithArray:theMessages];
 
     for (NSUInteger i = 0; i < messages.count; ++i) {
         [messages replaceObjectAtIndex:i withObject:massageMessage([messages objectAtIndex:i])];
@@ -141,7 +141,7 @@ id messageFromMultipart(NSArray* theMessages)
 
 + (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageToErrorObject:(int)errorCode
 {
-    NSDictionary* errDict = @{@"code" :[NSNumber numberWithInt:errorCode]};
+    NSDictionary *errDict = @{@"code" :[NSNumber numberWithInt:errorCode]};
 
     return [[self alloc] initWithStatus:statusOrdinal message:errDict];
 }
@@ -154,9 +154,9 @@ id messageFromMultipart(NSArray* theMessages)
 - (NSString*)argumentsAsJSON
 {
     id arguments = (self.message == nil ? [NSNull null] : self.message);
-    NSArray* argumentsWrappedInArray = [NSArray arrayWithObject:arguments];
+    NSArray *argumentsWrappedInArray = [NSArray arrayWithObject:arguments];
 
-    NSString* argumentsJSON = [argumentsWrappedInArray JSONString];
+    NSString *argumentsJSON = [argumentsWrappedInArray JSONString];
 
     argumentsJSON = [argumentsJSON substringWithRange:NSMakeRange(1, [argumentsJSON length] - 2)];
 
@@ -166,17 +166,17 @@ id messageFromMultipart(NSArray* theMessages)
 // These methods are used by the legacy plugin return result method
 - (NSString*)toJSONString
 {
-    NSDictionary* dict = [NSDictionary dictionaryWithObjectsAndKeys:
+    NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
         self.status, @"status",
         self.message ? self.                                message:[NSNull null], @"message",
         self.keepCallback, @"keepCallback",
         nil];
 
-    NSError* error = nil;
-    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:dict
+    NSError *error = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
                                                        options:NSJSONWritingPrettyPrinted
                                                          error:&error];
-    NSString* resultString = nil;
+    NSString *resultString = nil;
 
     if (error != nil) {
         NSLog(@"toJSONString error: %@", [error localizedDescription]);
@@ -192,7 +192,7 @@ id messageFromMultipart(NSArray* theMessages)
 
 - (NSString*)toSuccessCallbackString:(NSString*)callbackId
 {
-    NSString* successCB = [NSString stringWithFormat:@"cordova.callbackSuccess('%@',%@);", callbackId, [self toJSONString]];
+    NSString *successCB = [NSString stringWithFormat:@"cordova.callbackSuccess('%@',%@);", callbackId, [self toJSONString]];
 
     if ([[self class] isVerbose]) {
         NSLog(@"PluginResult toSuccessCallbackString: %@", successCB);
@@ -202,7 +202,7 @@ id messageFromMultipart(NSArray* theMessages)
 
 - (NSString*)toErrorCallbackString:(NSString*)callbackId
 {
-    NSString* errorCB = [NSString stringWithFormat:@"cordova.callbackError('%@',%@);", callbackId, [self toJSONString]];
+    NSString *errorCB = [NSString stringWithFormat:@"cordova.callbackError('%@',%@);", callbackId, [self toJSONString]];
 
     if ([[self class] isVerbose]) {
         NSLog(@"PluginResult toErrorCallbackString: %@", errorCB);

--- a/CordovaLib/Classes/CDVTimer.m
+++ b/CordovaLib/Classes/CDVTimer.m
@@ -23,9 +23,9 @@
 
 @interface CDVTimerItem : NSObject
 
-@property (nonatomic, strong) NSString* name;
-@property (nonatomic, strong) NSDate* started;
-@property (nonatomic, strong) NSDate* ended;
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) NSDate *started;
+@property (nonatomic, strong) NSDate *ended;
 
 - (void)log;
 
@@ -44,7 +44,7 @@
 
 @interface CDVTimer ()
 
-@property (nonatomic, strong) NSMutableDictionary* items;
+@property (nonatomic, strong) NSMutableDictionary *items;
 
 @end
 
@@ -64,7 +64,7 @@
 - (void)add:(NSString*)name
 {
     if ([self.items objectForKey:[name lowercaseString]] == nil) {
-        CDVTimerItem* item = [CDVTimerItem new];
+        CDVTimerItem *item = [CDVTimerItem new];
         item.name = name;
         item.started = [NSDate new];
         [self.items setObject:item forKey:[name lowercaseString]];
@@ -75,7 +75,7 @@
 
 - (void)remove:(NSString*)name
 {
-    CDVTimerItem* item = [self.items objectForKey:[name lowercaseString]];
+    CDVTimerItem *item = [self.items objectForKey:[name lowercaseString]];
 
     if (item != nil) {
         item.ended = [NSDate new];
@@ -111,7 +111,7 @@
 + (CDVTimer*)sharedInstance
 {
     static dispatch_once_t pred = 0;
-    __strong static CDVTimer* _sharedObject = nil;
+    __strong static CDVTimer *_sharedObject = nil;
 
     dispatch_once(&pred, ^{
             _sharedObject = [[self alloc] init];

--- a/CordovaLib/Classes/CDVURLProtocol.m
+++ b/CordovaLib/Classes/CDVURLProtocol.m
@@ -30,24 +30,24 @@
 @property (nonatomic) NSInteger statusCode;
 @end
 
-static CDVWhitelist* gWhitelist = nil;
+static CDVWhitelist *gWhitelist = nil;
 // Contains a set of NSNumbers of addresses of controllers. It doesn't store
 // the actual pointer to avoid retaining.
-static NSMutableSet* gRegisteredControllers = nil;
+static NSMutableSet *gRegisteredControllers = nil;
 
-NSString* const kCDVAssetsLibraryPrefixes = @"assets-library://";
+NSString *const kCDVAssetsLibraryPrefixes = @"assets-library://";
 
 // Returns the registered view controller that sent the given request.
 // If the user-agent is not from a UIWebView, or if it's from an unregistered one,
 // then nil is returned.
-static CDVViewController *viewControllerForRequest(NSURLRequest* request)
+static CDVViewController *viewControllerForRequest(NSURLRequest *request)
 {
     // The exec bridge explicitly sets the VC address in a header.
     // This works around the User-Agent not being set for file: URLs.
-    NSString* addrString = [request valueForHTTPHeaderField:@"vc"];
+    NSString *addrString = [request valueForHTTPHeaderField:@"vc"];
 
     if (addrString == nil) {
-        NSString* userAgent = [request valueForHTTPHeaderField:@"User-Agent"];
+        NSString *userAgent = [request valueForHTTPHeaderField:@"User-Agent"];
         if (userAgent == nil) {
             return nil;
         }
@@ -107,15 +107,15 @@ static CDVViewController *viewControllerForRequest(NSURLRequest* request)
 
 + (BOOL)canInitWithRequest:(NSURLRequest*)theRequest
 {
-    NSURL* theUrl = [theRequest URL];
-    CDVViewController* viewController = viewControllerForRequest(theRequest);
+    NSURL *theUrl = [theRequest URL];
+    CDVViewController *viewController = viewControllerForRequest(theRequest);
 
     if ([[theUrl absoluteString] hasPrefix:kCDVAssetsLibraryPrefixes]) {
         return YES;
     } else if (viewController != nil) {
         if ([[theUrl path] isEqualToString:@"/!gap_exec"]) {
-            NSString* queuedCommandsJSON = [theRequest valueForHTTPHeaderField:@"cmds"];
-            NSString* requestId = [theRequest valueForHTTPHeaderField:@"rc"];
+            NSString *queuedCommandsJSON = [theRequest valueForHTTPHeaderField:@"cmds"];
+            NSString *requestId = [theRequest valueForHTTPHeaderField:@"rc"];
             if (requestId == nil) {
                 NSLog(@"!cordova request missing rc header");
                 return NO;
@@ -155,37 +155,37 @@ static CDVViewController *viewControllerForRequest(NSURLRequest* request)
 - (void)startLoading
 {
     // NSLog(@"%@ received %@ - start", self, NSStringFromSelector(_cmd));
-    NSURL* url = [[self request] URL];
+    NSURL *url = [[self request] URL];
 
     if ([[url path] isEqualToString:@"/!gap_exec"]) {
         [self sendResponseWithResponseCode:200 data:nil mimeType:nil];
         return;
     } else if ([[url absoluteString] hasPrefix:kCDVAssetsLibraryPrefixes]) {
-        ALAssetsLibraryAssetForURLResultBlock resultBlock = ^(ALAsset* asset) {
+        ALAssetsLibraryAssetForURLResultBlock resultBlock = ^(ALAsset *asset) {
             if (asset) {
                 // We have the asset!  Get the data and send it along.
-                ALAssetRepresentation* assetRepresentation = [asset defaultRepresentation];
-                NSString* MIMEType = (__bridge_transfer NSString*)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)[assetRepresentation UTI], kUTTagClassMIMEType);
-                Byte* buffer = (Byte*)malloc([assetRepresentation size]);
+                ALAssetRepresentation *assetRepresentation = [asset defaultRepresentation];
+                NSString *MIMEType = (__bridge_transfer NSString*)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)[assetRepresentation UTI], kUTTagClassMIMEType);
+                Byte *buffer = (Byte*)malloc([assetRepresentation size]);
                 NSUInteger bufferSize = [assetRepresentation getBytes:buffer fromOffset:0.0 length:[assetRepresentation size] error:nil];
-                NSData* data = [NSData dataWithBytesNoCopy:buffer length:bufferSize freeWhenDone:YES];
+                NSData *data = [NSData dataWithBytesNoCopy:buffer length:bufferSize freeWhenDone:YES];
                 [self sendResponseWithResponseCode:200 data:data mimeType:MIMEType];
             } else {
                 // Retrieving the asset failed for some reason.  Send an error.
                 [self sendResponseWithResponseCode:404 data:nil mimeType:nil];
             }
         };
-        ALAssetsLibraryAccessFailureBlock failureBlock = ^(NSError* error) {
+        ALAssetsLibraryAccessFailureBlock failureBlock = ^(NSError *error) {
             // Retrieving the asset failed for some reason.  Send an error.
             [self sendResponseWithResponseCode:401 data:nil mimeType:nil];
         };
 
-        ALAssetsLibrary* assetsLibrary = [[ALAssetsLibrary alloc] init];
+        ALAssetsLibrary *assetsLibrary = [[ALAssetsLibrary alloc] init];
         [assetsLibrary assetForURL:url resultBlock:resultBlock failureBlock:failureBlock];
         return;
     }
 
-    NSString* body = [gWhitelist errorStringForURL:url];
+    NSString *body = [gWhitelist errorStringForURL:url];
     [self sendResponseWithResponseCode:401 data:[body dataUsingEncoding:NSASCIIStringEncoding] mimeType:nil];
 }
 
@@ -204,8 +204,8 @@ static CDVViewController *viewControllerForRequest(NSURLRequest* request)
     if (mimeType == nil) {
         mimeType = @"text/plain";
     }
-    NSString* encodingName = [@"text/plain" isEqualToString : mimeType] ? @"UTF-8" : nil;
-    CDVHTTPURLResponse* response =
+    NSString *encodingName = [@"text/plain" isEqualToString : mimeType] ? @"UTF-8" : nil;
+    CDVHTTPURLResponse *response =
         [[CDVHTTPURLResponse alloc] initWithURL:[[self request] URL]
                                        MIMEType:mimeType
                           expectedContentLength:[data length]

--- a/CordovaLib/Classes/CDVUserAgentUtil.m
+++ b/CordovaLib/Classes/CDVUserAgentUtil.m
@@ -24,13 +24,13 @@
 // #define VerboseLog NSLog
 #define VerboseLog(...) do {} while (0)
 
-static NSString* const kCdvUserAgentKey = @"Cordova-User-Agent";
-static NSString* const kCdvUserAgentVersionKey = @"Cordova-User-Agent-Version";
+static NSString *const kCdvUserAgentKey = @"Cordova-User-Agent";
+static NSString *const kCdvUserAgentVersionKey = @"Cordova-User-Agent-Version";
 
-static NSString* gOriginalUserAgent = nil;
+static NSString *gOriginalUserAgent = nil;
 static NSInteger gNextLockToken = 0;
 static NSInteger gCurrentLockToken = 0;
-static NSMutableArray* gPendingSetUserAgentBlocks = nil;
+static NSMutableArray *gPendingSetUserAgentBlocks = nil;
 
 @implementation CDVUserAgentUtil
 
@@ -40,19 +40,19 @@ static NSMutableArray* gPendingSetUserAgentBlocks = nil;
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppLocaleDidChange:)
                                                      name:NSCurrentLocaleDidChangeNotification object:nil];
 
-        NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-        NSString* systemVersion = [[UIDevice currentDevice] systemVersion];
-        NSString* localeStr = [[NSLocale currentLocale] localeIdentifier];
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+        NSString *localeStr = [[NSLocale currentLocale] localeIdentifier];
         // Record the model since simulator can change it without re-install (CB-5420).
-        NSString* model = [UIDevice currentDevice].model;
-        NSString* systemAndLocale = [NSString stringWithFormat:@"%@ %@ %@", model, systemVersion, localeStr];
+        NSString *model = [UIDevice currentDevice].model;
+        NSString *systemAndLocale = [NSString stringWithFormat:@"%@ %@ %@", model, systemVersion, localeStr];
 
-        NSString* cordovaUserAgentVersion = [userDefaults stringForKey:kCdvUserAgentVersionKey];
+        NSString *cordovaUserAgentVersion = [userDefaults stringForKey:kCdvUserAgentVersionKey];
         gOriginalUserAgent = [userDefaults stringForKey:kCdvUserAgentKey];
         BOOL cachedValueIsOld = ![systemAndLocale isEqualToString:cordovaUserAgentVersion];
 
         if ((gOriginalUserAgent == nil) || cachedValueIsOld) {
-            UIWebView* sampleWebView = [[UIWebView alloc] initWithFrame:CGRectZero];
+            UIWebView *sampleWebView = [[UIWebView alloc] initWithFrame:CGRectZero];
             gOriginalUserAgent = [sampleWebView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
 
             [userDefaults setObject:gOriginalUserAgent forKey:kCdvUserAgentKey];
@@ -115,7 +115,7 @@ static NSMutableArray* gPendingSetUserAgentBlocks = nil;
     // It is read per instantiation, so it does not affect previously created views.
     // Except! When a PDF is loaded, all currently active UIWebViews reload their
     // User-Agent from the NSUserDefaults some time after the DidFinishLoad of the PDF bah!
-    NSDictionary* dict = [[NSDictionary alloc] initWithObjectsAndKeys:value, @"UserAgent", nil];
+    NSDictionary *dict = [[NSDictionary alloc] initWithObjectsAndKeys:value, @"UserAgent", nil];
     [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
 }
 

--- a/CordovaLib/Classes/CDVViewController.h
+++ b/CordovaLib/Classes/CDVViewController.h
@@ -31,24 +31,24 @@
     @protected
     id <CDVCommandDelegate> _commandDelegate;
     @protected
-    CDVCommandQueue* _commandQueue;
-    NSString* _userAgent;
+    CDVCommandQueue *_commandQueue;
+    NSString *_userAgent;
 }
 
-@property (nonatomic, strong) IBOutlet UIWebView* webView;
+@property (nonatomic, strong) IBOutlet UIWebView *webView;
 
-@property (nonatomic, readonly, strong) NSMutableDictionary* pluginObjects;
-@property (nonatomic, readonly, strong) NSDictionary* pluginsMap;
-@property (nonatomic, readonly, strong) NSMutableDictionary* settings;
-@property (nonatomic, readonly, strong) NSXMLParser* configParser;
-@property (nonatomic, readonly, strong) CDVWhitelist* whitelist; // readonly for public
+@property (nonatomic, readonly, strong) NSMutableDictionary *pluginObjects;
+@property (nonatomic, readonly, strong) NSDictionary *pluginsMap;
+@property (nonatomic, readonly, strong) NSMutableDictionary *settings;
+@property (nonatomic, readonly, strong) NSXMLParser *configParser;
+@property (nonatomic, readonly, strong) CDVWhitelist *whitelist; // readonly for public
 @property (nonatomic, readonly, assign) BOOL loadFromString;
 
-@property (nonatomic, readwrite, copy) NSString* wwwFolderName;
-@property (nonatomic, readwrite, copy) NSString* startPage;
-@property (nonatomic, readonly, strong) CDVCommandQueue* commandQueue;
+@property (nonatomic, readwrite, copy) NSString *wwwFolderName;
+@property (nonatomic, readwrite, copy) NSString *startPage;
+@property (nonatomic, readonly, strong) CDVCommandQueue *commandQueue;
 @property (nonatomic, readonly, strong) id <CDVCommandDelegate> commandDelegate;
-@property (nonatomic, readonly) NSString* userAgent;
+@property (nonatomic, readonly) NSString *userAgent;
 
 + (NSDictionary*)getBundlePlist:(NSString*)plistName;
 + (NSString*)applicationDocumentsDirectory;

--- a/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/Classes/CDVViewController.m
@@ -29,21 +29,21 @@
 
 @interface CDVViewController () {
     NSInteger _userAgentLockToken;
-    CDVWebViewDelegate* _webViewDelegate;
+    CDVWebViewDelegate *_webViewDelegate;
 }
 
-@property (nonatomic, readwrite, strong) NSXMLParser* configParser;
-@property (nonatomic, readwrite, strong) NSMutableDictionary* settings;
-@property (nonatomic, readwrite, strong) CDVWhitelist* whitelist;
-@property (nonatomic, readwrite, strong) NSMutableDictionary* pluginObjects;
-@property (nonatomic, readwrite, strong) NSArray* startupPluginNames;
-@property (nonatomic, readwrite, strong) NSDictionary* pluginsMap;
-@property (nonatomic, readwrite, strong) NSArray* supportedOrientations;
+@property (nonatomic, readwrite, strong) NSXMLParser *configParser;
+@property (nonatomic, readwrite, strong) NSMutableDictionary *settings;
+@property (nonatomic, readwrite, strong) CDVWhitelist *whitelist;
+@property (nonatomic, readwrite, strong) NSMutableDictionary *pluginObjects;
+@property (nonatomic, readwrite, strong) NSArray *startupPluginNames;
+@property (nonatomic, readwrite, strong) NSDictionary *pluginsMap;
+@property (nonatomic, readwrite, strong) NSArray *supportedOrientations;
 @property (nonatomic, readwrite, assign) BOOL loadFromString;
 
 @property (readwrite, assign) BOOL initialized;
 
-@property (atomic, strong) NSURL* openURL;
+@property (atomic, strong) NSURL *openURL;
 
 @end
 
@@ -129,14 +129,14 @@
 
 - (void)printMultitaskingInfo
 {
-    UIDevice* device = [UIDevice currentDevice];
+    UIDevice *device = [UIDevice currentDevice];
     BOOL backgroundSupported = NO;
 
     if ([device respondsToSelector:@selector(isMultitaskingSupported)]) {
         backgroundSupported = device.multitaskingSupported;
     }
 
-    NSNumber* exitsOnSuspend = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationExitsOnSuspend"];
+    NSNumber *exitsOnSuspend = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationExitsOnSuspend"];
     if (exitsOnSuspend == nil) { // if it's missing, it should be NO (i.e. multi-tasking on by default)
         exitsOnSuspend = [NSNumber numberWithBool:NO];
     }
@@ -155,17 +155,17 @@
 
 - (void)loadSettings
 {
-    CDVConfigParser* delegate = [[CDVConfigParser alloc] init];
+    CDVConfigParser *delegate = [[CDVConfigParser alloc] init];
 
     // read from config.xml in the app bundle
-    NSString* path = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"xml"];
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"xml"];
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
         NSAssert(NO, @"ERROR: config.xml does not exist. Please run cordova-ios/bin/cordova_plist_to_config_xml path/to/project.");
         return;
     }
 
-    NSURL* url = [NSURL fileURLWithPath:path];
+    NSURL *url = [NSURL fileURLWithPath:path];
 
     configParser = [[NSXMLParser alloc] initWithContentsOfURL:url];
     if (configParser == nil) {
@@ -197,8 +197,8 @@
 {
     [super viewDidLoad];
 
-    NSURL* appURL = nil;
-    NSString* loadErr = nil;
+    NSURL *appURL = nil;
+    NSString *loadErr = nil;
 
     if ([self.startPage rangeOfString:@"://"].location != NSNotFound) {
         appURL = [NSURL URLWithString:self.startPage];
@@ -206,8 +206,8 @@
         appURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@", self.wwwFolderName, self.startPage]];
     } else {
         // CB-3005 strip parameters from start page to check if page exists in resources
-        NSURL* startURL = [NSURL URLWithString:self.startPage];
-        NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
+        NSURL *startURL = [NSURL URLWithString:self.startPage];
+        NSString *startFilePath = [self.commandDelegate pathForResource:[startURL path]];
 
         if (startFilePath == nil) {
             loadErr = [NSString stringWithFormat:@"ERROR: Start Page at '%@/%@' was not found.", self.wwwFolderName, self.startPage];
@@ -217,10 +217,10 @@
         } else {
             appURL = [NSURL fileURLWithPath:startFilePath];
             // CB-3005 Add on the query params or fragment.
-            NSString* startPageNoParentDirs = self.startPage;
+            NSString *startPageNoParentDirs = self.startPage;
             NSRange r = [startPageNoParentDirs rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"?#"] options:0];
             if (r.location != NSNotFound) {
-                NSString* queryAndOrFragment = [self.startPage substringFromIndex:r.location];
+                NSString *queryAndOrFragment = [self.startPage substringFromIndex:r.location];
                 appURL = [NSURL URLWithString:queryAndOrFragment relativeToURL:appURL];
             }
         }
@@ -228,7 +228,7 @@
 
     // // Fix the iOS 5.1 SECURITY_ERR bug (CB-347), this must be before the webView is instantiated ////
 
-    NSString* backupWebStorageType = @"cloud"; // default value
+    NSString *backupWebStorageType = @"cloud"; // default value
 
     id backupWebStorage = [self settingForKey:@"BackupWebStorage"];
     if ([backupWebStorage isKindOfClass:[NSString class]]) {
@@ -255,8 +255,8 @@
 
     // /////////////////
 
-    NSString* enableViewportScale = [self settingForKey:@"EnableViewportScale"];
-    NSNumber* allowInlineMediaPlayback = [self settingForKey:@"AllowInlineMediaPlayback"];
+    NSString *enableViewportScale = [self settingForKey:@"EnableViewportScale"];
+    NSNumber *allowInlineMediaPlayback = [self settingForKey:@"AllowInlineMediaPlayback"];
     BOOL mediaPlaybackRequiresUserAction = YES;  // default value
     if ([self settingForKey:@"MediaPlaybackRequiresUserAction"]) {
         mediaPlaybackRequiresUserAction = [(NSNumber*)[self settingForKey:@"MediaPlaybackRequiresUserAction"] boolValue];
@@ -285,9 +285,9 @@
     // By default, overscroll bouncing is allowed.
     // UIWebViewBounce has been renamed to DisallowOverscroll, but both are checked.
     BOOL bounceAllowed = YES;
-    NSNumber* disallowOverscroll = [self settingForKey:@"DisallowOverscroll"];
+    NSNumber *disallowOverscroll = [self settingForKey:@"DisallowOverscroll"];
     if (disallowOverscroll == nil) {
-        NSNumber* bouncePreference = [self settingForKey:@"UIWebViewBounce"];
+        NSNumber *bouncePreference = [self settingForKey:@"UIWebViewBounce"];
         bounceAllowed = (bouncePreference == nil || [bouncePreference boolValue]);
     } else {
         bounceAllowed = ![disallowOverscroll boolValue];
@@ -307,7 +307,7 @@
         }
     }
 
-    NSString* decelerationSetting = [self settingForKey:@"UIWebViewDecelerationSpeed"];
+    NSString *decelerationSetting = [self settingForKey:@"UIWebViewDecelerationSpeed"];
     if (![@"fast" isEqualToString : decelerationSetting]) {
         [self.webView.scrollView setDecelerationRate:UIScrollViewDecelerationRateNormal];
     }
@@ -375,8 +375,8 @@
         NSInteger paginationBreakingMode = 0; // default - UIWebPaginationBreakingModePage
         prefObj = [self settingForKey:@"PaginationBreakingMode"];
         if (prefObj != nil) {
-            NSArray* validValues = @[@"page", @"column"];
-            NSString* prefValue = [validValues objectAtIndex:0];
+            NSArray *validValues = @[@"page", @"column"];
+            NSString *prefValue = [validValues objectAtIndex:0];
 
             if ([prefObj isKindOfClass:[NSString class]]) {
                 prefValue = prefObj;
@@ -397,8 +397,8 @@
         NSInteger paginationMode = 0; // default - UIWebPaginationModeUnpaginated
         prefObj = [self settingForKey:@"PaginationMode"];
         if (prefObj != nil) {
-            NSArray* validValues = @[@"unpaginated", @"lefttoright", @"toptobottom", @"bottomtotop", @"righttoleft"];
-            NSString* prefValue = [validValues objectAtIndex:0];
+            NSArray *validValues = @[@"unpaginated", @"lefttoright", @"toptobottom", @"bottomtotop", @"righttoleft"];
+            NSString *prefValue = [validValues objectAtIndex:0];
 
             if ([prefObj isKindOfClass:[NSString class]]) {
                 prefValue = prefObj;
@@ -420,7 +420,7 @@
     if ([self.startupPluginNames count] > 0) {
         [CDVTimer start:@"TotalPluginStartup"];
 
-        for (NSString* pluginName in self.startupPluginNames) {
+        for (NSString *pluginName in self.startupPluginNames) {
             [CDVTimer start:pluginName];
             [self getCommandInstance:pluginName];
             [CDVTimer stop:pluginName];
@@ -434,10 +434,10 @@
         _userAgentLockToken = lockToken;
         [CDVUserAgentUtil setUserAgent:self.userAgent lockToken:lockToken];
         if (!loadErr) {
-            NSURLRequest* appReq = [NSURLRequest requestWithURL:appURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
+            NSURLRequest *appReq = [NSURLRequest requestWithURL:appURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
             [self.webView loadRequest:appReq];
         } else {
-            NSString* html = [NSString stringWithFormat:@"<html><body> %@ </body></html>", loadErr];
+            NSString *html = [NSString stringWithFormat:@"<html><body> %@ </body></html>", loadErr];
             [self.webView loadHTMLString:html baseURL:nil];
         }
     }];
@@ -455,11 +455,11 @@
 
 - (NSArray*)parseInterfaceOrientations:(NSArray*)orientations
 {
-    NSMutableArray* result = [[NSMutableArray alloc] init];
+    NSMutableArray *result = [[NSMutableArray alloc] init];
 
     if (orientations != nil) {
-        NSEnumerator* enumerator = [orientations objectEnumerator];
-        NSString* orientationString;
+        NSEnumerator *enumerator = [orientations objectEnumerator];
+        NSString *orientationString;
 
         while (orientationString = [enumerator nextObject]) {
             if ([orientationString isEqualToString:@"UIInterfaceOrientationPortrait"]) {
@@ -505,10 +505,10 @@
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
     // First, ask the webview via JS if it supports the new orientation
-    NSString* jsCall = [NSString stringWithFormat:
+    NSString *jsCall = [NSString stringWithFormat:
         @"window.shouldRotateToOrientation && window.shouldRotateToOrientation(%d);"
         , [self mapIosOrientationToJsOrientation:interfaceOrientation]];
-    NSString* res = [webView stringByEvaluatingJavaScriptFromString:jsCall];
+    NSString *res = [webView stringByEvaluatingJavaScriptFromString:jsCall];
 
     if ([res length] > 0) {
         return [res boolValue];
@@ -556,7 +556,7 @@
 - (NSString*)userAgent
 {
     if (_userAgent == nil) {
-        NSString* originalUserAgent = [CDVUserAgentUtil originalUserAgent];
+        NSString *originalUserAgent = [CDVUserAgentUtil originalUserAgent];
         // Use our address as a unique number to append to the User-Agent.
         _userAgent = [NSString stringWithFormat:@"%@ (%lld)", originalUserAgent, (long long)self];
     }
@@ -581,8 +581,8 @@
     // iterate through all the plugin objects, and call hasPendingOperation
     // if at least one has a pending operation, we don't call [super didReceiveMemoryWarning]
 
-    NSEnumerator* enumerator = [self.pluginObjects objectEnumerator];
-    CDVPlugin* plugin;
+    NSEnumerator *enumerator = [self.pluginObjects objectEnumerator];
+    CDVPlugin *plugin;
 
     BOOL doPurge = YES;
 
@@ -652,7 +652,7 @@
 
 - (BOOL)webView:(UIWebView*)theWebView shouldStartLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType
 {
-    NSURL* url = [request URL];
+    NSURL *url = [request URL];
 
     /*
      * Execute any commands queued with cordova.exec() on the JS side.
@@ -673,7 +673,7 @@
         // be unexpected to callers (exec callbacks will be called before exec() even
         // returns). To avoid this, we do not do any synchronous JS evals by using
         // flushCommandQueueWithDelayedJs.
-        NSString* inlineCommands = [[url fragment] substringFromIndex:3];
+        NSString *inlineCommands = [[url fragment] substringFromIndex:3];
         if ([inlineCommands length] == 0) {
             // Reach in right away since the WebCore / Main thread are already synchronized.
             [_commandQueue fetchCommandsFromJs];
@@ -693,8 +693,8 @@
     /*
      * Give plugins the chance to handle the url
      */
-    for (NSString* pluginName in pluginObjects) {
-        CDVPlugin* plugin = [pluginObjects objectForKey:pluginName];
+    for (NSString *pluginName in pluginObjects) {
+        CDVPlugin *plugin = [pluginObjects objectForKey:pluginName];
         SEL selector = NSSelectorFromString(@"shouldOverrideLoadWithRequest:navigationType:");
         if ([plugin respondsToSelector:selector]) {
             if ((BOOL)objc_msgSend(plugin, selector, request, navigationType) == YES) {
@@ -763,14 +763,14 @@
 
 - (void)javascriptAlert:(NSString*)text
 {
-    NSString* jsString = [NSString stringWithFormat:@"alert('%@');", text];
+    NSString *jsString = [NSString stringWithFormat:@"alert('%@');", text];
 
     [self.commandDelegate evalJs:jsString];
 }
 
 + (NSString*)resolveImageResource:(NSString*)resource
 {
-    NSString* systemVersion = [[UIDevice currentDevice] systemVersion];
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
     BOOL isLessThaniOS4 = ([systemVersion compare:@"4.0" options:NSNumericSearch] == NSOrderedAscending);
 
     // the iPad image (nor retina) differentiation code was not in 3.x, and we have to explicitly set the path
@@ -787,8 +787,8 @@
 
 + (NSString*)applicationDocumentsDirectory
 {
-    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString* basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
 
     return basePath;
 }
@@ -819,7 +819,7 @@
         [plugin setCommandDelegate:_commandDelegate];
     }
 
-    NSString* className = NSStringFromClass([plugin class]);
+    NSString *className = NSStringFromClass([plugin class]);
     [self.pluginObjects setObject:plugin forKey:className];
     [self.pluginsMap setValue:className forKey:[pluginName lowercaseString]];
     [plugin pluginInitialize];
@@ -835,7 +835,7 @@
     // NOTE: plugin names are matched as lowercase to avoid problems - however, a
     // possible issue is there can be duplicates possible if you had:
     // "org.apache.cordova.Foo" and "org.apache.cordova.foo" - only the lower-cased entry will match
-    NSString* className = [self.pluginsMap objectForKey:[pluginName lowercaseString]];
+    NSString *className = [self.pluginsMap objectForKey:[pluginName lowercaseString]];
 
     if (className == nil) {
         return nil;
@@ -858,14 +858,14 @@
 
 - (NSString*)appURLScheme
 {
-    NSString* URLScheme = nil;
+    NSString *URLScheme = nil;
 
-    NSArray* URLTypes = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleURLTypes"];
+    NSArray *URLTypes = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleURLTypes"];
 
     if (URLTypes != nil) {
-        NSDictionary* dict = [URLTypes objectAtIndex:0];
+        NSDictionary *dict = [URLTypes objectAtIndex:0];
         if (dict != nil) {
-            NSArray* URLSchemes = [dict objectForKey:@"CFBundleURLSchemes"];
+            NSArray *URLSchemes = [dict objectForKey:@"CFBundleURLSchemes"];
             if (URLSchemes != nil) {
                 URLScheme = [URLSchemes objectAtIndex:0];
             }
@@ -880,11 +880,11 @@
  */
 + (NSDictionary*)getBundlePlist:(NSString*)plistName
 {
-    NSString* errorDesc = nil;
+    NSString *errorDesc = nil;
     NSPropertyListFormat format;
-    NSString* plistPath = [[NSBundle mainBundle] pathForResource:plistName ofType:@"plist"];
-    NSData* plistXML = [[NSFileManager defaultManager] contentsAtPath:plistPath];
-    NSDictionary* temp = (NSDictionary*)[NSPropertyListSerialization
+    NSString *plistPath = [[NSBundle mainBundle] pathForResource:plistName ofType:@"plist"];
+    NSData *plistXML = [[NSFileManager defaultManager] contentsAtPath:plistPath];
+    NSDictionary *temp = (NSDictionary*)[NSPropertyListSerialization
         propertyListFromData:plistXML
             mutabilityOption:NSPropertyListMutableContainersAndLeaves
                       format:&format errorDescription:&errorDesc];
@@ -901,17 +901,17 @@
 - (void)onAppWillTerminate:(NSNotification*)notification
 {
     // empty the tmp directory
-    NSFileManager* fileMgr = [[NSFileManager alloc] init];
-    NSError* __autoreleasing err = nil;
+    NSFileManager *fileMgr = [[NSFileManager alloc] init];
+    NSError *__autoreleasing err = nil;
 
     // clear contents of NSTemporaryDirectory
-    NSString* tempDirectoryPath = NSTemporaryDirectory();
-    NSDirectoryEnumerator* directoryEnumerator = [fileMgr enumeratorAtPath:tempDirectoryPath];
-    NSString* fileName = nil;
+    NSString *tempDirectoryPath = NSTemporaryDirectory();
+    NSDirectoryEnumerator *directoryEnumerator = [fileMgr enumeratorAtPath:tempDirectoryPath];
+    NSString *fileName = nil;
     BOOL result;
 
     while ((fileName = [directoryEnumerator nextObject])) {
-        NSString* filePath = [tempDirectoryPath stringByAppendingPathComponent:fileName];
+        NSString *filePath = [tempDirectoryPath stringByAppendingPathComponent:fileName];
         result = [fileMgr removeItemAtPath:filePath error:&err];
         if (!result && err) {
             NSLog(@"Failed to delete: %@ (error: %@)", filePath, err);
@@ -968,7 +968,7 @@
 {
     if (self.openURL) {
         // calls into javascript global function 'handleOpenURL'
-        NSString* jsString = [NSString stringWithFormat:@"handleOpenURL(\"%@\");", [self.openURL description]];
+        NSString *jsString = [NSString stringWithFormat:@"handleOpenURL(\"%@\");", [self.openURL description]];
         [self.webView stringByEvaluatingJavaScriptFromString:jsString];
         self.openURL = nil;
     }

--- a/CordovaLib/Classes/CDVWebViewDelegate.h
+++ b/CordovaLib/Classes/CDVWebViewDelegate.h
@@ -26,7 +26,7 @@
  * Relevant bug: CB-2389
  */
 @interface CDVWebViewDelegate : NSObject <UIWebViewDelegate>{
-    __weak NSObject <UIWebViewDelegate>* _delegate;
+    __weak NSObject <UIWebViewDelegate> *_delegate;
     NSInteger _loadCount;
     NSInteger _state;
     NSInteger _curLoadToken;

--- a/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -91,7 +91,7 @@ typedef enum {
     STATE_CANCELLED = 5
 } State;
 
-static NSString *stripFragment(NSString* url)
+static NSString *stripFragment(NSString *url)
 {
     NSRange r = [url rangeOfString:@"#"];
 
@@ -117,11 +117,11 @@ static NSString *stripFragment(NSString* url)
 - (BOOL)request:(NSURLRequest*)newRequest isFragmentIdentifierToRequest:(NSURLRequest*)originalRequest
 {
     if (originalRequest.URL && newRequest.URL) {
-        NSString* originalRequestUrl = [originalRequest.URL absoluteString];
-        NSString* newRequestUrl = [newRequest.URL absoluteString];
+        NSString *originalRequestUrl = [originalRequest.URL absoluteString];
+        NSString *newRequestUrl = [newRequest.URL absoluteString];
 
-        NSString* baseOriginalRequestUrl = stripFragment(originalRequestUrl);
-        NSString* baseNewRequestUrl = stripFragment(newRequestUrl);
+        NSString *baseOriginalRequestUrl = stripFragment(originalRequestUrl);
+        NSString *baseNewRequestUrl = stripFragment(newRequestUrl);
         return [baseOriginalRequestUrl isEqualToString:baseNewRequestUrl];
     }
 
@@ -130,14 +130,14 @@ static NSString *stripFragment(NSString* url)
 
 - (BOOL)isPageLoaded:(UIWebView*)webView
 {
-    NSString* readyState = [webView stringByEvaluatingJavaScriptFromString:@"document.readyState"];
+    NSString *readyState = [webView stringByEvaluatingJavaScriptFromString:@"document.readyState"];
 
     return [readyState isEqualToString:@"loaded"] || [readyState isEqualToString:@"complete"];
 }
 
 - (BOOL)isJsLoadTokenSet:(UIWebView*)webView
 {
-    NSString* loadToken = [webView stringByEvaluatingJavaScriptFromString:@"window.__cordovaLoadToken"];
+    NSString *loadToken = [webView stringByEvaluatingJavaScriptFromString:@"window.__cordovaLoadToken"];
 
     return [[NSString stringWithFormat:@"%d", _curLoadToken] isEqualToString:loadToken];
 }
@@ -212,7 +212,7 @@ static NSString *stripFragment(NSString* url)
             // Ignore hash changes that don't navigate to a different page.
             // webView.request does actually update when history.replaceState() gets called.
             if ([self request:request isFragmentIdentifierToRequest:webView.request]) {
-                NSString* prevURL = [self evalForCurrentURL:webView];
+                NSString *prevURL = [self evalForCurrentURL:webView];
                 if ([prevURL isEqualToString:[request.URL absoluteString]]) {
                     VerboseLog(@"Page reload detected.");
                 } else {
@@ -242,11 +242,11 @@ static NSString *stripFragment(NSString* url)
                     {
                         _loadCount = 0;
                         _state = STATE_WAITING_FOR_LOAD_START;
-                        NSString* description = [NSString stringWithFormat:@"CDVWebViewDelegate: Navigation started when state=%d", _state];
+                        NSString *description = [NSString stringWithFormat:@"CDVWebViewDelegate: Navigation started when state=%d", _state];
                         NSLog(@"%@", description);
                         if ([_delegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
-                            NSDictionary* errorDictionary = @{NSLocalizedDescriptionKey : description};
-                            NSError* error = [[NSError alloc] initWithDomain:@"CDVWebViewDelegate" code:1 userInfo:errorDictionary];
+                            NSDictionary *errorDictionary = @{NSLocalizedDescriptionKey : description};
+                            NSError *error = [[NSError alloc] initWithDomain:@"CDVWebViewDelegate" code:1 userInfo:errorDictionary];
                             [_delegate webView:webView didFailLoadWithError:error];
                         }
                     }

--- a/CordovaLib/Classes/CDVWhitelist.h
+++ b/CordovaLib/Classes/CDVWhitelist.h
@@ -19,11 +19,11 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString* const kCDVDefaultWhitelistRejectionString;
+extern NSString *const kCDVDefaultWhitelistRejectionString;
 
 @interface CDVWhitelist : NSObject
 
-@property (nonatomic, copy) NSString* whitelistRejectionFormatString;
+@property (nonatomic, copy) NSString *whitelistRejectionFormatString;
 
 - (id)initWithArray:(NSArray*)array;
 - (BOOL)schemeIsAllowed:(NSString*)scheme;

--- a/CordovaLib/Classes/CDVWhitelist.m
+++ b/CordovaLib/Classes/CDVWhitelist.m
@@ -19,15 +19,15 @@
 
 #import "CDVWhitelist.h"
 
-NSString* const kCDVDefaultWhitelistRejectionString = @"ERROR whitelist rejection: url='%@'";
-NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
+NSString *const kCDVDefaultWhitelistRejectionString = @"ERROR whitelist rejection: url='%@'";
+NSString *const kCDVDefaultSchemeName = @"cdv-default-scheme";
 
 @interface CDVWhitelistPattern : NSObject {
     @private
-    NSRegularExpression* _scheme;
-    NSRegularExpression* _host;
-    NSNumber* _port;
-    NSRegularExpression* _path;
+    NSRegularExpression *_scheme;
+    NSRegularExpression *_host;
+    NSNumber *_port;
+    NSRegularExpression *_path;
 }
 
 + (NSString*)regexFromPattern:(NSString*)pattern allowWildcards:(bool)allowWildcards;
@@ -40,7 +40,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
 
 + (NSString*)regexFromPattern:(NSString*)pattern allowWildcards:(bool)allowWildcards
 {
-    NSString* regex = [NSRegularExpression escapedPatternForString:pattern];
+    NSString *regex = [NSRegularExpression escapedPatternForString:pattern];
 
     if (allowWildcards) {
         regex = [regex stringByReplacingOccurrencesOfString:@"\\*" withString:@".*"];
@@ -97,8 +97,8 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
 
 @interface CDVWhitelist ()
 
-@property (nonatomic, readwrite, strong) NSMutableArray* whitelist;
-@property (nonatomic, readwrite, strong) NSMutableSet* permittedSchemes;
+@property (nonatomic, readwrite, strong) NSMutableArray *whitelist;
+@property (nonatomic, readwrite, strong) NSMutableSet *permittedSchemes;
 
 - (void)addWhiteListEntry:(NSString*)pattern;
 
@@ -116,7 +116,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
         self.permittedSchemes = [[NSMutableSet alloc] init];
         self.whitelistRejectionFormatString = kCDVDefaultWhitelistRejectionString;
 
-        for (NSString* pattern in array) {
+        for (NSString *pattern in array) {
             [self addWhiteListEntry:pattern];
         }
     }
@@ -130,7 +130,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
 
     // we could use a regex to solve this problem but then I would have two problems
     // anyways, this is much clearer and maintainable
-    NSArray* octets = [externalHost componentsSeparatedByString:@"."];
+    NSArray *octets = [externalHost componentsSeparatedByString:@"."];
     NSUInteger num_octets = [octets count];
 
     // quick check
@@ -139,13 +139,13 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
     }
 
     // restrict number parsing to 0-255
-    NSNumberFormatter* numberFormatter = [[NSNumberFormatter alloc] init];
+    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
     [numberFormatter setMinimum:[NSNumber numberWithUnsignedInteger:0]];
     [numberFormatter setMaximum:[NSNumber numberWithUnsignedInteger:255]];
 
     // iterate through each octet, and test for a number between 0-255 or if it equals '*'
     for (NSUInteger i = 0; i < num_octets; ++i) {
-        NSString* octet = [octets objectAtIndex:i];
+        NSString *octet = [octets objectAtIndex:i];
 
         if ([octet isEqualToString:@"*"]) { // passes - check next octet
             continue;
@@ -168,17 +168,17 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
         self.whitelist = nil;
         self.permittedSchemes = nil;
     } else { // specific access
-        NSRegularExpression* parts = [NSRegularExpression regularExpressionWithPattern:@"^((\\*|[A-Za-z-]+)://)?(((\\*\\.)?[^*/:]+)|\\*)?(:(\\d+))?(/.*)?" options:0 error:nil];
-        NSTextCheckingResult* m = [parts firstMatchInString:origin options:NSMatchingAnchored range:NSMakeRange(0, [origin length])];
+        NSRegularExpression *parts = [NSRegularExpression regularExpressionWithPattern:@"^((\\*|[A-Za-z-]+)://)?(((\\*\\.)?[^*/:]+)|\\*)?(:(\\d+))?(/.*)?" options:0 error:nil];
+        NSTextCheckingResult *m = [parts firstMatchInString:origin options:NSMatchingAnchored range:NSMakeRange(0, [origin length])];
         if (m != nil) {
             NSRange r;
-            NSString* scheme = nil;
+            NSString *scheme = nil;
             r = [m rangeAtIndex:2];
             if (r.location != NSNotFound) {
                 scheme = [origin substringWithRange:r];
             }
 
-            NSString* host = nil;
+            NSString *host = nil;
             r = [m rangeAtIndex:3];
             if (r.location != NSNotFound) {
                 host = [origin substringWithRange:r];
@@ -189,13 +189,13 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
                 host = @"*";
             }
 
-            NSString* port = nil;
+            NSString *port = nil;
             r = [m rangeAtIndex:7];
             if (r.location != NSNotFound) {
                 port = [origin substringWithRange:r];
             }
 
-            NSString* path = nil;
+            NSString *path = nil;
             r = [m rangeAtIndex:8];
             if (r.location != NSNotFound) {
                 path = [origin substringWithRange:r];
@@ -245,7 +245,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
     }
 
     // Shortcut rejection: Check that the scheme is supported
-    NSString* scheme = [[url scheme] lowercaseString];
+    NSString *scheme = [[url scheme] lowercaseString];
     if (![self schemeIsAllowed:scheme]) {
         if (logFailure) {
             NSLog(@"%@", [self errorStringForURL:url]);
@@ -255,7 +255,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
 
     // http[s] and ftp[s] should also validate against the common set in the kCDVDefaultSchemeName list
     if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"] || [scheme isEqualToString:@"ftp"] || [scheme isEqualToString:@"ftps"]) {
-        NSURL* newUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@%@", kCDVDefaultSchemeName, [url host], [[url path] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
+        NSURL *newUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@%@", kCDVDefaultSchemeName, [url host], [[url path] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
         // If it is allowed, we are done.  If not, continue to check for the actual scheme-specific list
         if ([self URLIsAllowed:newUrl logFailure:NO]) {
             return YES;
@@ -263,7 +263,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
     }
 
     // Check the url against patterns in the whitelist
-    for (CDVWhitelistPattern* p in self.whitelist) {
+    for (CDVWhitelistPattern *p in self.whitelist) {
         if ([p matches:url]) {
             return YES;
         }

--- a/CordovaLib/Classes/NSArray+Comparisons.m
+++ b/CordovaLib/Classes/NSArray+Comparisons.m
@@ -31,7 +31,7 @@
             return aDefault;
         }
     }
-    @catch(NSException* exception) {
+    @catch(NSException *exception) {
         NSLog(@"Exception - Name: %@ Reason: %@", [exception name], [exception reason]);
     }
 

--- a/CordovaLib/Classes/NSData+Base64.m
+++ b/CordovaLib/Classes/NSData+Base64.m
@@ -77,7 +77,7 @@ void *CDVNewBase64Decode(
     }
 
     size_t outputBufferSize = (length / CDV_BASE64_UNIT_SIZE) * CDV_BINARY_UNIT_SIZE;
-    unsigned char* outputBuffer = (unsigned char*)malloc(outputBufferSize);
+    unsigned char *outputBuffer = (unsigned char*)malloc(outputBufferSize);
 
     size_t i = 0;
     size_t j = 0;
@@ -139,7 +139,7 @@ char *CDVNewBase64Encode(
     bool      separateLines,
     size_t    * outputLength)
 {
-    const unsigned char* inputBuffer = (const unsigned char*)buffer;
+    const unsigned char *inputBuffer = (const unsigned char*)buffer;
 
 #define MAX_NUM_PADDING_CHARS 2
 #define OUTPUT_LINE_LENGTH 64
@@ -166,7 +166,7 @@ char *CDVNewBase64Encode(
     //
     // Allocate the output buffer
     //
-    char* outputBuffer = (char*)malloc(outputBufferSize);
+    char *outputBuffer = (char*)malloc(outputBufferSize);
     if (!outputBuffer) {
         return NULL;
     }
@@ -250,7 +250,7 @@ char *CDVNewBase64Encode(
 + (NSData*)dataFromBase64String:(NSString*)aString
 {
     size_t outputLength = 0;
-    void* outputBuffer = CDVNewBase64Decode([aString UTF8String], [aString length], &outputLength);
+    void *outputBuffer = CDVNewBase64Decode([aString UTF8String], [aString length], &outputLength);
 
     return [NSData dataWithBytesNoCopy:outputBuffer length:outputLength freeWhenDone:YES];
 }
@@ -267,10 +267,10 @@ char *CDVNewBase64Encode(
 - (NSString*)base64EncodedString
 {
     size_t outputLength = 0;
-    char* outputBuffer =
+    char *outputBuffer =
         CDVNewBase64Encode([self bytes], [self length], true, &outputLength);
 
-    NSString* result = [[NSString alloc] initWithBytesNoCopy:outputBuffer
+    NSString *result = [[NSString alloc] initWithBytesNoCopy:outputBuffer
                                                       length:outputLength
                                                     encoding:NSASCIIStringEncoding
                                                 freeWhenDone:YES];

--- a/CordovaLib/Classes/NSDictionary+Extensions.m
+++ b/CordovaLib/Classes/NSDictionary+Extensions.m
@@ -38,7 +38,7 @@
 {
     NSInteger value = defaultValue;
 
-    NSNumber* val = [self valueForKey:key];  // value is an NSNumber
+    NSNumber *val = [self valueForKey:key];  // value is an NSNumber
 
     if (val != nil) {
         value = [val integerValue];
@@ -55,7 +55,7 @@
 {
     NSInteger value = defaultValue;
 
-    NSNumber* val = [self valueForKey:key];  // value is an NSNumber
+    NSNumber *val = [self valueForKey:key];  // value is an NSNumber
 
     if (val != nil) {
         value = [val integerValue];
@@ -80,7 +80,7 @@
 - (BOOL)typeValueForKey:(NSString*)key isArray:(BOOL*)bArray isNull:(BOOL*)bNull isNumber:(BOOL*)bNumber isString:(BOOL*)bString
 {
     BOOL bExists = YES;
-    NSObject* value = [self objectForKey:key];
+    NSObject *value = [self objectForKey:key];
 
     if (value) {
         bExists = YES;
@@ -103,7 +103,7 @@
 - (BOOL)valueForKeyIsArray:(NSString*)key
 {
     BOOL bArray = NO;
-    NSObject* value = [self objectForKey:key];
+    NSObject *value = [self objectForKey:key];
 
     if (value) {
         bArray = [value isKindOfClass:[NSArray class]];
@@ -114,7 +114,7 @@
 - (BOOL)valueForKeyIsNull:(NSString*)key
 {
     BOOL bNull = NO;
-    NSObject* value = [self objectForKey:key];
+    NSObject *value = [self objectForKey:key];
 
     if (value) {
         bNull = [value isKindOfClass:[NSNull class]];
@@ -125,7 +125,7 @@
 - (BOOL)valueForKeyIsString:(NSString*)key
 {
     BOOL bString = NO;
-    NSObject* value = [self objectForKey:key];
+    NSObject *value = [self objectForKey:key];
 
     if (value) {
         bString = [value isKindOfClass:[NSString class]];
@@ -136,7 +136,7 @@
 - (BOOL)valueForKeyIsNumber:(NSString*)key
 {
     BOOL bNumber = NO;
-    NSObject* value = [self objectForKey:key];
+    NSObject *value = [self objectForKey:key];
 
     if (value) {
         bNumber = [value isKindOfClass:[NSNumber class]];
@@ -146,8 +146,8 @@
 
 - (NSDictionary*)dictionaryWithLowercaseKeys
 {
-    NSMutableDictionary* result = [NSMutableDictionary dictionaryWithCapacity:self.count];
-    NSString* key;
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:self.count];
+    NSString *key;
 
     for (key in self) {
         [result setObject:[self objectForKey:key] forKey:[key lowercaseString]];

--- a/CordovaLib/Classes/UIDevice+Extensions.m
+++ b/CordovaLib/Classes/UIDevice+Extensions.m
@@ -24,10 +24,10 @@
 
 - (NSString*)uniqueAppInstanceIdentifier
 {
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    static NSString* UUID_KEY = @"CDVUUID";
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    static NSString *UUID_KEY = @"CDVUUID";
 
-    NSString* app_uuid = [userDefaults stringForKey:UUID_KEY];
+    NSString *app_uuid = [userDefaults stringForKey:UUID_KEY];
 
     if (app_uuid == nil) {
         CFUUIDRef uuidRef = CFUUIDCreate(kCFAllocatorDefault);

--- a/CordovaLibTests/CDVBase64Tests.m
+++ b/CordovaLibTests/CDVBase64Tests.m
@@ -42,21 +42,21 @@
 
 - (void)testBase64Encode
 {
-    NSString* decodedString = @"abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&";
-    NSData* decodedData = [decodedString dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *decodedString = @"abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&";
+    NSData *decodedData = [decodedString dataUsingEncoding:NSUTF8StringEncoding];
 
-    NSString* expectedEncodedString = @"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwIUAjJCVeJg==";
-    NSString* actualEncodedString = [decodedData base64EncodedString];
+    NSString *expectedEncodedString = @"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwIUAjJCVeJg==";
+    NSString *actualEncodedString = [decodedData base64EncodedString];
 
     STAssertTrue([expectedEncodedString isEqualToString:actualEncodedString], nil);
 }
 
 - (void)testBase64Decode
 {
-    NSString* encodedString = @"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwIUAjJCVeJg==";
-    NSString* decodedString = @"abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&";
-    NSData* encodedData = [decodedString dataUsingEncoding:NSUTF8StringEncoding];
-    NSData* decodedData = [NSData dataFromBase64String:encodedString];
+    NSString *encodedString = @"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwIUAjJCVeJg==";
+    NSString *decodedString = @"abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&";
+    NSData *encodedData = [decodedString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *decodedData = [NSData dataFromBase64String:encodedString];
 
     STAssertTrue([encodedData isEqualToData:decodedData], nil);
 }

--- a/CordovaLibTests/CDVInvokedUrlCommandTests.m
+++ b/CordovaLibTests/CDVInvokedUrlCommandTests.m
@@ -28,8 +28,8 @@
 
 - (void)testInitWithNoArgs
 {
-    NSArray* jsonArr = [NSArray arrayWithObjects:@"callbackId", @"className", @"methodName", [NSArray array], nil];
-    CDVInvokedUrlCommand* command = [CDVInvokedUrlCommand commandFromJson:jsonArr];
+    NSArray *jsonArr = [NSArray arrayWithObjects:@"callbackId", @"className", @"methodName", [NSArray array], nil];
+    CDVInvokedUrlCommand *command = [CDVInvokedUrlCommand commandFromJson:jsonArr];
 
     STAssertEquals(@"callbackId", command.callbackId, nil);
     STAssertEquals(@"className", command.className, nil);
@@ -39,8 +39,8 @@
 
 - (void)testArgumentAtIndex
 {
-    NSArray* jsonArr = [NSArray arrayWithObjects:[NSNull null], @"className", @"methodName", [NSArray array], nil];
-    CDVInvokedUrlCommand* command = [CDVInvokedUrlCommand commandFromJson:jsonArr];
+    NSArray *jsonArr = [NSArray arrayWithObjects:[NSNull null], @"className", @"methodName", [NSArray array], nil];
+    CDVInvokedUrlCommand *command = [CDVInvokedUrlCommand commandFromJson:jsonArr];
 
     STAssertNil([command argumentAtIndex:0], @"NSNull to nil");
     STAssertNil([command argumentAtIndex:100], @"Invalid index to nil");

--- a/CordovaLibTests/CDVLocalStorageTests.m
+++ b/CordovaLibTests/CDVLocalStorageTests.m
@@ -54,9 +54,9 @@
 
 - (void)deleteOriginals:(BOOL)originals backups:(BOOL)backups
 {
-    NSFileManager* fileManager = [NSFileManager defaultManager];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
 
-    for (CDVBackupInfo* info in [self localStorage].backupInfo) {
+    for (CDVBackupInfo *info in [self localStorage].backupInfo) {
         if (originals) {
             [fileManager removeItemAtPath:info.original error:nil];
         }
@@ -68,7 +68,7 @@
 
 - (void)disabled_testBackupAndRestore
 {
-    CDVLocalStorage* localStorage = [self localStorage];
+    CDVLocalStorage *localStorage = [self localStorage];
 
     [self waitForConditionName:@"shouldBackup" block:^{
         [self evalJs:@"localStorage.setItem('foo', 'bar')"];
@@ -91,12 +91,12 @@
 
 - (void)testVerifyAndFixDatabaseLocations_noChangeRequired
 {
-    NSString* const kBundlePath = @"/bpath";
-    id fakeFileManager = [CDVFakeFileManager managerWithFileExistsBlock:^(NSString* path) {
+    NSString *const kBundlePath = @"/bpath";
+    id fakeFileManager = [CDVFakeFileManager managerWithFileExistsBlock:^(NSString *path) {
             STFail(@"fileExists called.");
             return NO;
         }];
-    NSMutableDictionary* appPlistDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSMutableDictionary *appPlistDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
         @"/bpath/foo", @"WebKitLocalStorageDatabasePathPreferenceKey",
         @"/bpath/foo", @"WebDatabaseDirectory",
         nil];
@@ -109,11 +109,11 @@
 
 - (void)testVerifyAndFixDatabaseLocations_changeRequired1
 {
-    NSString* const kBundlePath = @"/bpath";
-    id fakeFileManager = [CDVFakeFileManager managerWithFileExistsBlock:^(NSString* path) {
+    NSString *const kBundlePath = @"/bpath";
+    id fakeFileManager = [CDVFakeFileManager managerWithFileExistsBlock:^(NSString *path) {
             return YES;
         }];
-    NSMutableDictionary* appPlistDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSMutableDictionary *appPlistDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
         @"/foo", @"WebKitLocalStorageDatabasePathPreferenceKey",
         nil];
     BOOL modified = [CDVLocalStorage __verifyAndFixDatabaseLocationsWithAppPlistDict:appPlistDict
@@ -121,17 +121,17 @@
                                                                          fileManager:fakeFileManager];
 
     STAssertTrue(modified, @"Should have applied fix.");
-    NSString* newPath = [appPlistDict objectForKey:@"WebKitLocalStorageDatabasePathPreferenceKey"];
+    NSString *newPath = [appPlistDict objectForKey:@"WebKitLocalStorageDatabasePathPreferenceKey"];
     STAssertTrue([@"/bpath/Library/Caches" isEqualToString: newPath], nil);
 }
 
 - (void)testVerifyAndFixDatabaseLocations_changeRequired2
 {
-    NSString* const kBundlePath = @"/bpath";
-    id fakeFileManager = [CDVFakeFileManager managerWithFileExistsBlock:^(NSString* path) {
+    NSString *const kBundlePath = @"/bpath";
+    id fakeFileManager = [CDVFakeFileManager managerWithFileExistsBlock:^(NSString *path) {
             return NO;
         }];
-    NSMutableDictionary* appPlistDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSMutableDictionary *appPlistDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
         @"/foo", @"WebDatabaseDirectory",
         nil];
     BOOL modified = [CDVLocalStorage __verifyAndFixDatabaseLocationsWithAppPlistDict:appPlistDict
@@ -139,7 +139,7 @@
                                                                          fileManager:fakeFileManager];
 
     STAssertTrue(modified, @"Should have applied fix.");
-    NSString* newPath = [appPlistDict objectForKey:@"WebDatabaseDirectory"];
+    NSString *newPath = [appPlistDict objectForKey:@"WebDatabaseDirectory"];
     STAssertTrue([@"/bpath/Library/WebKit" isEqualToString: newPath], nil);
 }
 

--- a/CordovaLibTests/CDVPluginResultJSONSerializationTests.m
+++ b/CordovaLibTests/CDVPluginResultJSONSerializationTests.m
@@ -30,34 +30,34 @@
 
 - (void)testSerializingMessageAsInt
 {
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:5];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSNumber* message = [dic objectForKey:@"message"];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:5];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSNumber *message = [dic objectForKey:@"message"];
 
     STAssertTrue([[NSNumber numberWithInt:5] isEqual:message], nil);
 }
 
 - (void)testSerializingMessageAsDouble
 {
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:5.5];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSNumber* message = [dic objectForKey:@"message"];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:5.5];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSNumber *message = [dic objectForKey:@"message"];
 
     STAssertTrue([[NSNumber numberWithDouble:5.5] isEqual:message], nil);
 }
 
 - (void)testSerializingMessageAsBool
 {
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSNumber* message = [dic objectForKey:@"message"];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSNumber *message = [dic objectForKey:@"message"];
 
     STAssertTrue([[NSNumber numberWithBool:YES] isEqual:message], nil);
 }
 
 - (void)testSerializingMessageAsArray
 {
-    NSArray* testValues = [NSArray arrayWithObjects:
+    NSArray *testValues = [NSArray arrayWithObjects:
         [NSNull null],
         @"string",
         [NSNumber numberWithInt:5],
@@ -65,9 +65,9 @@
         [NSNumber numberWithBool:true],
         nil];
 
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:testValues];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSArray* message = [dic objectForKey:@"message"];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:testValues];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSArray *message = [dic objectForKey:@"message"];
 
     STAssertTrue([message isKindOfClass:[NSArray class]], nil);
     STAssertTrue([testValues count] == [message count], nil);
@@ -100,7 +100,7 @@
 
 - (void)testSerializingMessageAsDictionary
 {
-    NSMutableDictionary* testValues = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSMutableDictionary *testValues = [NSMutableDictionary dictionaryWithObjectsAndKeys:
         [NSNull null], @"nullItem",
         @"string", @"stringItem",
         [NSNumber numberWithInt:5], @"intItem",
@@ -108,46 +108,46 @@
         [NSNumber numberWithBool:true], @"boolItem",
         nil];
 
-    NSDictionary* nestedDict = [testValues copy];
+    NSDictionary *nestedDict = [testValues copy];
 
     [testValues setValue:nestedDict forKey:@"nestedDict"];
 
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:testValues];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSDictionary* message = [dic objectForKey:@"message"];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:testValues];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSDictionary *message = [dic objectForKey:@"message"];
 
     [self __testDictionary:testValues withDictionary:message];
 }
 
 - (void)testSerializingMessageAsErrorCode
 {
-    NSMutableDictionary* testValues = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSMutableDictionary *testValues = [NSMutableDictionary dictionaryWithObjectsAndKeys:
         [NSNumber numberWithInt:1], @"code",
         nil];
 
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageToErrorObject:1];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSDictionary* message = [dic objectForKey:@"message"];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageToErrorObject:1];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSDictionary *message = [dic objectForKey:@"message"];
 
     [self __testDictionary:testValues withDictionary:message];
 }
 
 - (void)testSerializingMessageAsStringContainingQuotes
 {
-    NSString* quotedString = @"\"quoted\"";
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:quotedString];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSString* message = [dic objectForKey:@"message"];
+    NSString *quotedString = @"\"quoted\"";
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:quotedString];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSString *message = [dic objectForKey:@"message"];
 
     STAssertTrue([quotedString isEqual:message], nil);
 }
 
 - (void)testSerializingMessageAsStringThatIsNil
 {
-    NSString* nilString = nil;
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nilString];
-    NSDictionary* dic = [[result toJSONString] JSONObject];
-    NSString* message = [dic objectForKey:@"message"];
+    NSString *nilString = nil;
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nilString];
+    NSDictionary *dic = [[result toJSONString] JSONObject];
+    NSString *message = [dic objectForKey:@"message"];
 
     STAssertTrue([[NSNull null] isEqual:message], nil);
 }

--- a/CordovaLibTests/CDVStartPageTests.m
+++ b/CordovaLibTests/CDVStartPageTests.m
@@ -24,8 +24,8 @@
 #import "AppDelegate.h"
 
 @interface CDVStartPageTestViewController : UIViewController
-@property (strong, nonatomic) CDVViewController* vc1;
-@property (strong, nonatomic) CDVViewController* vc2;
+@property (strong, nonatomic) CDVViewController *vc1;
+@property (strong, nonatomic) CDVViewController *vc2;
 @end
 
 @implementation CDVStartPageTestViewController
@@ -44,7 +44,7 @@
     [self addChildViewController:_vc2];
 
     CGRect applicationFrame = [[UIScreen mainScreen] applicationFrame];
-    UIView* contentView = [[UIView alloc] initWithFrame:applicationFrame];
+    UIView *contentView = [[UIView alloc] initWithFrame:applicationFrame];
 
     CGRect sub1, sub2;
     CGRectDivide(applicationFrame, &sub1, &sub2, applicationFrame.size.height / 2, CGRectMinYEdge);
@@ -76,16 +76,16 @@
 
 - (void)testParametersInStartPage
 {
-    CDVStartPageTestViewController* rootVc = [[CDVStartPageTestViewController alloc] init];
+    CDVStartPageTestViewController *rootVc = [[CDVStartPageTestViewController alloc] init];
 
     self.appDelegate.window.rootViewController = rootVc;
 
-    NSString* geHREF = @"window.location.href";
+    NSString *geHREF = @"window.location.href";
     [self waitForConditionName:@"getting href" block:^{
         return (BOOL)(rootVc.vc1.webView.request != nil && rootVc.vc1.webView.request != nil);
     }];
 
-    NSString* href = [rootVc.vc1.webView stringByEvaluatingJavaScriptFromString:geHREF];
+    NSString *href = [rootVc.vc1.webView stringByEvaluatingJavaScriptFromString:geHREF];
     STAssertTrue([href hasSuffix:@"index.html"], @"href should point to index.html");
 
     href = [rootVc.vc2.webView stringByEvaluatingJavaScriptFromString:geHREF];

--- a/CordovaLibTests/CDVUserAgentTest.m
+++ b/CordovaLibTests/CDVUserAgentTest.m
@@ -24,8 +24,8 @@
 #import "AppDelegate.h"
 
 @interface CDVUserAgentTestViewController : UIViewController
-@property (nonatomic) CDVViewController* vc1;
-@property (nonatomic) CDVViewController* vc2;
+@property (nonatomic) CDVViewController *vc1;
+@property (nonatomic) CDVViewController *vc2;
 @end
 
 @implementation CDVUserAgentTestViewController
@@ -44,7 +44,7 @@
     [self addChildViewController:_vc2];
 
     CGRect applicationFrame = [[UIScreen mainScreen] applicationFrame];
-    UIView* contentView = [[UIView alloc] initWithFrame:applicationFrame];
+    UIView *contentView = [[UIView alloc] initWithFrame:applicationFrame];
 
     CGRect sub1, sub2;
     CGRectDivide(applicationFrame, &sub1, &sub2, applicationFrame.size.height / 2, CGRectMinYEdge);
@@ -76,16 +76,16 @@
 
 - (void)testMultipleViews
 {
-    CDVUserAgentTestViewController* rootVc = [[CDVUserAgentTestViewController alloc] init];
+    CDVUserAgentTestViewController *rootVc = [[CDVUserAgentTestViewController alloc] init];
 
     self.appDelegate.window.rootViewController = rootVc;
 
-    NSString* getUserAgentCode = @"navigator.userAgent";
+    NSString *getUserAgentCode = @"navigator.userAgent";
     [self waitForConditionName:@"getting user-agents" block:^{
         return (BOOL)(rootVc.vc1.webView.request != nil && rootVc.vc2.webView.request != nil);
     }];
-    NSString* ua1 = [rootVc.vc1.webView stringByEvaluatingJavaScriptFromString:getUserAgentCode];
-    NSString* ua2 = [rootVc.vc2.webView stringByEvaluatingJavaScriptFromString:getUserAgentCode];
+    NSString *ua1 = [rootVc.vc1.webView stringByEvaluatingJavaScriptFromString:getUserAgentCode];
+    NSString *ua2 = [rootVc.vc2.webView stringByEvaluatingJavaScriptFromString:getUserAgentCode];
 
     STAssertFalse([ua1 isEqual:ua2], @"User-Agents should be different.");
 }

--- a/CordovaLibTests/CDVWebViewDelegateTests.m
+++ b/CordovaLibTests/CDVWebViewDelegateTests.m
@@ -53,19 +53,19 @@
 
 - (void)doTestFragmentIdentifiersWithBaseUrl:(NSString*)baseUrl fragment:(NSString*)fragment
 {
-    CDVWebViewDelegate* wvd = [[CDVWebViewDelegate alloc] initWithDelegate:nil]; // not really testing delegate handling
+    CDVWebViewDelegate *wvd = [[CDVWebViewDelegate alloc] initWithDelegate:nil]; // not really testing delegate handling
 
-    NSString* originalUrlString = baseUrl;
-    NSURL* originalUrl = [NSURL URLWithString:originalUrlString];
-    NSURL* originalUrlWithFragmentOnly = [NSURL URLWithString:[NSString stringWithFormat:@"%@#%@", originalUrlString, fragment]];
-    NSURL* originalUrlWithFragmentOnlyNoIdentifier = [NSURL URLWithString:[NSString stringWithFormat:@"%@#", originalUrlString]];
-    NSURL* originalUrlWithQueryParamsAndFragment = [NSURL URLWithString:[NSString stringWithFormat:@"%@?foo=bar#%@", originalUrlString, fragment]];
+    NSString *originalUrlString = baseUrl;
+    NSURL *originalUrl = [NSURL URLWithString:originalUrlString];
+    NSURL *originalUrlWithFragmentOnly = [NSURL URLWithString:[NSString stringWithFormat:@"%@#%@", originalUrlString, fragment]];
+    NSURL *originalUrlWithFragmentOnlyNoIdentifier = [NSURL URLWithString:[NSString stringWithFormat:@"%@#", originalUrlString]];
+    NSURL *originalUrlWithQueryParamsAndFragment = [NSURL URLWithString:[NSString stringWithFormat:@"%@?foo=bar#%@", originalUrlString, fragment]];
 
-    NSURLRequest* originalRequest = [NSURLRequest requestWithURL:originalUrl];
-    NSURLRequest* originalRequestWithFragmentOnly = [NSURLRequest requestWithURL:originalUrlWithFragmentOnly];
-    NSURLRequest* originalRequestWithFragmentOnlyNoIdentifier = [NSURLRequest requestWithURL:originalUrlWithFragmentOnlyNoIdentifier];
-    NSURLRequest* originalRequestWithQueryParamsAndFragment = [NSURLRequest requestWithURL:originalUrlWithQueryParamsAndFragment];
-    NSURLRequest* notOriginalRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://httpd.apache.org"]];
+    NSURLRequest *originalRequest = [NSURLRequest requestWithURL:originalUrl];
+    NSURLRequest *originalRequestWithFragmentOnly = [NSURLRequest requestWithURL:originalUrlWithFragmentOnly];
+    NSURLRequest *originalRequestWithFragmentOnlyNoIdentifier = [NSURLRequest requestWithURL:originalUrlWithFragmentOnlyNoIdentifier];
+    NSURLRequest *originalRequestWithQueryParamsAndFragment = [NSURLRequest requestWithURL:originalUrlWithQueryParamsAndFragment];
+    NSURLRequest *notOriginalRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://httpd.apache.org"]];
 
     STAssertFalse([wvd request:originalRequest isFragmentIdentifierToRequest:originalRequest], @"originalRequest should not be a fragment of originalRequest");
     STAssertTrue([wvd request:originalRequestWithFragmentOnly isFragmentIdentifierToRequest:originalRequest], @"originalRequestWithFragment should be a fragment of originalRequest");

--- a/CordovaLibTests/CDVWebViewTest.h
+++ b/CordovaLibTests/CDVWebViewTest.h
@@ -25,7 +25,7 @@
 
 @interface CDVWebViewTest : SenTestCase
 
-@property (nonatomic, strong) UIWebView* webView;
+@property (nonatomic, strong) UIWebView *webView;
 
 - (AppDelegate*)appDelegate;
 - (CDVViewController*)viewController;

--- a/CordovaLibTests/CDVWebViewTest.m
+++ b/CordovaLibTests/CDVWebViewTest.m
@@ -95,7 +95,7 @@
     // Useful when debugging so that it does not timeout after one loop.
     const int kMinIterations = 4;
 
-    NSDate* startTime = [NSDate date];
+    NSDate *startTime = [NSDate date];
     int i = 0;
 
     while (!block()) {

--- a/CordovaLibTests/CDVWhitelistTests.m
+++ b/CordovaLibTests/CDVWhitelistTests.m
@@ -42,11 +42,11 @@
 
 - (void)testAllowedSchemes
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"*.apache.org",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist schemeIsAllowed:@"http"], nil);
     STAssertTrue([whitelist schemeIsAllowed:@"https"], nil);
@@ -57,11 +57,11 @@
 
 - (void)testSubdomainWildcard
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"*.apache.org",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://build.apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://apache.org"]], nil);
@@ -71,11 +71,11 @@
 
 - (void)testCatchallWildcardOnly
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"*",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"https://build.apache.prg"]], nil);
@@ -86,14 +86,14 @@
 
 - (void)testCatchallWildcardByProto
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"http://*",
         @"https://*",
         @"ftp://*",
         @"ftps://*",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"https://build.apache.prg"]], nil);
@@ -104,11 +104,11 @@
 
 - (void)testExactMatch
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"www.apache.org",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://www.apache.org"]], nil);
     STAssertFalse([whitelist URLIsAllowed:[NSURL URLWithString:@"http://build.apache.org"]], nil);
@@ -117,11 +117,11 @@
 
 - (void)testNoMatchInQueryParam
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"www.apache.org",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertFalse([whitelist URLIsAllowed:[NSURL URLWithString:@"www.malicious-site.org?url=http://www.apache.org"]], nil);
     STAssertFalse([whitelist URLIsAllowed:[NSURL URLWithString:@"www.malicious-site.org?url=www.apache.org"]], nil);
@@ -129,12 +129,12 @@
 
 - (void)testIpExactMatch
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"192.168.1.1",
         @"192.168.2.1",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertFalse([whitelist URLIsAllowed:[NSURL URLWithString:@"http://apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://192.168.1.1"]], nil);
@@ -144,12 +144,12 @@
 
 - (void)testIpWildcardMatch
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"192.168.1.*",
         @"192.168.2.*",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertFalse([whitelist URLIsAllowed:[NSURL URLWithString:@"http://apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://192.168.1.1"]], nil);
@@ -161,7 +161,7 @@
 
 - (void)testHostnameExtraction
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"http://apache.org/",
         @"http://apache.org/foo/bar?x=y",
         @"ftp://apache.org/foo/bar?x=y",
@@ -169,7 +169,7 @@
         @"http://apache.*/foo/bar?x=y",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://apache.org/"]], nil);
     STAssertFalse([whitelist URLIsAllowed:[NSURL URLWithString:@"http://google.com/"]], nil);
@@ -177,12 +177,12 @@
 
 - (void)testWhitelistRejectionString
 {
-    NSArray* allowedHosts = [NSArray arrayWithObject:@"http://www.yahoo.com/"];  // Doesn't matter in this test.
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    NSArray *allowedHosts = [NSArray arrayWithObject:@"http://www.yahoo.com/"];  // Doesn't matter in this test.
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
-    NSURL* testUrl = [NSURL URLWithString:@"http://www/google.com"];
-    NSString* errorString = [whitelist errorStringForURL:testUrl];
-    NSString* expectedErrorString = [NSString stringWithFormat:kCDVDefaultWhitelistRejectionString, [testUrl absoluteString]];
+    NSURL *testUrl = [NSURL URLWithString:@"http://www/google.com"];
+    NSString *errorString = [whitelist errorStringForURL:testUrl];
+    NSString *expectedErrorString = [NSString stringWithFormat:kCDVDefaultWhitelistRejectionString, [testUrl absoluteString]];
 
     STAssertTrue([expectedErrorString isEqualToString:errorString], @"Default error string has an unexpected value.");
 
@@ -194,12 +194,12 @@
 
 - (void)testSpecificProtocol
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"http://www.apache.org",
         @"cordova://www.google.com",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://www.apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"cordova://www.google.com"]], nil);
@@ -211,12 +211,12 @@
 {
     // test for https://issues.apache.org/jira/browse/CB-3394
 
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"*",
         @"cordova.apache.org",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://*.apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"https://www.google.com"]], nil);
@@ -227,11 +227,11 @@
 
 - (void)testWildcardPlusScheme
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"http://*.apache.org",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://www.apache.org"]], nil);
     STAssertFalse([whitelist URLIsAllowed:[NSURL URLWithString:@"https://www.google.com"]], nil);
@@ -242,12 +242,12 @@
 
 - (void)testCredentials
 {
-    NSArray* allowedHosts = [NSArray arrayWithObjects:
+    NSArray *allowedHosts = [NSArray arrayWithObjects:
         @"http://*.apache.org",
         @"http://www.google.com",
         nil];
 
-    CDVWhitelist* whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
+    CDVWhitelist *whitelist = [[CDVWhitelist alloc] initWithArray:allowedHosts];
 
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://user:pass@www.apache.org"]], nil);
     STAssertTrue([whitelist URLIsAllowed:[NSURL URLWithString:@"http://user:pass@www.google.com"]], nil);

--- a/CordovaLibTests/CordovaLibApp/AppDelegate.h
+++ b/CordovaLibTests/CordovaLibApp/AppDelegate.h
@@ -23,9 +23,9 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow* window;
+@property (strong, nonatomic) UIWindow *window;
 
-@property (strong, nonatomic) ViewController* viewController;
+@property (strong, nonatomic) ViewController *viewController;
 
 - (void)createViewController;
 - (void)destroyViewController;

--- a/CordovaLibTests/CordovaLibApp/AppDelegate.m
+++ b/CordovaLibTests/CordovaLibApp/AppDelegate.m
@@ -28,7 +28,7 @@
 
 - (id)init
 {
-    NSHTTPCookieStorage* cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
 
     [cookieStorage setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
 

--- a/CordovaLibTests/CordovaLibApp/main.m
+++ b/CordovaLibTests/CordovaLibApp/main.m
@@ -21,7 +21,7 @@
 
 #import "AppDelegate.h"
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
     @autoreleasepool {
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));

--- a/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.h
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.h
@@ -36,7 +36,7 @@
 // a simple tutorial can be found here :
 // http://iphonedevelopertips.com/cocoa/launching-your-own-application-via-a-custom-url-scheme.html
 
-@property (nonatomic, strong) IBOutlet UIWindow* window;
-@property (nonatomic, strong) IBOutlet CDVViewController* viewController;
+@property (nonatomic, strong) IBOutlet UIWindow *window;
+@property (nonatomic, strong) IBOutlet CDVViewController *viewController;
 
 @end

--- a/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.m
@@ -39,16 +39,16 @@
     /** If you need to do any extra app-specific initialization, you can do it here
      *  -jm
      **/
-    NSHTTPCookieStorage* cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
 
     [cookieStorage setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
 
     int cacheSizeMemory = 8 * 1024 * 1024; // 8MB
     int cacheSizeDisk = 32 * 1024 * 1024; // 32MB
 #if __has_feature(objc_arc)
-        NSURLCache* sharedCache = [[NSURLCache alloc] initWithMemoryCapacity:cacheSizeMemory diskCapacity:cacheSizeDisk diskPath:@"nsurlcache"];
+        NSURLCache *sharedCache = [[NSURLCache alloc] initWithMemoryCapacity:cacheSizeMemory diskCapacity:cacheSizeDisk diskPath:@"nsurlcache"];
 #else
-        NSURLCache* sharedCache = [[[NSURLCache alloc] initWithMemoryCapacity:cacheSizeMemory diskCapacity:cacheSizeDisk diskPath:@"nsurlcache"] autorelease];
+        NSURLCache *sharedCache = [[[NSURLCache alloc] initWithMemoryCapacity:cacheSizeMemory diskCapacity:cacheSizeDisk diskPath:@"nsurlcache"] autorelease];
 #endif
     [NSURLCache setSharedURLCache:sharedCache];
 
@@ -100,7 +100,7 @@
     }
 
     // calls into javascript global function 'handleOpenURL'
-    NSString* jsString = [NSString stringWithFormat:@"handleOpenURL(\"%@\");", url];
+    NSString *jsString = [NSString stringWithFormat:@"handleOpenURL(\"%@\");", url];
     [self.viewController.webView stringByEvaluatingJavaScriptFromString:jsString];
 
     // all plugins will get the notification, and their handlers will be called

--- a/bin/templates/project/__PROJECT_NAME__/main.m
+++ b/bin/templates/project/__PROJECT_NAME__/main.m
@@ -26,7 +26,7 @@
 
 #import <UIKit/UIKit.h>
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
     @autoreleasepool {
         int retVal = UIApplicationMain(argc, argv, nil, @"AppDelegate");


### PR DESCRIPTION
In C and Objective-C, the operator `*` is a right-to-left associative operator: 
https://en.wikipedia.org/wiki/Operators_in_C_and_C++#Operator_precedence

Which means it should be next to the right element, not the left element. And easy way to understand the issue:

```
char* a, b;
```

As `*` is a right-to-left associative operator, `*` applies to `a`, not `char` and we have:
- `a` is an array of char
- `b` is a char, not an array of char

To make it easier to apprehend, and to avoid mistakes when we want twice the same type, we should have:

```
char *a, *b;
```

Right-to-left associativity for `*` is the same as the one for `!`. And you don't write:

```
BOOL p =! q;
```

You write:

```
BOOL p = !q;
```
