### PR TITLE
Fix Macos Japanese Filename Problem. (Change NFD projectName to NFC t…

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -146,7 +146,7 @@ function getXcodeArgs(projectName, projectPath, configuration, isDevice) {
         xcodebuildArgs = [
             '-xcconfig', path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
             '-project', projectName + '.xcodeproj',
-            '-target', projectName,
+            '-target', projectName.normalize(),
             '-configuration', configuration,
             '-destination', 'platform=iOS',
             'build',
@@ -157,7 +157,7 @@ function getXcodeArgs(projectName, projectPath, configuration, isDevice) {
         xcodebuildArgs = [
             '-xcconfig', path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
             '-project', projectName + '.xcodeproj',
-            '-target', projectName ,
+            '-target', projectName.normalize() ,
             '-configuration', configuration,
             '-sdk', 'iphonesimulator',
             '-destination', 'platform=iOS Simulator',


### PR DESCRIPTION
This request fixes the NFC / NFD problem. (Filename String for Mac)
In Mac, The filename is treated as NFD.
However, the target name in xcode is treated as NFC.
Therefore, cordova build fails when we use the specific Japanese name for project title.
(For example, 

    cordova create サンプル com.example.sample サンプル
    cordova platform add ios
    cordova build

==> Fail.
Because the サンプル in NFC is different from and サンプル in NFD.)
