### PR TITLE
Remove duplicate reference to the same libCordova.a.

### DIFF
--- a/bin/templates/project/__CLI__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__CLI__.xcodeproj/project.pbxproj
@@ -486,8 +486,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				PRODUCT_NAME = "__PROJECT_NAME__";
@@ -517,8 +515,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				PRODUCT_NAME = "__PROJECT_NAME__";
@@ -562,8 +558,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				SDKROOT = iphoneos;
@@ -607,8 +601,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				SDKROOT = iphoneos;

--- a/bin/templates/project/__NON-CLI__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__NON-CLI__.xcodeproj/project.pbxproj
@@ -472,8 +472,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				PRODUCT_NAME = "__PROJECT_NAME__";
@@ -503,8 +501,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				PRODUCT_NAME = "__PROJECT_NAME__";
@@ -548,8 +544,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				SDKROOT = iphoneos;
@@ -593,8 +587,6 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libCordova.a\"",
 					"-ObjC",
 				);
 				SDKROOT = iphoneos;


### PR DESCRIPTION
libCordova.a has already been referred to as a framework, no need to
force_load it again.

Normally it is OK to refer to libCordova.a twice, as they are the same
file anyway. But when symbolic link is used in workspace and Jenkins is
use to do the build, there will be a problem because Jenkins will
dereference symbolic links (https://issues.jenkins-ci.org/browse/JENKINS-5597)
and now we could have 2 copies of libCordova.a, and have countless
duplicate symbols errors.
