### PR TITLE
[CB-8948] Clipboard fix for iOS safari copy

### DIFF
--- a/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/Classes/CDVViewController.m
@@ -980,6 +980,13 @@
 {
     // NSLog(@"%@",@"applicationWillEnterForeground");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resume');"];
+    
+    /** Clipboard fix **/
+    UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+    NSString *string = pasteboard.string;
+    if (string) {
+        [pasteboard setValue:string forPasteboardType:@"public.text"];
+    } 
 }
 
 // This method is called to let your application know that it moved from the inactive to active state.


### PR DESCRIPTION
Using the iOS helper copy widget, its not possible to paste into any HTML5 inputs. A possible workaround is to grab from the clipboard and re-copy when the app resumes. 
