### PR TITLE
CB-8084 conform AppDelegate.m with provisioning profile

### DIFF
--- a/bin/templates/project/__CLI__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__CLI__.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 
 /* Begin PBXFileReference section */
 		1D3623240D0F684500981E51 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		1D3623240D0F684500981E99 /* PushNotificationsEnabled.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushNotificationsEnabled.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		1D6058910D05DD3D006BFB54 /* __PROJECT_NAME__.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "__PROJECT_NAME__.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F766FDD13BBADB100FB74C0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
@@ -125,6 +126,7 @@
 				302D95EF14D2391D003F00A1 /* MainViewController.m */,
 				302D95F014D2391D003F00A1 /* MainViewController.xib */,
 				1D3623240D0F684500981E51 /* AppDelegate.h */,
+				1D3623240D0F684500981E99 /* PushNotificationsEnabled.h */,
 				1D3623250D0F684500981E51 /* AppDelegate.m */,
 			);
 			name = Classes;
@@ -291,6 +293,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "__PROJECT_NAME__" */;
 			buildPhases = (
+				D83631551A790FDE00797B39 /* Push Notifications */,
 				304B58A110DAC018002A0835 /* Copy www directory */,
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
@@ -388,6 +391,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		D83631551A790FDE00797B39 /* Push Notifications */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Push Notifications";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "node cordova/lib/push-notifications.js";
+			showEnvVarsInLog = 0;
+		};
 		304B58A110DAC018002A0835 /* Copy www directory */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/bin/templates/project/__NON-CLI__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__NON-CLI__.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 
 /* Begin PBXFileReference section */
 		1D3623240D0F684500981E51 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		1D3623240D0F684500981E99 /* PushNotificationsEnabled.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushNotificationsEnabled.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		1D6058910D05DD3D006BFB54 /* __PROJECT_NAME__.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "__PROJECT_NAME__.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F766FDD13BBADB100FB74C0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
@@ -122,6 +123,7 @@
 				302D95EF14D2391D003F00A1 /* MainViewController.m */,
 				302D95F014D2391D003F00A1 /* MainViewController.xib */,
 				1D3623240D0F684500981E51 /* AppDelegate.h */,
+				1D3623240D0F684500981E99 /* PushNotificationsEnabled.h */,
 				1D3623250D0F684500981E51 /* AppDelegate.m */,
 			);
 			name = Classes;
@@ -277,6 +279,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "__PROJECT_NAME__" */;
 			buildPhases = (
+				D83631551A790FDE00797B39 /* Push Notifications */,
 				304B58A110DAC018002A0835 /* Copy www directory */,
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
@@ -374,6 +377,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		D83631551A790FDE00797B39 /* Push Notifications */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Push Notifications";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "node cordova/lib/push-notifications.js";
+			showEnvVarsInLog = 0;
+		};
 		304B58A110DAC018002A0835 /* Copy www directory */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.m
@@ -26,6 +26,7 @@
 //
 
 #import "AppDelegate.h"
+#import "PushNotificationsEnabled.h"
 #import "MainViewController.h"
 
 #import <Cordova/CDVPlugin.h>
@@ -117,6 +118,8 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:CDVLocalNotification object:notification];
 }
 
+#if PUSH_NOTIFICATIONS_ENABLED
+
 - (void)                                application:(UIApplication *)application
    didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
@@ -135,6 +138,8 @@
     // re-post ( broadcast )
     [[NSNotificationCenter defaultCenter] postNotificationName:CDVRemoteNotificationError object:error];
 }
