### PR TITLE
Change _state after creating logging string

### DIFF
--- a/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -251,10 +251,10 @@ static NSString *stripFragment(NSString* url)
 
                 default:
                     {
-                        _loadCount = 0;
-                        _state = STATE_WAITING_FOR_LOAD_START;
                         NSString* description = [NSString stringWithFormat:@"CDVWebViewDelegate: Navigation started when state=%ld", (long)_state];
                         NSLog(@"%@", description);
+                        _loadCount = 0;
+                        _state = STATE_WAITING_FOR_LOAD_START;
                         if ([_delegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
                             NSDictionary* errorDictionary = @{NSLocalizedDescriptionKey : description};
                             NSError* error = [[NSError alloc] initWithDomain:@"CDVWebViewDelegate" code:1 userInfo:errorDictionary];


### PR DESCRIPTION
Currently, the code sets `_state` immediately before creating the string to log, so it will always print "CDVWebViewDelegate: Navigation started when state=1". This change just moves setting `_state` to after the log statement.