### PR TITLE
CDVWebViewDelegate fails to update the webview state properly in iOS

### DIFF
--- a/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -378,7 +378,11 @@ static NSString *stripFragment(NSString* url)
             break;
 
         case STATE_WAITING_FOR_LOAD_START:
-            _state = STATE_IDLE;
+            if ([error code] == NSURLErrorCancelled) {
+                _state = STATE_CANCELLED;
+            } else {
+                _state = STATE_IDLE;
+            }
             fireCallback = YES;
             break;
 


### PR DESCRIPTION
CDVWebViewDelegate fails to update the webview state properly in iOS when a page loads an iframe using javascript and does a redirect to another page using javascript. Method didFailLoadWithError gets called while in STATE_WAITING_FOR_LOAD_START with a NSURLErrorCancelled (-999) error. Instead of entering STATE_CANCELLED in this situation it always enters STATE_IDLE, which causes didFailLoadWithError event to never fire (which depending on the app, and definitely in our case, can cause a hang condition).

For a simplified Cordova project that reproduces the problem in the most straigth forward way possible, please refer to: https://github.com/greatvines/cordova-webview-state-bug-www
