### PR TITLE
CB-10233: Support different config.xml file per CDVViewController instance

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.h
+++ b/CordovaLib/Classes/Public/CDVViewController.h
@@ -44,6 +44,7 @@
 @property (nonatomic, readonly, strong) NSMutableDictionary* settings;
 @property (nonatomic, readonly, strong) NSXMLParser* configParser;
 
+@property (nonatomic, readwrite, copy) NSString* configFile;
 @property (nonatomic, readwrite, copy) NSString* wwwFolderName;
 @property (nonatomic, readwrite, copy) NSString* startPage;
 @property (nonatomic, readonly, strong) CDVCommandQueue* commandQueue;

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -82,9 +82,6 @@
         [self printMultitaskingInfo];
         [self printPlatformVersionWarning];
         self.initialized = YES;
-
-        // load config.xml settings
-        [self loadSettings];
     }
 }
 
@@ -140,16 +137,32 @@
     NSLog(@"Multi-tasking -> Device: %@, App: %@", (backgroundSupported ? @"YES" : @"NO"), (![exitsOnSuspend intValue]) ? @"YES" : @"NO");
 }
 
+-(NSString*)configFilePath{
+    NSString* path = self.configFile ?: @"config.xml";
+
+    // if path is relative, resolve it against the main bundle
+    if(![path isAbsolutePath]){
+        NSString* absolutePath = [[NSBundle mainBundle] pathForResource:path ofType:nil];
+        if(!absolutePath){
+            NSAssert(NO, @"ERROR: %@ not found in the main bundle!", path);
+        }
+        path = absolutePath;
+    }
+    
+    // Assert file exists
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        NSAssert(NO, @"ERROR: %@ does not exist. Please run cordova-ios/bin/cordova_plist_to_config_xml path/to/project.", path);
+        return nil;
+    }
+    
+    return path;
+}
+
 - (void)parseSettingsWithParser:(NSObject <NSXMLParserDelegate>*)delegate
 {
     // read from config.xml in the app bundle
-    NSString* path = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"xml"];
-
-    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
-        NSAssert(NO, @"ERROR: config.xml does not exist. Please run cordova-ios/bin/cordova_plist_to_config_xml path/to/project.");
-        return;
-    }
-
+    NSString* path = [self configFilePath];
+    
     NSURL* url = [NSURL fileURLWithPath:path];
 
     self.configParser = [[NSXMLParser alloc] initWithContentsOfURL:url];
@@ -173,8 +186,12 @@
     self.settings = delegate.settings;
 
     // And the start folder/page.
-    self.wwwFolderName = @"www";
-    self.startPage = delegate.startPage;
+    if(self.wwwFolderName == nil){
+        self.wwwFolderName = @"www";
+    }
+    if(delegate.startPage && self.startPage == nil){
+        self.startPage = delegate.startPage;
+    }
     if (self.startPage == nil) {
         self.startPage = @"index.html";
     }
@@ -252,6 +269,9 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
+    // Load settings
+    [self loadSettings];
 
     NSString* backupWebStorageType = @"cloud"; // default value
 

