### PR TITLE
CB-7493 Adds test-build command to package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: objective-c
+install: npm install
+script: "npm test"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
         "cordova",
         "apache"
     ],
+    "scripts": {
+        "test": "rm -rf \"testcreate 応用\"; ./bin/create \"testcreate 応用\" com.test.app 応用 && \"./testcreate 応用/cordova/build\" && rm -rf \"testcreate 応用\""
+    },
     "author": "Apache Software Foundation",
     "license": "Apache Version 2.0",
     "dependencies": {


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CB-7493

\+ bonus - travis configuration file.
Succesful build log: https://travis-ci.org/vladimir-kotikov/cordova-ios
