### PR TITLE
Incorrect reference to UIWebView

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewNavigationDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewNavigationDelegate.m
@@ -45,7 +45,7 @@
     CDVViewController* vc = (CDVViewController*)self.enginePlugin.viewController;
 
     [vc.commandQueue resetRequestId];
-    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginResetNotification object:self.enginePlugin.webView]];
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginResetNotification object:theWebView]];
 }
 
 /**
@@ -64,7 +64,7 @@
      */
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
 
-    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPageDidLoadNotification object:self.enginePlugin.webView]];
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPageDidLoadNotification object:theWebView]];
 }
 
 - (void)webView:(UIWebView*)theWebView didFailLoadWithError:(NSError*)error


### PR DESCRIPTION
In `CDVUIWebViewNavigationDelegate.m` there is a call to `self.enginePlugin.webView` which returns nil.
This bug breaks the Cordova mechanism for posting notifications to the default notification center, so the application cannot listen to notifications.
The webview is already part of the functions signature, so we can simply use `theWebView` instead of `self.enginePlugin.webView`.

