### PR TITLE
Created strongly typed configuration class

### DIFF
--- a/CordovaLib/Classes/CDVConfiguration.h
+++ b/CordovaLib/Classes/CDVConfiguration.h
@@ -1,0 +1,37 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+@interface CDVConfiguration : NSObject
+
+@property (nonatomic, strong) NSMutableDictionary* settings;
+@property (nonatomic) BOOL bounceAllowed;
+@property (nonatomic) CGFloat gapBetweenPages;
+@property (nonatomic) CGFloat pageLength;
+@property (nonatomic) BOOL enableViewportScale;
+@property (nonatomic) BOOL allowInlineMediaPlayback;
+@property (nonatomic) BOOL mediaPlaybackRequiresUserAction;
+@property (nonatomic) BOOL keyboardDisplayRequiresUserAction;
+@property (nonatomic) BOOL suppressesIncrementalRendering;
+
+- (void)setData:(NSMutableDictionary*)settings;
+
+@end

--- a/CordovaLib/Classes/CDVConfiguration.m
+++ b/CordovaLib/Classes/CDVConfiguration.m
@@ -1,0 +1,79 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "CDVConfiguration.h"
+
+@implementation CDVConfiguration
+
+- (void)setData:(NSMutableDictionary*)settings
+{
+    self.settings = settings;
+    
+    self.enableViewportScale = [self boolSettingForKey:@"EnableViewportScale" withDefault:YES];
+    self.mediaPlaybackRequiresUserAction = [self boolSettingForKey:@"MediaPlaybackRequiresUserAction" withDefault:YES];
+    self.allowInlineMediaPlayback = [self boolSettingForKey:@"AllowInlineMediaPlayback" withDefault:NO];
+    
+    BOOL bouncing = [self boolSettingForKey:@"UIWebViewBounce" withDefault:YES];
+    BOOL disallowOverscroll = [self boolSettingForKey:@"DisallowOverscroll" withDefault:!bouncing];
+    self.bounceAllowed = !disallowOverscroll;
+    
+    self.keyboardDisplayRequiresUserAction = [self boolSettingForKey:@"KeyboardDisplayRequiresUserAction"
+                                                         withDefault:YES];
+    self.suppressesIncrementalRendering = [self boolSettingForKey:@"SuppressesIncrementalRendering"
+                                                     withDefault:NO];
+    
+    self.gapBetweenPages = [self floatSettingForKey:@"GapBetweenPages" withDefault:0.0];
+    self.pageLength = [self floatSettingForKey:@"PageLength" withDefault:0.0];
+}
+
+- (BOOL)boolSettingForKey:(NSString*)key withDefault:(BOOL)value
+{
+    NSNumber* val = (NSNumber*)[self settingForKey:key];
+    if (val == nil) {
+        return value;
+    }
+    
+    return [val boolValue];
+}
+
+- (CGFloat)floatSettingForKey:(NSString*)key withDefault:(CGFloat)value
+{
+    id val = (NSNumber*)[self settingForKey:key];
+    if (val == nil) {
+        return value;
+    }
+    
+#if CGFLOAT_IS_DOUBLE
+    return [val doubleValue];
+#else
+    return [val floatValue];
+#endif
+}
+
+- (id)settingForKey:(NSString*)key
+{
+    return [[self settings] objectForKey:[key lowercaseString]];
+}
+
+- (void)setSetting:(id)setting forKey:(NSString*)key
+{
+    [[self settings] setObject:setting forKey:[key lowercaseString]];
+}
+
+@end

--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		8887FD751090FBE7009987E8 /* CDVInvokedUrlCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 8887FD351090FBE7009987E8 /* CDVInvokedUrlCommand.m */; };
 		8887FD8F1090FBE7009987E8 /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 8887FD501090FBE7009987E8 /* NSData+Base64.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8887FD901090FBE7009987E8 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 8887FD511090FBE7009987E8 /* NSData+Base64.m */; };
