### PR TITLE
Update CDVWebViewDelegate.m

### DIFF
--- a/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -350,6 +350,7 @@ static NSString *stripFragment(NSString* url)
     if (fireCallback && [_delegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
         [_delegate webViewDidFinishLoad:webView];
     }
+    webView.keyboardDisplayRequiresUserAction = NO;
 }
 
 - (void)webView:(UIWebView*)webView didFailLoadWithError:(NSError*)error


### PR DESCRIPTION
allow for <input> tags to be autofocused with the native HTMLElement.focus method or autofocus attribute on iOS.
