### PR TITLE
CB-10912: update ios-sim to 5.0.7 to fix 'Invalid Device State' errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "cordova-common": "^1.1.0",
-    "ios-sim": "^5.0.6",
+    "ios-sim": "^5.0.7",
     "nopt": "^3.0.6",
     "plist": "^1.2.0",
     "q": "^1.4.1",


### PR DESCRIPTION
This issue seems to have been introduced by a change in simctl, which ios-sim relies on:

https://github.com/phonegap/simctl/commit/34426c719130a73b83af65f50a11a46267a5ad0b