### PR TITLE
CB-11238 Expose supportedOrientations method

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.h
+++ b/CordovaLib/Classes/Public/CDVViewController.h
@@ -64,6 +64,12 @@
 @property (nonatomic, readwrite, copy) NSString* baseUserAgent;
 
 /**
+	Takes/Gives an array of UIInterfaceOrientation (int) objects
+	ex. UIInterfaceOrientationPortrait
+*/
+@property (nonatomic, readwrite, strong) NSArray* supportedOrientations;
+
+/**
  The address of the lock token used for controlling access to setting the user-agent
  */
 @property (nonatomic, readonly) NSInteger* userAgentLockToken;

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -37,7 +37,6 @@
 @property (nonatomic, readwrite, strong) NSMutableDictionary* pluginObjects;
 @property (nonatomic, readwrite, strong) NSMutableArray* startupPluginNames;
 @property (nonatomic, readwrite, strong) NSDictionary* pluginsMap;
-@property (nonatomic, readwrite, strong) NSArray* supportedOrientations;
 @property (nonatomic, readwrite, strong) id <CDVWebViewEngineProtocol> webViewEngine;
 
 @property (readwrite, assign) BOOL initialized;


### PR DESCRIPTION
Expose supportedOrientations getter/setter so native code can override the current behavior.
I think this would require a minor version bump only, as we are exposing a new (native) API, but not breaking any existing functionality.