### PR TITLE
CB-9558 Blob schemes won't load in iframes

### DIFF
--- a/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -197,7 +197,7 @@ static NSString *stripFragment(NSString* url)
 {
     NSString* scheme = [[request URL] scheme];
 
-    if ([scheme isEqualToString:@"mailto"] || [scheme isEqualToString:@"tel"] || [scheme isEqualToString:@"sms"]) {
+    if ([scheme isEqualToString:@"mailto"] || [scheme isEqualToString:@"tel"] || [scheme isEqualToString:@"sms"] || [scheme isEqualToString:@"blob"]) {
         return YES;
     }
 


### PR DESCRIPTION
Blob schemes won't load in iframes, even though blob:* is whitelisted.
This is needed for special cases, like when using an epub reader ([ePub.js](https://github.com/futurepress/epub.js/)), that downloads an epub, extracts it to a blob and displays it in an iframe.
This currently works perfectly in cordova-android, but not in cordova-ios.
I've debugged why it happens... the Whitelists says the scheme is allowed and the URL is allowed, but then
```Objective-C
[NSURLConnection canHandleRequest]
```
returns false, thus cancelling the request. Hardcoding "blob" as an allowed scheme (like it's currently done with mailto, tel and sms) fixes this issue.