### PR TITLE
Fix Q include in check_reqs.js

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -22,7 +22,7 @@
           sub:true, laxcomma:true, laxbreak:true
 */
 
-var Q     = require('Q'),
+var Q     = require('q'),
     os    = require('os'),
     shell = require('shelljs'),
     versions = require('./versions');


### PR DESCRIPTION
The npm package is q (lowercase) but was being required as Q (uppercase). For most people this probably works fine due to case insensitive filesystems, but if your Mac is configured to be case-sensitive or you're on Linux, this script would generate an error and prevent building.