### PR TITLE
Fixed RegEx error when callbackId is nil

### DIFF
--- a/CordovaLib/Classes/CDVCommandDelegateImpl.m
+++ b/CordovaLib/Classes/CDVCommandDelegateImpl.m
@@ -107,6 +107,10 @@
             return NO;
         }
     }
+    //Allow nil callbackId
+    if (callbackId == nil){
+      return YES;
+    }
     // Disallow if too long or if any invalid characters were found.
     if (([callbackId length] > 100) || [_callbackIdPattern firstMatchInString:callbackId options:0 range:NSMakeRange(0, [callbackId length])]) {
         return NO;


### PR DESCRIPTION
Hi, my barebones cordova/ionic app was terminating with the PushPlugin.  I have no idea if this fix is appropriate.  I submitted details of the error here:

https://issues.apache.org/jira/browse/CB-6897
