### PR TITLE
CB-11475 Ignore unsupported 60x60 icon

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -310,7 +310,6 @@ function mapIconResources(icons, iconsDir) {
     // See https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html
     // for launch images sizes reference.
     var platformIcons = [
-        {dest: 'icon-60.png', width: 60, height: 60},
         {dest: 'icon-60@2x.png', width: 120, height: 120},
         {dest: 'icon-60@3x.png', width: 180, height: 180},
         {dest: 'icon-76.png', width: 76, height: 76},


### PR DESCRIPTION
The 60x60 icon is not used in `AppIcon` catalog and has been removed in 68af7ea. However if you have `<icon width="60" height="60" ...>` in `config.xml` it'll be added to catalog as `icon-60.png`. This will result in Xcode warning `The app icon set "AppIcon" has an unassigned child`

See also [CB-11475](https://issues.apache.org/jira/browse/CB-11475)