### PR TITLE
CB-10659 changed project name to fix the platform add failure

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/config.xml
+++ b/bin/templates/project/__PROJECT_NAME__/config.xml
@@ -20,7 +20,7 @@
 <widget xmlns     = "http://www.w3.org/ns/widgets"
         id        = "io.cordova.helloCordova"
         version   = "2.0.0">
-    <name>Hello Cordova</name>
+    <name>HelloCordova</name>
 
     <description>
         A sample Apache Cordova application that responds to the deviceready event.


### PR DESCRIPTION
The project name "Hello Cordova" does not match with template project "HelloCordova", and it causes failure when finding the <project_name>.xcodeproj file as a part of installing plugin files.
By matching the project names with the template, platform add worked fine.

After the fix is applied, the platforms/ios directory contains the following files:
```
[ios] ls
CordovaLib             cordova                www
HelloCordova           ios.json
HelloCordova.xcodeproj platform_www
```
The platform add ios worked fine now.
```
[t6.0.1] cordova platform add ~/cordova/bso-cordova-ios
Adding ios project...
iOS project created with cordova-ios@4.1.0-dev
Installing "cordova-plugin-device" for ios
Discovered plugin "cordova-plugin-whitelist" in config.xml. Installing to the project
Fetching plugin "cordova-plugin-whitelist@1" via npm
Installing "cordova-plugin-whitelist" for ios
```