### PR TITLE
CB-8772 ios bin scripts are nonexecutable on Windows

### DIFF
--- a/bin/templates/scripts/cordova/build.bat
+++ b/bin/templates/scripts/cordova/build.bat
@@ -16,4 +16,4 @@
 :: under the License
 
 @ECHO OFF
-ECHO WARN: The 'clean' command is not available for cordova-ios on windows machines.>&2
+ECHO WARN: The 'build' command is not available for cordova-ios on windows machines.>&2

--- a/bin/templates/scripts/cordova/log.bat
+++ b/bin/templates/scripts/cordova/log.bat
@@ -16,4 +16,4 @@
 :: under the License
 
 @ECHO OFF
-ECHO WARN: The 'clean' command is not available for cordova-ios on windows machines.>&2
+ECHO WARN: The 'log' command is not available for cordova-ios on windows machines.>&2

--- a/bin/templates/scripts/cordova/run.bat
+++ b/bin/templates/scripts/cordova/run.bat
@@ -14,12 +14,6 @@
 :: KIND, either express or implied.  See the License for the
 :: specific language governing permissions and limitations
 :: under the License
+
 @ECHO OFF
-SET script_path="%~dp0run"
-IF EXIST %script_path% (
-        node %script_path% %*
-) ELSE (
-    ECHO.
-    ECHO ERROR: Could not find 'run' script in 'cordova' folder, aborting...>&2
-    EXIT /B 1
-)
+ECHO WARN: The `run` is not available for cordova-ios on windows machines.>&2


### PR DESCRIPTION
Just output a warning for ios project scripts on windows