### PR TITLE
Use "cdv_" prefixed scrollView for UIView to avoid conflicts

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewEngine.m
@@ -116,8 +116,8 @@
 
     // prevent webView from bouncing
     if (!bounceAllowed) {
-        if ([uiWebView respondsToSelector:@selector(scrollView)]) {
-            ((UIScrollView*)[uiWebView scrollView]).bounces = NO;
+        if ([uiWebView respondsToSelector:@selector(cdv_srollView)]) {
+            ((UIScrollView*)[uiWebView cdv_srollView]).bounces = NO;
         } else {
             for (id subview in self.webView.subviews) {
                 if ([[subview class] isSubclassOfClass:[UIScrollView class]]) {
@@ -129,7 +129,7 @@
 
     NSString* decelerationSetting = [settings cordovaSettingForKey:@"UIWebViewDecelerationSpeed"];
     if (![@"fast" isEqualToString:decelerationSetting]) {
-        [uiWebView.scrollView setDecelerationRate:UIScrollViewDecelerationRateNormal];
+        [uiWebView.cdv_srollView setDecelerationRate:UIScrollViewDecelerationRateNormal];
     }
 
     NSInteger paginationBreakingMode = 0; // default - UIWebPaginationBreakingModePage

--- a/CordovaLib/Classes/Public/CDVPlugin.h
+++ b/CordovaLib/Classes/Public/CDVPlugin.h
@@ -26,7 +26,7 @@
 
 @interface UIView (org_apache_cordova_UIView_Extension)
 
-@property (nonatomic, weak) UIScrollView* scrollView;
+@property (nonatomic, weak) UIScrollView* cdv_srollView;
 
 @end
 

--- a/CordovaLib/Classes/Public/CDVPlugin.m
+++ b/CordovaLib/Classes/Public/CDVPlugin.m
@@ -25,11 +25,11 @@
 
 @implementation UIView (org_apache_cordova_UIView_Extension)
 
-@dynamic scrollView;
+@dynamic cdv_srollView;
 
-- (UIScrollView*)scrollView
+- (UIScrollView*)cdv_srollView
 {
-    SEL scrollViewSelector = NSSelectorFromString(@"scrollView");
+    SEL scrollViewSelector = NSSelectorFromString(@"cdv_srollView");
 
     if ([self respondsToSelector:scrollViewSelector]) {
         return ((id (*)(id, SEL))objc_msgSend)(self, scrollViewSelector);


### PR DESCRIPTION
After upgrading cordova-ios from 3.9.x to 4.0.x, I found there's a conflict for my custom UIView and cordova. It is caused by the category in Cordova, CDVPlugin.h:

```
@interface UIView (org_apache_cordova_UIView_Extension)

@property (nonatomic, weak) UIScrollView* srollView;

@end
```

As an extension that used internally in Cordova, it should not use a common name of "scrollView". If developer's project have a custom UIView that has a scrollView, the project will be broken.

So I did this pull request that rename this "scrollView" to "cdv_srollView".

Please take a review, thanks.