+		B726317E196A98A5000B8A89 /* CDVConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = B726317C196A98A5000B8A89 /* CDVConfiguration.h */; };
+		B726317F196A98A5000B8A89 /* CDVConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = B726317D196A98A5000B8A89 /* CDVConfiguration.m */; };
 		EB3B3547161CB44D003DBE7D /* CDVCommandQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = EB3B3545161CB44D003DBE7D /* CDVCommandQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB3B3548161CB44D003DBE7D /* CDVCommandQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = EB3B3546161CB44D003DBE7D /* CDVCommandQueue.m */; };
 		EB3B357C161F2A45003DBE7D /* CDVCommandDelegateImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = EB3B357A161F2A44003DBE7D /* CDVCommandDelegateImpl.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -103,6 +105,8 @@
 		8887FD501090FBE7009987E8 /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+Base64.h"; path = "Classes/NSData+Base64.h"; sourceTree = "<group>"; };
 		8887FD511090FBE7009987E8 /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Base64.m"; path = "Classes/NSData+Base64.m"; sourceTree = "<group>"; };
 		AA747D9E0F9514B9006C5449 /* CordovaLib_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CordovaLib_Prefix.pch; sourceTree = SOURCE_ROOT; };
+		B726317C196A98A5000B8A89 /* CDVConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDVConfiguration.h; path = Classes/CDVConfiguration.h; sourceTree = "<group>"; };
+		B726317D196A98A5000B8A89 /* CDVConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDVConfiguration.m; path = Classes/CDVConfiguration.m; sourceTree = "<group>"; };
 		EB3B3545161CB44D003DBE7D /* CDVCommandQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDVCommandQueue.h; path = Classes/CDVCommandQueue.h; sourceTree = "<group>"; };
 		EB3B3546161CB44D003DBE7D /* CDVCommandQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDVCommandQueue.m; path = Classes/CDVCommandQueue.m; sourceTree = "<group>"; };
 		EB3B357A161F2A44003DBE7D /* CDVCommandDelegateImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDVCommandDelegateImpl.h; path = Classes/CDVCommandDelegateImpl.h; sourceTree = "<group>"; };
@@ -170,6 +174,8 @@
 		3054098714B77FF3009841CA /* Cleaver */ = {
 			isa = PBXGroup;
 			children = (
+				B726317C196A98A5000B8A89 /* CDVConfiguration.h */,
+				B726317D196A98A5000B8A89 /* CDVConfiguration.m */,
 				F858FBC4166009A8007DA594 /* CDVConfigParser.h */,
 				F858FBC5166009A8007DA594 /* CDVConfigParser.m */,
 				8852C43614B65FD800F0E735 /* CDVViewController.h */,
@@ -271,6 +277,7 @@
 				30F5EBAB14CA26E700987760 /* CDVCommandDelegate.h in Headers */,
 				301F2F2A14F3C9CA003FE9FC /* CDV.h in Headers */,
 				30392E4E14F4FCAB00B9E0B8 /* CDVAvailability.h in Headers */,
+				B726317E196A98A5000B8A89 /* CDVConfiguration.h in Headers */,
 				3034979C1513D56A0090E688 /* CDVLocalStorage.h in Headers */,
 				3062D120151D0EDB000D9128 /* UIDevice+Extensions.h in Headers */,
 				EBA3557315ABD38C00F4DE24 /* NSArray+Comparisons.h in Headers */,
@@ -352,6 +359,7 @@
 				3034979E1513D56A0090E688 /* CDVLocalStorage.m in Sources */,
 				3062D122151D0EDB000D9128 /* UIDevice+Extensions.m in Sources */,
 				EBA3557515ABD38C00F4DE24 /* NSArray+Comparisons.m in Sources */,
+				B726317F196A98A5000B8A89 /* CDVConfiguration.m in Sources */,
 				EB3B3548161CB44D003DBE7D /* CDVCommandQueue.m in Sources */,
 				EB3B357D161F2A45003DBE7D /* CDVCommandDelegateImpl.m in Sources */,
 				F858FBC7166009A8007DA594 /* CDVConfigParser.m in Sources */,


### PR DESCRIPTION
Created strongly typed configuration for the following purposes:
- Remove configuration parsing logic and defaults handling from the
CDVViewController.m
- Improved testability of the Cordova configuration and other parts of
code which related on configuration could be much clearly mocked.
- Reduction for code duplication during configuration parsing.
- Ability to verify configuration issues during parsing, For example
passing not a number to the value which expected to be a number should
result to warning, so application developer could easily find error on
their side.
- Single place for storing configuration defaults.

Drawbacks in current implementation
- Not sure about memory leaks during such approach. Not very familiar
with iOS. This is need review
- No tests so far, could be added later if whole idea get traction.
- Currently no support for settings with limited set of values allowed.
Like «PaginationMode». Again could be added if whole idea would be
supported.