### PR TITLE
CB-9685 A fix for the magnifying glass popping up on iOS9 longpress

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.h
@@ -1,0 +1,26 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "CDVPlugin.h"
+
+@interface CDVGestureHandler : CDVPlugin
+
+@property (nonatomic, strong) UILongPressGestureRecognizer* lpgr;
+
+@end

--- a/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
@@ -1,0 +1,60 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "CDVGestureHandler.h"
+
+@implementation CDVGestureHandler
+
+- (void)pluginInitialize
+{
+    [self applyLongPressFix];
+}
+
+- (void)applyLongPressFix
+{
+    self.lpgr = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGestures:)];
+    self.lpgr.minimumPressDuration = 0.45f;
+    self.lpgr.allowableMovement = 100.0f;
+
+    NSArray *views = self.webView.subviews;
+    if (views.count == 0) {
+        NSLog(@"No webview subviews found, not applying the longpress fix.");
+        return;
+    }
+    for (int i=0; i<views.count; i++) {
+        UIView *webViewScrollView = views[i];
+        if ([webViewScrollView isKindOfClass:[UIScrollView class]]) {
+            NSArray *webViewScrollViewSubViews = webViewScrollView.subviews;
+            UIView *browser = webViewScrollViewSubViews[0];
+            [browser addGestureRecognizer:self.lpgr];
+            break;
+        }
+    }
+}
+
+- (void)handleLongPressGestures:(UILongPressGestureRecognizer*)sender
+{
+    if ([sender isEqual:self.lpgr]) {
+        if (sender.state == UIGestureRecognizerStateBegan) {
+          NSLog(@"Ignoring a longpress in order to suppress the magnifying glass.");
+        }
+    }
+}
+
+@end

--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		7ED95D591AB9029B008C4574 /* NSMutableArray+QueueAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED95D331AB9029B008C4574 /* NSMutableArray+QueueAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7ED95D5A1AB9029B008C4574 /* NSMutableArray+QueueAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED95D341AB9029B008C4574 /* NSMutableArray+QueueAdditions.m */; };
 		7EDCF3001B17D9DF00F7019F /* CDVURLRequestFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EDCF2FF1B17D9DF00F7019F /* CDVURLRequestFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3B082D41BB15CEA00D8DC35 /* CDVGestureHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = A3B082D21BB15CEA00D8DC35 /* CDVGestureHandler.h */; settings = {ASSET_TAGS = (); }; };
+		A3B082D51BB15CEA00D8DC35 /* CDVGestureHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B082D31BB15CEA00D8DC35 /* CDVGestureHandler.m */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -118,6 +120,8 @@
 		7ED95D331AB9029B008C4574 /* NSMutableArray+QueueAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+QueueAdditions.h"; sourceTree = "<group>"; };
 		7ED95D341AB9029B008C4574 /* NSMutableArray+QueueAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+QueueAdditions.m"; sourceTree = "<group>"; };
 		7EDCF2FF1B17D9DF00F7019F /* CDVURLRequestFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVURLRequestFilter.h; sourceTree = "<group>"; };
+		A3B082D21BB15CEA00D8DC35 /* CDVGestureHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVGestureHandler.h; sourceTree = "<group>"; };
+		A3B082D31BB15CEA00D8DC35 /* CDVGestureHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVGestureHandler.m; sourceTree = "<group>"; };
 		AA747D9E0F9514B9006C5449 /* CordovaLib_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CordovaLib_Prefix.pch; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -177,6 +181,7 @@
 		7ED95CF61AB9028C008C4574 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
+				A3B082D11BB15CEA00D8DC35 /* CDVGestureHandler */,
 				3093E2201B16D6A3003F381A /* CDVSystemSchemes */,
 				7ED95CF71AB9028C008C4574 /* CDVHandleOpenURL */,
 				7ED95CFA1AB9028C008C4574 /* CDVLocalStorage */,
@@ -261,6 +266,15 @@
 			path = Classes/Public;
 			sourceTree = "<group>";
 		};
+		A3B082D11BB15CEA00D8DC35 /* CDVGestureHandler */ = {
+			isa = PBXGroup;
+			children = (
+				A3B082D21BB15CEA00D8DC35 /* CDVGestureHandler.h */,
+				A3B082D31BB15CEA00D8DC35 /* CDVGestureHandler.m */,
+			);
+			path = CDVGestureHandler;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -271,6 +285,7 @@
 				7ED95D521AB9029B008C4574 /* CDVWebViewEngineProtocol.h in Headers */,
 				7ED95D491AB9029B008C4574 /* CDVScreenOrientationDelegate.h in Headers */,
 				7ED95D351AB9029B008C4574 /* CDV.h in Headers */,
+				A3B082D41BB15CEA00D8DC35 /* CDVGestureHandler.h in Headers */,
 				7ED95D3B1AB9029B008C4574 /* CDVCommandDelegateImpl.h in Headers */,
 				7ED95D3D1AB9029B008C4574 /* CDVCommandQueue.h in Headers */,
 				7ED95D531AB9029B008C4574 /* CDVWhitelist.h in Headers */,
@@ -367,6 +382,7 @@
 				7ED95D4B1AB9029B008C4574 /* CDVTimer.m in Sources */,
 				7ED95D4F1AB9029B008C4574 /* CDVUserAgentUtil.m in Sources */,
 				7ED95D401AB9029B008C4574 /* CDVConfigParser.m in Sources */,
+				A3B082D51BB15CEA00D8DC35 /* CDVGestureHandler.m in Sources */,
 				7ED95D071AB9028C008C4574 /* CDVHandleOpenURL.m in Sources */,
 				30193A501AE6350A0069A75F /* CDVUIWebViewNavigationDelegate.m in Sources */,
 				7ED95D5A1AB9029B008C4574 /* NSMutableArray+QueueAdditions.m in Sources */,

--- a/bin/templates/project/__PROJECT_NAME__/config.xml
+++ b/bin/templates/project/__PROJECT_NAME__/config.xml
@@ -71,4 +71,8 @@
         <param name="ios-package" value="CDVSystemSchemes"/>
         <param name="onload" value="true"/>
     </feature>
+    <feature name="GestureHandler">
+        <param name="ios-package" value="CDVGestureHandler"/>
+        <param name="onload" value="true"/>
+    </feature>
 </widget>

--- a/bin/templates/scripts/cordova/defaults.xml
+++ b/bin/templates/scripts/cordova/defaults.xml
@@ -45,5 +45,9 @@
         <param name="ios-package" value="CDVSystemSchemes"/>
         <param name="onload" value="true"/>
     </feature>
-    
+    <feature name="GestureHandler">
+        <param name="ios-package" value="CDVGestureHandler"/>
+        <param name="onload" value="true"/>
+    </feature>
+
 </widget>

--- a/tests/CordovaLibTests/CordovaLibApp/config.xml
+++ b/tests/CordovaLibTests/CordovaLibApp/config.xml
@@ -55,4 +55,8 @@
         <param name="ios-package" value="CDVHandleOpenURL"/>
         <param name="onload" value="true"/>
     </feature>
+    <feature name="GestureHandler">
+        <param name="ios-package" value="CDVGestureHandler"/>
+        <param name="onload" value="true"/>
+    </feature>
 </widget>


### PR DESCRIPTION
I thought `CDVLongPressFix` would not be the best name. Especially if we ever need to fix any other gestures Apple breaks for us, so I went for `CDVGestureHandler`.

Btw, a check for `IsAtLeastVersion(@"9")` was omitted on purpose because it doesn't hurt on lower versions (it even suppresses other longtap glitches we've been seeing for a long while now).

I hope you like it!