--- a/tests/CordovaLibTests/CDVViewControllerTest.m
+++ b/tests/CordovaLibTests/CDVViewControllerTest.m
@@ -1,0 +1,60 @@
+//
+//  CDVViewControllerTest.m
+//  CordovaLibTests
+//
+//  Created by Mirko Luchi on 23/12/15.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import <Cordova/CDVViewController.h>
+
+#define CDVViewControllerTestSettingKey @"test_cdvconfigfile"
+#define CDVViewControllerTestSettingValueDefault @"config.xml"
+#define CDVViewControllerTestSettingValueCustom @"config-custom.xml"
+
+@interface CDVViewControllerTest : XCTestCase
+
+@end
+
+@implementation CDVViewControllerTest
+
+-(CDVViewController*)viewController{
+    CDVViewController* viewController = [CDVViewController new];
+    return viewController;
+}
+
+-(void)doTestInitWithConfigFile:(NSString*)configFile expectedSettingValue:(NSString*)value{
+    // Create a CDVViewController
+    CDVViewController* viewController = [self viewController];
+    if(configFile){
+        // Set custom config file
+        viewController.configFile = configFile;
+    }else{
+        // Do not specify config file ==> fallback to default config.xml
+    }
+    
+    // Trigger -viewDidLoad
+    [viewController view];
+    
+    // Assert that the proper file was actually loaded, checking the value of a test setting it must contain
+    NSString* settingValue = [viewController.settings objectForKey:CDVViewControllerTestSettingKey];
+    XCTAssertEqualObjects(settingValue, value);
+}
+
+-(void)testInitWithDefaultConfigFile{
+    [self doTestInitWithConfigFile:nil expectedSettingValue:CDVViewControllerTestSettingValueDefault];
+}
+
+-(void)testInitWithCustomConfigFileAbsolutePath{
+    NSString* configFileAbsolutePath = [[NSBundle mainBundle] pathForResource:@"config-custom" ofType:@"xml"];
+    [self doTestInitWithConfigFile:configFileAbsolutePath expectedSettingValue:CDVViewControllerTestSettingValueCustom];
+}
+
+-(void)testInitWithCustomConfigFileRelativePath{
+    NSString* configFileRelativePath = @"config-custom.xml";
+    [self doTestInitWithConfigFile:configFileRelativePath expectedSettingValue:CDVViewControllerTestSettingValueCustom];
+}
+
+@end
+

--- a/tests/CordovaLibTests/CordovaLibApp/config.xml
+++ b/tests/CordovaLibTests/CordovaLibApp/config.xml
@@ -49,7 +49,9 @@
     <preference name="PageLength" value="0" />
     <preference name="PaginationBreakingMode" value="page" /> <!-- page, column -->
     <preference name="PaginationMode" value="unpaginated" /> <!-- unpaginated, leftToRight, topToBottom, bottomToTop, rightToLeft -->
-
+    <!-- This settings is just used by the CDVViewControllerTest to assert which config file has been loaded -->
+    <preference name="test_CDVConfigFile" value="config.xml" />
+    
     <feature name="LocalStorage">
         <param name="ios-package" value="CDVLocalStorage"/>
     </feature>

--- a/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
+++ b/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		30B342F515224B360070E6A5 /* CDVWebViewTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 30B342F415224B360070E6A5 /* CDVWebViewTest.m */; };
 		30D1B08C15A2B36D0060C291 /* CDVBase64Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D1B08B15A2B36D0060C291 /* CDVBase64Tests.m */; };
 		30F8AE1D152129DA006625B3 /* www in Resources */ = {isa = PBXBuildFile; fileRef = 30F8AE1C152129DA006625B3 /* www */; };
+		5C4C91761C2ACE450055AFC3 /* CDVViewControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C4C91751C2ACE450055AFC3 /* CDVViewControllerTest.m */; };
+		5C4C917B1C2AD44E0055AFC3 /* config-custom.xml in Resources */ = {isa = PBXBuildFile; fileRef = 5C4C91771C2ACF130055AFC3 /* config-custom.xml */; };
 		686357B5141002F200DF4CF2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 686357B3141002F200DF4CF2 /* InfoPlist.strings */; };
 		686357BA141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 686357B9141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m */; };
 		7E91406017711D88002C6A3F /* CDVWebViewDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E91405F17711D88002C6A3F /* CDVWebViewDelegateTests.m */; };
@@ -54,6 +56,8 @@
 		30B342F415224B360070E6A5 /* CDVWebViewTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVWebViewTest.m; sourceTree = "<group>"; };
 		30D1B08B15A2B36D0060C291 /* CDVBase64Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVBase64Tests.m; sourceTree = "<group>"; };
 		30F8AE1C152129DA006625B3 /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = "<group>"; };
+		5C4C91751C2ACE450055AFC3 /* CDVViewControllerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVViewControllerTest.m; sourceTree = "<group>"; };
+		5C4C91771C2ACF130055AFC3 /* config-custom.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "config-custom.xml"; sourceTree = "<group>"; };
 		686357A9141002F100DF4CF2 /* CordovaLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CordovaLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		686357B2141002F200DF4CF2 /* CordovaLibTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "CordovaLibTests-Info.plist"; sourceTree = "<group>"; };
 		686357B4141002F200DF4CF2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -104,6 +108,7 @@
 			children = (
 				7EF33BD61911ABA20048544E /* Default-568h@2x.png */,
 				F8EB14D0165FFD3200616F39 /* config.xml */,
