### PR TITLE
[CB-8785] add try/catch for evalJS:

### DIFF
--- a/CordovaLib/Classes/CDVCommandDelegateImpl.m
+++ b/CordovaLib/Classes/CDVCommandDelegateImpl.m
@@ -143,7 +143,7 @@
 
 - (void)evalJs:(NSString*)js scheduledOnRunLoop:(BOOL)scheduledOnRunLoop
 {
-    js = [NSString stringWithFormat:@"cordova.require('cordova/exec').nativeEvalAndFetch(function(){%@})", js];
+    js = [NSString stringWithFormat:@"try{cordova.require('cordova/exec').nativeEvalAndFetch(function(){%@})}catch(e){console.log('exeption nativeEvalAndFetch : '+e);};", js];
     if (scheduledOnRunLoop) {
         [self evalJsHelper:js];
     } else {


### PR DESCRIPTION
evalJS's javascript starts with cordova.require. 
If there's no cordova object? Show's big alert view. So add try/catch for evalJS: