### PR TITLE
CB-6992 Fix non-working create case, add new test

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -21,6 +21,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var unorm = require('unorm');
 
 var CordovaError = require('cordova-common').CordovaError;
 var CordovaLogger = require('cordova-common').CordovaLogger;
@@ -108,8 +109,13 @@ function Api(platform, platformRootDir, events) {
 Api.createPlatform = function (destination, config, options, events) {
     setupEvents(events);
 
+    // CB-6992 it is necessary to normalize characters
+    // because node and shell scripts handles unicode symbols differently
+    // We need to normalize the name to NFD form since iOS uses NFD unicode form
+    var name = unorm.nfd(config.name());
+
     return require('../../../lib/create')
-    .createProject(destination, config.packageName(), config.name(), options)
+    .createProject(destination, config.packageName(), name, options)
     .then(function () {
         // after platform is created we return Api instance based on new Api.js location
         // This is required to correctly resolve paths in the future api calls

--- a/tests/spec/create.spec.js
+++ b/tests/spec/create.spec.js
@@ -74,6 +74,13 @@ describe('create', function() {
         createAndBuild(projectname, projectid);
     });
 
+    it('create project with unicode name 2, no spaces', function() {
+        var projectname = 'إثرا';
+        var projectid = 'com.test.app3.2';
+
+        createAndBuild(projectname, projectid);
+    });
+
     it('create project with unicode name, and spaces', function() {
         var projectname = '応応応応 用用用用';
         var projectid = 'com.test.app4';


### PR DESCRIPTION
Added name normalization from prepare to createProject in order to support the case where the user edits name in config.xml, then adds ios platform to project.

Also added a new test since the existing test was passing.  The new test used a different unicode string. It fails without this fix and passes with this fix.

Please see [this JIRA comment](https://issues.apache.org/jira/browse/CB-6992?focusedCommentId=15237088&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15237088) for additional background info.