+
+#endif
 
 - (NSUInteger)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window
 {

--- a/bin/templates/project/__PROJECT_NAME__/Classes/PushNotificationsEnabled.h
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/PushNotificationsEnabled.h
@@ -1,0 +1,1 @@
+#define PUSH_NOTIFICATIONS_ENABLED true

--- a/bin/templates/scripts/cordova/lib/push-notifications.js
+++ b/bin/templates/scripts/cordova/lib/push-notifications.js
@@ -1,0 +1,85 @@
+(function () {
+    var fs = require('fs'),
+        path = require('path'),
+        exec = require('child_process').exec,
+        PUSH_NOTIFICATIONS_ENABLED_HEADER_FILE = 'PushNotificationsEnabled.h',
+        PUSH_NOTIFICATIONS_ENABLED_HEADER_FILE_CONTENT = '#define PUSH_NOTIFICATIONS_ENABLED ',
+        EXPANDED_PROVISIONING_PROFILE = process.env.EXPANDED_PROVISIONING_PROFILE,
+        PATH_TO_MOBILE_PROVISIONS = path.join(process.env.HOME, 'Library', 'MobileDevice', 'Provisioning Profiles'),
+        PROVISIONING_PROFILE_REQUIRED = process.env.PROVISIONING_PROFILE_REQUIRED,
+        PROVISIONING_PROFILE_UUID_REGEX = new RegExp('<key>UUID<\/key>[\\s\\S]*<string>' + EXPANDED_PROVISIONING_PROFILE + '<\/string>');
+
+    function logErrorIfExists(error) {
+        if (error !== null) {
+            console.error('exec error: ' + error);
+        }
+    }
+
+    function sanitizeMobileProvision(mobileProvision) {
+        if (mobileProvision.indexOf('.mobileprovision') === -1) {
+            mobileProvision += '.mobileprovision';
+        }
+
+        return mobileProvision;
+    }
+
+    function createPushNotificationsEnabledHeaderFile(pushPluginsEnabled) {
+        var cordovaEnablePluginHeaderFileLocation = path.join(__dirname, '..', '..', process.env.PROJECT_NAME, 'Classes', PUSH_NOTIFICATIONS_ENABLED_HEADER_FILE);
+        fs.writeFileSync(cordovaEnablePluginHeaderFileLocation, PUSH_NOTIFICATIONS_ENABLED_HEADER_FILE_CONTENT + pushPluginsEnabled);
+    }
+
+    function createPushNotificationsEnabledHeaderFileWithMobileProvision(mobileProvision) {
+        var pathToProvisioningProfile = path.join(PATH_TO_MOBILE_PROVISIONS, sanitizeMobileProvision(mobileProvision));
+
+        exec("security cms -D -i \"" + pathToProvisioningProfile + "\"", function (error, stdout, stderr) {
+            logErrorIfExists(error);
+            var pushPluginsEnabled = stdout.indexOf("<key>aps-environment</key>") > -1;
+            createPushNotificationsEnabledHeaderFile(pushPluginsEnabled);
+        });
+    }
+
+    function isprovisionUUIDSuitable(provisionContents) {
+        return PROVISIONING_PROFILE_UUID_REGEX.test(provisionContents);
+    }
+
+    function findValidMobileProvision(provisions) {
+        if (provisions.length === 0) {
+            console.warn('WARNING: No suitable mobile provision found!');
+            return null;
+        }
+
+        var currentMobileProvision = provisions[0];
+        var currentMobileProvisionPath = path.join(PATH_TO_MOBILE_PROVISIONS, currentMobileProvision);
+
+        exec("security cms -D -i \"" + currentMobileProvisionPath + "\"", function (error, stdout, stderr) {
+            logErrorIfExists(error);
+            if (isprovisionUUIDSuitable(stdout)) {
+                createPushNotificationsEnabledHeaderFileWithMobileProvision(currentMobileProvision);
+                return;
+            }
+            provisions.splice(provisions.indexOf(currentMobileProvision), 1);
+            findValidMobileProvision(provisions);
+        });
+    }
+
+    function getMobileProvisions() {
+        return fs.readdirSync(PATH_TO_MOBILE_PROVISIONS);
+    }
+
+    if (PROVISIONING_PROFILE_REQUIRED) {
+        var mobileProvisions = getMobileProvisions();
+        if (mobileProvisions.length === 0) {
+            console.warn('WARNING: No mobile provisions found!');
+            return this;
+        }
+
+        if (mobileProvisions.indexOf(sanitizeMobileProvision(EXPANDED_PROVISIONING_PROFILE)) !== -1) {
+            createPushNotificationsEnabledHeaderFileWithMobileProvision(EXPANDED_PROVISIONING_PROFILE);
+            return this;
+        }
+
+        findValidMobileProvision(mobileProvisions);
+    } else {
+        createPushNotificationsEnabledHeaderFile(true);
+    }
+}());


### PR DESCRIPTION
Hide the two methods in AppDelegate.m for push notifications
when provisioning profile doesn't include the push notifications service
Related to https://issues.apache.org/jira/browse/CB-8084