### PR TITLE
[CB-8838]Moved commandQueue push into non-WK_WEBVIEW_BINDING branch.

### DIFF
--- a/CordovaLib/cordova.js
+++ b/CordovaLib/cordova.js
@@ -970,14 +970,14 @@ function iOSExec() {
 
     var command = [callbackId, service, action, actionArgs];
 
-    // Stringify and queue the command. We stringify to command now to
-    // effectively clone the command arguments in case they are mutated before
-    // the command is executed.
-    commandQueue.push(JSON.stringify(command));
-    
     if (bridgeMode === jsToNativeModes.WK_WEBVIEW_BINDING) {
         window.webkit.messageHandlers.cordova.postMessage(command);
     } else {
+        // Stringify and queue the command. We stringify to command now to
+        // effectively clone the command arguments in case they are mutated before
+        // the command is executed.
+        commandQueue.push(JSON.stringify(command));
+
         // If we're in the context of a stringByEvaluatingJavaScriptFromString call,
         // then the queue will be flushed when it returns; no need for a poke.
         // Also, if there is already a command in the queue, then we've already

--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -171,14 +171,14 @@ function iOSExec() {
 
     var command = [callbackId, service, action, actionArgs];
 
-    // Stringify and queue the command. We stringify to command now to
-    // effectively clone the command arguments in case they are mutated before
-    // the command is executed.
-    commandQueue.push(JSON.stringify(command));
-    
     if (bridgeMode === jsToNativeModes.WK_WEBVIEW_BINDING) {
         window.webkit.messageHandlers.cordova.postMessage(command);
     } else {
+        // Stringify and queue the command. We stringify to command now to
+        // effectively clone the command arguments in case they are mutated before
+        // the command is executed.
+        commandQueue.push(JSON.stringify(command));
+    
         // If we're in the context of a stringByEvaluatingJavaScriptFromString call,
         // then the queue will be flushed when it returns; no need for a poke.
         // Also, if there is already a command in the queue, then we've already


### PR DESCRIPTION
Hi Shazron (et al.)
I am working on an html5 video game that is packaged for ios using cordova.
We were having memory issues with UIWebView and have integrated your work on WKWebView recently.
Its working great for the performance! thanks! but, we are of course feeling alpha growing pains.

One thing we have noticed is that when we invoke the cordova Barcode plugin, it is always called twice!

I have only looked at the code a short time, but it appears to me that:
* the first call to Barcode happens, and in iosExec, it gets placed in commandQueue.
* the first call passes to Objective C world by WKScriptMessageHandler - (void)userContentController:(WKUserContentController*)userContentController didReceiveScriptMessage:(WKScriptMessage*)message
* this call to Barcode does its thing, completes, and it's javascript response handler code winds through:
    CDVCommandDelegateImpl::sendPluginResult
    CDVCommandDelegateImpl::evalJSHelper
    CDVCommandDelegateImpl::evalJSHelper2
* in Helper2, the callback is finally passed to a webViewEngine, which processes the Javascript, and returns, on completion, a list of commands remaining in the javascript commandQueue.
* these commands are queued on the Obj-C side and run in CDVCommandQueue fashion.

AHA!

* since the command was persisted in commandQueue before execution, and not removed, it is called again!

SO

I moved the enqueue behavior into the branch that excludes bridgeMode === jsToNativeModes.WK_WEBVIEW_BINDING
This fixes it, but I am not confident its the right solution.

Do you have any insight into this problem?
Feedback for my solution?
A broader or more appropriate venue for the conversation?

Thanks!
Alex Mouton