### PR TITLE
CB-10673 fixed conflicting plugin install issue with overlapped <sour…

### DIFF
--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -201,7 +201,7 @@ function installHelper(type, obj, plugin_dir, project_dir, plugin_id, options, p
     if (link) {
         var trueSrc = fs.realpathSync(srcFile);
         // Create a symlink in the expected place, so that uninstall can use it.
-        if (options && options.forceCopyingSrc) {
+        if (options && options.force) {
             copyFile(plugin_dir, trueSrc, project_dir, destFile, link);
         } else {
             copyNewFile(plugin_dir, trueSrc, project_dir, destFile, link);
@@ -212,7 +212,7 @@ function installHelper(type, obj, plugin_dir, project_dir, plugin_id, options, p
         // library special-cases Plugins/ prefix.
         project_ref = 'Plugins/' + fixPathSep(path.relative(fs.realpathSync(project.plugins_dir), trueSrc));
     } else {
-        if (options && options.forceCopyingSrc) {
+        if (options && options.force) {
             copyFile(plugin_dir, srcFile, project_dir, destFile, link);
         } else {
             copyNewFile(plugin_dir, srcFile, project_dir, destFile, link);

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -201,7 +201,7 @@ function installHelper(type, obj, plugin_dir, project_dir, plugin_id, options, p
     if (link) {
         var trueSrc = fs.realpathSync(srcFile);
         // Create a symlink in the expected place, so that uninstall can use it.
-        copyNewFile(plugin_dir, trueSrc, project_dir, destFile, link);
+        copyFile(plugin_dir, trueSrc, project_dir, destFile, link);
 
         // Xcode won't save changes to a file if there is a symlink involved.
         // Make the Xcode reference the file directly.

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -201,15 +201,22 @@ function installHelper(type, obj, plugin_dir, project_dir, plugin_id, options, p
     if (link) {
         var trueSrc = fs.realpathSync(srcFile);
         // Create a symlink in the expected place, so that uninstall can use it.
-        copyFile(plugin_dir, trueSrc, project_dir, destFile, link);
-
+        if (options && options.forceCopyingSrc) {
+            copyFile(plugin_dir, trueSrc, project_dir, destFile, link);
+        } else {
+            copyNewFile(plugin_dir, trueSrc, project_dir, destFile, link);
+        }
         // Xcode won't save changes to a file if there is a symlink involved.
         // Make the Xcode reference the file directly.
         // Note: Can't use path.join() here since it collapses 'Plugins/..', and xcode
         // library special-cases Plugins/ prefix.
         project_ref = 'Plugins/' + fixPathSep(path.relative(fs.realpathSync(project.plugins_dir), trueSrc));
     } else {
-        copyNewFile(plugin_dir, srcFile, project_dir, destFile, link);
+        if (options && options.forceCopyingSrc) {
+            copyFile(plugin_dir, srcFile, project_dir, destFile, link);
+        } else {
+            copyNewFile(plugin_dir, srcFile, project_dir, destFile, link);
+        }
         project_ref = 'Plugins/' + fixPathSep(path.relative(project.plugins_dir, destFile));
     }
 


### PR DESCRIPTION
…ce-file> tag
The problem is that copyNewFile is too strict for <source-file> tag.
You will never know which two plugins will write the library to the same target-dir of the source-file.
We should let it copy the library to the same location.