+				5C4C91771C2ACF130055AFC3 /* config-custom.xml */,
 				EB3B34F4161B585D003DBE7D /* CordovaLibTests */,
 				303A406D152124BB00182201 /* CordovaLibApp */,
 				0867D69AFE84028FC02AAC07 /* Frameworks */,
@@ -156,18 +161,19 @@
 		EB3B34F4161B585D003DBE7D /* CordovaLibTests */ = {
 			isa = PBXGroup;
 			children = (
+				30D1B08B15A2B36D0060C291 /* CDVBase64Tests.m */,
 				30610C9119AD9B95000B3781 /* CDVCommandDelegateTests.m */,
-				EBA7F20417962CCD001A0CE6 /* CDVStartPageTests.m */,
-				7E91405F17711D88002C6A3F /* CDVWebViewDelegateTests.m */,
-				EB96677116ADBCF500D86CDF /* CDVUserAgentTest.m */,
 				EBA3554415A731F100F4DE24 /* CDVFakeFileManager.h */,
 				EBA3554515A731F100F4DE24 /* CDVFakeFileManager.m */,
-				EBA3550F15A5F18900F4DE24 /* CDVWebViewTest.h */,
-				30B342F415224B360070E6A5 /* CDVWebViewTest.m */,
-				30D1B08B15A2B36D0060C291 /* CDVBase64Tests.m */,
 				EB89634915FE66EA00E12277 /* CDVInvokedUrlCommandTests.m */,
 				3062D1AD151D4D9D000D9128 /* CDVLocalStorageTests.m */,
 				686357B9141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m */,
+				EBA7F20417962CCD001A0CE6 /* CDVStartPageTests.m */,
+				EB96677116ADBCF500D86CDF /* CDVUserAgentTest.m */,
+				5C4C91751C2ACE450055AFC3 /* CDVViewControllerTest.m */,
+				7E91405F17711D88002C6A3F /* CDVWebViewDelegateTests.m */,
+				EBA3550F15A5F18900F4DE24 /* CDVWebViewTest.h */,
+				30B342F415224B360070E6A5 /* CDVWebViewTest.m */,
 				30356213141049E1006C2D43 /* CDVWhitelistTests.m */,
 				686357B1141002F200DF4CF2 /* Supporting Files */,
 			);
@@ -253,6 +259,7 @@
 				7EF33BD71911ABA20048544E /* Default-568h@2x.png in Resources */,
 				303A4072152124BB00182201 /* InfoPlist.strings in Resources */,
 				30F8AE1D152129DA006625B3 /* www in Resources */,
+				5C4C917B1C2AD44E0055AFC3 /* config-custom.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -319,6 +326,7 @@
 				30B342F515224B360070E6A5 /* CDVWebViewTest.m in Sources */,
 				30D1B08C15A2B36D0060C291 /* CDVBase64Tests.m in Sources */,
 				EBA3554615A731F100F4DE24 /* CDVFakeFileManager.m in Sources */,
+				5C4C91761C2ACE450055AFC3 /* CDVViewControllerTest.m in Sources */,
 				EB89634A15FE66EA00E12277 /* CDVInvokedUrlCommandTests.m in Sources */,
 				EB96677216ADBCF500D86CDF /* CDVUserAgentTest.m in Sources */,
 				7E91406017711D88002C6A3F /* CDVWebViewDelegateTests.m in Sources */,

--- a/tests/CordovaLibTests/config-custom.xml
+++ b/tests/CordovaLibTests/config-custom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+<widget>
+    <!-- This settings is just used by the CDVViewControllerTest to assert which config file has been loaded -->
+    <preference name="test_CDVConfigFile" value="config-custom.xml" />
+</widget>


### PR DESCRIPTION
- Add a configFile property to CDVViewController (path to the config
file, absolute or relative to main bundle)
- Move loading of settings from -init to -viewDidLoad