### PR TITLE
CB-11069 - CDVViewController appURL is nil if wwwFolderName is the path to a framework

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -212,6 +212,10 @@
         // www folder is actually a bundle
         NSBundle* bundle = [NSBundle bundleWithPath:self.wwwFolderName];
         appURL = [bundle URLForResource:self.startPage withExtension:nil];
+    } else if([self.wwwFolderName hasSuffix:@".framework"]){
+        // www folder is actually a framework
+        NSBundle* bundle = [NSBundle bundleWithPath:self.wwwFolderName];
+        appURL = [bundle URLForResource:self.startPage withExtension:nil];
     } else {
         // CB-3005 strip parameters from start page to check if page exists in resources
         NSURL* startURL = [NSURL URLWithString:self.startPage];


### PR DESCRIPTION
Fix -[CDVViewController appUrl] method to take into account a wwwFolderName which is a framework