### PR TITLE
Fixed the CDV_IsIPhone5() macro for iOS8 landscape

### DIFF
--- a/CordovaLib/Classes/CDVAvailability.h
+++ b/CordovaLib/Classes/CDVAvailability.h
@@ -75,7 +75,7 @@
 
 #define CDV_IsIPad() ([[UIDevice currentDevice] respondsToSelector:@selector(userInterfaceIdiom)] && ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad))
 
-#define CDV_IsIPhone5() ([[UIScreen mainScreen] bounds].size.height == 568 && [[UIScreen mainScreen] bounds].size.width == 320)
+#define CDV_IsIPhone5() (([[UIScreen mainScreen] bounds].size.width == 568 && [[UIScreen mainScreen] bounds].size.height == 320) || ([[UIScreen mainScreen] bounds].size.height == 568 && [[UIScreen mainScreen] bounds].size.width == 320))
 
 /* Return the string version of the decimal version */
 #define CDV_VERSION [NSString stringWithFormat:@"%d.%d.%d", \


### PR DESCRIPTION
iOS8 introduces a change to screen orientation, making [UIScreen bounds] orientation-dependent. As a result, testing if the screen resolution matches the iPhone5, as this macro does, now needs to account for landscape (568x320) in addition to portrait (320x568).

Details at http://stackoverflow.com/questions/24150359/is-uiscreen-mainscreen-bounds-size-becoming-orientation-dependent-in-ios8
