### PR TITLE
CB-9836 Add .gitattributes to prevent CRLF line endings in repos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
[Jira issue](https://issues.apache.org/jira/browse/CB-9836)