### PR TITLE
CB-9013: Fix listing of multiple devices in list-devices for iOS

### DIFF
--- a/bin/templates/scripts/cordova/lib/list-devices
+++ b/bin/templates/scripts/cordova/lib/list-devices
@@ -42,9 +42,13 @@ function listDevices() {
           var devicefound;
           // Each command promise resolves with array [stout, stderr], and we need stdout only
           // Append stdout lines to accumulator
-          devicefound = result[0].trim().split('\n')[0];
-          if(devicefound !== ''){
-            accumulator.push(devicefound);
+          devicefound = result[0].trim().split('\n');
+          if(devicefound && devicefound.length) {
+            devicefound.forEach(function(device) {
+              if (device) {
+                accumulator.push(device);
+              }
+            });
           }
         });
         return accumulator;


### PR DESCRIPTION
when multiple of same type devices are connected, like two iPhones,
only the first was returned.

Now all connected devices will be returned.

Note it might be even better if there was a way to get the devices
names as descriptions because now they are all called ‘iPhone’