### PR TITLE
CB-8485 Support for creating signed archive for iOS

### DIFF
--- a/bin/templates/scripts/cordova/build-extras.xcconfig
+++ b/bin/templates/scripts/cordova/build-extras.xcconfig
@@ -18,8 +18,5 @@
 //
 
 //
-// XCode Build settings for "Debug" Build Configuration.
+// Auto-generated config file to override configuration files (build-release/build-debug).
 //
-
-#include "build.xcconfig"
-#include "build-extras.xcconfig"

--- a/bin/templates/scripts/cordova/build-release.xcconfig
+++ b/bin/templates/scripts/cordova/build-release.xcconfig
@@ -25,3 +25,5 @@
 
 CODE_SIGN_IDENTITY = iPhone Distribution
 CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Distribution
+
+#include "build-extras.xcconfig"


### PR DESCRIPTION
Allows the user to specify the provisioning profile and the signing identity using the command line and a build.json file.