### PR TITLE
Disable ios-deploy wifi mode when deploying to a device

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -25,7 +25,7 @@ var XCODEBUILD_MIN_VERSION = '6.0.0';
 var XCODEBUILD_NOT_FOUND_MESSAGE =
     'Please install version ' + XCODEBUILD_MIN_VERSION + ' or greater from App Store';
 
-var IOS_DEPLOY_MIN_VERSION = '1.8.0';
+var IOS_DEPLOY_MIN_VERSION = '1.8.3';
 var IOS_DEPLOY_NOT_FOUND_MESSAGE =
     'Please download, build and install version ' + IOS_DEPLOY_MIN_VERSION + ' or greater' +
     ' from https://github.com/phonegap/ios-deploy into your path, or do \'npm install -g ios-deploy\'';

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -135,7 +135,7 @@ function deployToDevice(appPath, target, extraArgs) {
     if (target) {
         return spawn('ios-deploy', ['--justlaunch', '-d', '-b', appPath, '-i', target].concat(extraArgs));
     } else {
-        return spawn('ios-deploy', ['--justlaunch', '-d', '-b', appPath].concat(extraArgs));
+        return spawn('ios-deploy', ['--justlaunch', '--no-wifi', '-d', '-b', appPath].concat(extraArgs));
     }
 }
 


### PR DESCRIPTION
Currently when running `cordova run ios --device` the app gets deployed two times via usb and wifi. But when disconnecting from USB it is not possible to deploy at all, so the deployment fails. This issue is related to phonegap/ios-deploy#170 and disables this behavior to get the deployment working again, when using usb.