### PR TITLE
Fix __PROJECT_NAME__ replacing code

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -126,14 +126,15 @@ mv "$R/gitignore" "$R/.gitignore"
 # - ./__PROJECT_NAME__/Resources/__PROJECT_NAME__-info.plist
 # - ./__PROJECT_NAME__/Resources/__PROJECT_NAME__-Prefix.plist
 
-"$BINDIR/replaces" "$R.xcodeproj/project.pbxproj" __PROJECT_NAME__ "$PROJECT_NAME"
-"$BINDIR/replaces" "$R/Classes/AppDelegate.h"     __PROJECT_NAME__ "$PROJECT_NAME"
-"$BINDIR/replaces" "$R/Classes/AppDelegate.m"     __PROJECT_NAME__ "$PROJECT_NAME"
-"$BINDIR/replaces" "$R/Classes/MainViewController.h" __PROJECT_NAME__ "$PROJECT_NAME"
-"$BINDIR/replaces" "$R/Classes/MainViewController.m" __PROJECT_NAME__ "$PROJECT_NAME"
-"$BINDIR/replaces" "$R/main.m"                    __PROJECT_NAME__ "$PROJECT_NAME"
-"$BINDIR/replaces" "$R/$PROJECT_NAME-Info.plist"  __PROJECT_NAME__ "$PROJECT_NAME"
-"$BINDIR/replaces" "$R/$PROJECT_NAME-Prefix.pch"  __PROJECT_NAME__ "$PROJECT_NAME"
+PROJECT_NAME_ESC="${PROJECT_NAME//&/\\&}"
+"$BINDIR/replaces" "$R.xcodeproj/project.pbxproj" __PROJECT_NAME__ "$PROJECT_NAME_ESC"
+"$BINDIR/replaces" "$R/Classes/AppDelegate.h"     __PROJECT_NAME__ "$PROJECT_NAME_ESC"
+"$BINDIR/replaces" "$R/Classes/AppDelegate.m"     __PROJECT_NAME__ "$PROJECT_NAME_ESC"
+"$BINDIR/replaces" "$R/Classes/MainViewController.h" __PROJECT_NAME__ "$PROJECT_NAME_ESC"
+"$BINDIR/replaces" "$R/Classes/MainViewController.m" __PROJECT_NAME__ "$PROJECT_NAME_ESC"
+"$BINDIR/replaces" "$R/main.m"                    __PROJECT_NAME__ "$PROJECT_NAME_ESC"
+"$BINDIR/replaces" "$R/$PROJECT_NAME-Info.plist"  __PROJECT_NAME__ "$PROJECT_NAME_ESC"
+"$BINDIR/replaces" "$R/$PROJECT_NAME-Prefix.pch"  __PROJECT_NAME__ "$PROJECT_NAME_ESC"
 
 "$BINDIR/replaces" "$R/$PROJECT_NAME-Info.plist" --ID-- $PACKAGE
 


### PR DESCRIPTION
`&` is a special character for `sed` and this fixes the problem of having `__PROJECT_NAME__` in the final output when the project name contains an ampersand, this is not only a cosmetic issue but also leads to compilation errors:

```
xcodebuild: error: The project 'A&B.xcodeproj' does not contain a target named 'A&B'.
{ [Error: /Users/lapo/projDir/platforms/ios/cordova/build: Command failed with exit code 65] code: 65 }
   [error] /Users/lapo/projDir/platforms/ios/cordova/build: Command failed with exit code 65
```
