### PR TITLE
Fix build warnings

### DIFF
--- a/CordovaLib/Classes/CDVURLProtocol.m
+++ b/CordovaLib/Classes/CDVURLProtocol.m
@@ -166,8 +166,8 @@ static CDVViewController *viewControllerForRequest(NSURLRequest* request)
                 // We have the asset!  Get the data and send it along.
                 ALAssetRepresentation* assetRepresentation = [asset defaultRepresentation];
                 NSString* MIMEType = (__bridge_transfer NSString*)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)[assetRepresentation UTI], kUTTagClassMIMEType);
-                Byte* buffer = (Byte*)malloc([assetRepresentation size]);
-                NSUInteger bufferSize = [assetRepresentation getBytes:buffer fromOffset:0.0 length:[assetRepresentation size] error:nil];
+                Byte* buffer = (Byte*)malloc((unsigned long)[assetRepresentation size]);
+                NSUInteger bufferSize = [assetRepresentation getBytes:buffer fromOffset:0.0 length:(NSUInteger)[assetRepresentation size] error:nil];
                 NSData* data = [NSData dataWithBytesNoCopy:buffer length:bufferSize freeWhenDone:YES];
                 [self sendResponseWithResponseCode:200 data:data mimeType:MIMEType];
             } else {


### PR DESCRIPTION
- CordovaLib/Classes/CDVURLProtocol.m:169: Implicit conversion loses integer precision: 'long long' to 'unsigned long'
- CordovaLib/Classes/CDVURLProtocol.m:170: Implicit conversion loses integer precision: 'long long' to 'NSUInteger' (aka 'unsigned int')
