### PR TITLE
CB-9371, CB-9703: Fix how prepare handles orientation on ios

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
+++ b/bin/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
@@ -35,6 +35,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -267,9 +267,9 @@ function handleOrientationSettings(platformConfig, infoPlist) {
             infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
             infoPlist['UISupportedInterfaceOrientations~ipad'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
             break;
-        default:
-            delete infoPlist['UISupportedInterfaceOrientations'];
-            delete infoPlist['UISupportedInterfaceOrientations~ipad'];
+        case 'default':
+            infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
+            infoPlist['UISupportedInterfaceOrientations~ipad'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
             delete infoPlist['UIInterfaceOrientation'];
     }
 }
@@ -471,7 +471,7 @@ function getOrientationValue(platformConfig) {
 
     var orientation = platformConfig.getPreference('orientation');
     if (!orientation) {
-        return ORIENTATION_DEFAULT;
+        return '';
     }
 
     orientation = orientation.toLowerCase();

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -150,8 +150,8 @@ describe('prepare', function () {
         it('should handle default orientation', function(done) {
             cfg.getPreference.andReturn('default');
             wrapper(updateProject(cfg, p.locations), done, function() {
-                expect(plist.build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toBeUndefined();
-                expect(plist.build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toBeUndefined();
+                expect(plist.build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ]);
+                expect(plist.build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ]);
                 expect(plist.build.mostRecentCall.args[0].UIInterfaceOrientation).toBeUndefined();
             });
         });
@@ -179,7 +179,8 @@ describe('prepare', function () {
         it('should handle custom orientation', function(done) {
             cfg.getPreference.andReturn('some-custom-orientation');
             wrapper(updateProject(cfg, p.locations), done, function() {
-                expect(plist.build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toBeUndefined();
+                expect(plist.build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ]);
+                expect(plist.build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ]);
                 expect(plist.build.mostRecentCall.args[0].UIInterfaceOrientation).toBeUndefined();
             });
         });


### PR DESCRIPTION
Relates to https://github.com/apache/cordova-lib/pull/260

This changes the behavior of the default orientation preference to match the default orientation settings for new native iOS projects.

It also no longer modifies the orientation settings if the user does not specify an orientation preference.