### PR TITLE
Stay attached to LLDB when running app

### DIFF
--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -133,9 +133,9 @@ function checkDeviceConnected() {
 function deployToDevice(appPath, target, extraArgs) {
     // Deploying to device...
     if (target) {
-        return spawn('ios-deploy', ['--justlaunch', '-d', '-b', appPath, '-i', target].concat(extraArgs));
+        return spawn('ios-deploy', ['-d', '-b', appPath, '-i', target].concat(extraArgs));
     } else {
-        return spawn('ios-deploy', ['--justlaunch', '-d', '-b', appPath].concat(extraArgs));
+        return spawn('ios-deploy', ['-d', '-b', appPath].concat(extraArgs));
     }
 }
 


### PR DESCRIPTION
https://github.com/apache/cordova-ios/commit/ba7bafdbd8d4dab29899a7a804a6bf8ad6893e51 added the `justlaunch` flag to `ios-deploy`, which conflicts with `-d`. The previous behavior was to stay attached to the debugger when the application launched, and by reading the issue in Jira I found no traces of why this behavior was overturned.

Ideally I'd like to continue to deploy to the device and stay attached to the debugger without using Xcode.