### PR TITLE
CB-9610 Prevent Compilation Warning : Conflicting Return Type

### DIFF
--- a/CordovaLib/Classes/Public/CDVAppDelegate.m
+++ b/CordovaLib/Classes/Public/CDVAppDelegate.m
@@ -85,7 +85,7 @@
     return YES;
 }
 
-- (NSUInteger)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window
+- (UIInterfaceOrientationMask)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window
 {
     // iPhone doesn't support upside down by default, while the iPad does.  Override to allow all orientations always, and let the root view controller decide what's allowed (the supported orientations mask gets intersected).
     NSUInteger supportedInterfaceOrientations = (1 << UIInterfaceOrientationPortrait) | (1 << UIInterfaceOrientationLandscapeLeft) | (1 << UIInterfaceOrientationLandscapeRight) | (1 << UIInterfaceOrientationPortraitUpsideDown);


### PR DESCRIPTION
The `supportedInterfaceOrientationsForWindow` method currently returns a value of type `NSUInteger`. This causes a warning in the Xcode console: 
> Conflicting return type in implementation of 'application:supportedInterfaceOrientationsForWindow:': 'UIInterfaceOrientationMask' (aka 'enum UIInterfaceOrientationMask') vs 'NSUInteger' (aka 'unsigned long')

This change updates the return type to be `UIInterfaceOrientationMask` rather than `NSUInteger` to avoid the warning