### PR TITLE
CB-6637 - Removed - request:isFragmentIdentifierToRequest: deprecated method in CDVWebViewDelegate

### DIFF
--- a/CordovaLib/Classes/CDVWebViewDelegate.h
+++ b/CordovaLib/Classes/CDVWebViewDelegate.h
@@ -35,7 +35,6 @@
 }
 
 - (id)initWithDelegate:(NSObject <UIWebViewDelegate>*)delegate;
-- (BOOL)request:(NSURLRequest*)newRequest isFragmentIdentifierToRequest:(NSURLRequest*)originalRequest CDV_DEPRECATED(3.5, "Use request:isEqualToRequestAfterStrippingFragments: instead.");
 
 - (BOOL)request:(NSURLRequest*)newRequest isEqualToRequestAfterStrippingFragments:(NSURLRequest*)originalRequest;
 

--- a/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -114,11 +114,6 @@ static NSString *stripFragment(NSString* url)
     return self;
 }
 
-- (BOOL)request:(NSURLRequest*)newRequest isFragmentIdentifierToRequest:(NSURLRequest*)originalRequest
-{
-    return [self request:newRequest isEqualToRequestAfterStrippingFragments:originalRequest];
-}
-
 - (BOOL)request:(NSURLRequest*)newRequest isEqualToRequestAfterStrippingFragments:(NSURLRequest*)originalRequest
 {
     if (originalRequest.URL && newRequest.URL) {


### PR DESCRIPTION
Hello,

I know this is a small contribution but I wanted to help and so fixed this bug:
https://issues.apache.org/jira/browse/CB-6637

I just went through the steps here:
http://wiki.apache.org/cordova/ContributorWorkflow
But was not able to assign the issue in JIRA to myself.

Please let me know if I did something incorrectly, if yes - will do better next time. I hope to be more active in Cordova/iOS projects so this is a first step for me.

Best regards,
Ivan Karpan
