### PR TITLE
Adding WebViewEngine plugin that uses WKWebView

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewDelegate.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewDelegate.h
@@ -1,0 +1,43 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Created by Bharath Hariharan on 7/15/16.
+ */
+
+#import <WebKit/WebKit.h>
+#import "CDVAvailability.h"
+
+/**
+ * Distinguishes top-level navigations from sub-frame navigations.
+ * shouldStartLoadWithRequest is called for every request, but didStartLoad
+ * and didFinishLoad is called only for top-level navigations.
+ * Relevant bug: CB-2389
+ */
+@interface CDVWKWebViewDelegate : NSObject <WKNavigationDelegate>{
+    __weak NSObject <WKNavigationDelegate>* _delegate;
+    NSInteger _loadCount;
+    NSInteger _state;
+    NSInteger _curLoadToken;
+    NSInteger _loadStartPollCount;
+}
+
+- (id)initWithDelegate:(NSObject <WKNavigationDelegate>*)delegate;
+
+- (BOOL)request:(NSURLRequest*)newRequest isEqualToRequestAfterStrippingFragments:(NSURLRequest*)originalRequest;
+
+@end

--- a/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewDelegate.m
@@ -1,0 +1,430 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Created by Bharath Hariharan on 7/15/16.
+ */
+
+//
+// Testing shows:
+//
+// In all cases, webView.request.URL is the previous page's URL (or empty) during the didStartLoad callback.
+// When loading a page with a redirect:
+// 1. shouldStartLoading (requestURL is target page)
+// 2. didStartLoading
+// 3. shouldStartLoading (requestURL is redirect target)
+// 4. didFinishLoad (request.URL is redirect target)
+//
+// Note the lack of a second didStartLoading **
+//
+// When loading a page with iframes:
+// 1. shouldStartLoading (requestURL is main page)
+// 2. didStartLoading
+// 3. shouldStartLoading (requestURL is one of the iframes)
+// 4. didStartLoading
+// 5. didFinishLoad
+// 6. didFinishLoad
+//
+// Note there is no way to distinguish which didFinishLoad maps to which didStartLoad **
+//
+// Loading a page by calling window.history.go(-1):
+// 1. didStartLoading
+// 2. didFinishLoad
+//
+// Note the lack of a shouldStartLoading call **
+// Actually - this is fixed on iOS6. iOS6 has a shouldStart. **
+//
+// Loading a page by calling location.reload()
+// 1. shouldStartLoading
+// 2. didStartLoading
+// 3. didFinishLoad
+//
+// Loading a page with an iframe that fails to load:
+// 1. shouldStart (main page)
+// 2. didStart
+// 3. shouldStart (iframe)
+// 4. didStart
+// 5. didFailWithError
+// 6. didFinish
+//
+// Loading a page with an iframe that fails to load due to an invalid URL:
+// 1. shouldStart (main page)
+// 2. didStart
+// 3. shouldStart (iframe)
+// 5. didFailWithError
+// 6. didFinish
+//
+// This case breaks our logic since there is a missing didStart. To prevent this,
+// we check URLs in shouldStart and return NO if they are invalid.
+//
+// Loading a page with an invalid URL
+// 1. shouldStart (main page)
+// 2. didFailWithError
+//
+// TODO: Record order when page is re-navigated before the first navigation finishes.
+//
+
+#import "CDVWKWebViewDelegate.h"
+
+// #define VerboseLog NSLog
+#define VerboseLog(...) do { \
+} while (0)
+
+typedef enum {
+    STATE_IDLE = 0,
+    STATE_WAITING_FOR_LOAD_START = 1,
+    STATE_WAITING_FOR_LOAD_FINISH = 2,
+    STATE_IOS5_POLLING_FOR_LOAD_START = 3,
+    STATE_IOS5_POLLING_FOR_LOAD_FINISH = 4,
+    STATE_CANCELLED = 5
+} State;
+
+static NSString *stripFragment(NSString* url)
+{
+    NSRange r = [url rangeOfString:@"#"];
+
+    if (r.location == NSNotFound) {
+        return url;
+    }
+    return [url substringToIndex:r.location];
+}
+
+@implementation CDVWKWebViewDelegate
+
+- (id)initWithDelegate:(NSObject <WKNavigationDelegate>*)delegate
+{
+    self = [super init];
+    if (self != nil) {
+        _delegate = delegate;
+        _loadCount = -1;
+        _state = STATE_IDLE;
+    }
+    return self;
+}
+
+- (BOOL)request:(NSURLRequest*)newRequest isEqualToRequestAfterStrippingFragments:(NSURLRequest*)originalRequest
+{
+    if (originalRequest.URL && newRequest.URL) {
+        NSString* originalRequestUrl = [originalRequest.URL absoluteString];
+        NSString* newRequestUrl = [newRequest.URL absoluteString];
+
+        NSString* baseOriginalRequestUrl = stripFragment(originalRequestUrl);
+        NSString* baseNewRequestUrl = stripFragment(newRequestUrl);
+        return [baseOriginalRequestUrl isEqualToString:baseNewRequestUrl];
+    }
+
+    return NO;
+}
+
+- (BOOL)isPageLoaded:(WKWebView*)webView
+{
+    NSString* readyState = [self stringByEvaluatingJavaScriptFromString:@"document.readyState" webView:webView];
+
+    return [readyState isEqualToString:@"loaded"] || [readyState isEqualToString:@"complete"];
+}
+
+- (BOOL)isJsLoadTokenSet:(WKWebView*)webView
+{
+    NSString* loadToken = [self stringByEvaluatingJavaScriptFromString:@"window.__cordovaLoadToken" webView:webView];
+
+    return [[NSString stringWithFormat:@"%ld", (long)_curLoadToken] isEqualToString:loadToken];
+}
+
+- (void)setLoadToken:(WKWebView*)webView
+{
+    _curLoadToken += 1;
+    [self stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"window.__cordovaLoadToken=%ld", (long)_curLoadToken] webView:webView];
+}
+
+- (NSString*)evalForCurrentURL:(WKWebView*)webView
+{
+    return [self stringByEvaluatingJavaScriptFromString:@"location.href" webView:webView];
+}
+
+- (void)pollForPageLoadStart:(WKWebView*)webView
+{
+    if (_state != STATE_IOS5_POLLING_FOR_LOAD_START) {
+        return;
+    }
+    if (![self isJsLoadTokenSet:webView]) {
+        VerboseLog(@"Polled for page load start. result = YES!");
+        _state = STATE_IOS5_POLLING_FOR_LOAD_FINISH;
+        [self setLoadToken:webView];
+        [self pollForPageLoadFinish:webView];
+    } else {
+        VerboseLog(@"Polled for page load start. result = NO");
+        // Poll only for 1 second, and then fall back on checking only when delegate methods are called.
+        ++_loadStartPollCount;
+        if (_loadStartPollCount < (1000 * .05)) {
+            [self performSelector:@selector(pollForPageLoadStart:) withObject:webView afterDelay:.05];
+        }
+    }
+}
+
+- (void)pollForPageLoadFinish:(WKWebView*)webView
+{
+    if (_state != STATE_IOS5_POLLING_FOR_LOAD_FINISH) {
+        return;
+    }
+    if ([self isPageLoaded:webView]) {
+        VerboseLog(@"Polled for page load finish. result = YES!");
+        _state = STATE_IDLE;
+    } else {
+        VerboseLog(@"Polled for page load finish. result = NO");
+        [self performSelector:@selector(pollForPageLoadFinish:) withObject:webView afterDelay:.05];
+    }
+}
+
+- (BOOL)shouldLoadRequest:(NSURLRequest*)request
+{
+    NSString* scheme = [[request URL] scheme];
+    NSArray* allowedSchemes = [NSArray arrayWithObjects:@"mailto",@"tel",@"blob",@"sms",@"data", nil];
+    if([allowedSchemes containsObject:scheme]) {
+        return YES;
+    }
+    else {
+        return [NSURLConnection canHandleRequest:request];
+    }
+}
+
+- (void) webView:(WKWebView *) webView decidePolicyForNavigationAction:(WKNavigationAction *) navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy)) decisionHandler
+{
+    __block BOOL shouldLoad = YES;
+    
+    if ([_delegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {
+        [_delegate webView:webView decidePolicyForNavigationAction:navigationAction decisionHandler:^void(WKNavigationActionPolicy policy) {
+            if (policy == WKNavigationActionPolicyAllow) {
+                shouldLoad = YES;
+            } else {
+                shouldLoad = NO;
+            }
+        }];
+    }
+
+    VerboseLog(@"webView decidePolicyForNavigationAction=%d (before) state=%d loadCount=%d URL=%@", shouldLoad, _state, _loadCount, request.URL);
+
+    if (shouldLoad) {
+        // When devtools refresh occurs, it blindly uses the same request object. If a history.replaceState() has occured, then
+        // mainDocumentURL != URL even though it's a top-level navigation.
+        NSURLRequest *request = navigationAction.request;
+        BOOL isTopLevelNavigation = [request.URL isEqual:[request mainDocumentURL]];
+        if (isTopLevelNavigation) {
+            // Ignore hash changes that don't navigate to a different page.
+            // webView.request does actually update when history.replaceState() gets called.
+            if ([self request:request isEqualToRequestAfterStrippingFragments:request]) {
+                NSString* prevURL = [self evalForCurrentURL:webView];
+                if ([prevURL isEqualToString:[request.URL absoluteString]]) {
+                    VerboseLog(@"Page reload detected.");
+                } else {
+                    VerboseLog(@"Detected hash change shouldLoad");
+                    if (shouldLoad) {
+                        decisionHandler(WKNavigationActionPolicyAllow);
+                    } else {
+                        decisionHandler(WKNavigationActionPolicyCancel);
+                    }
+                }
+            }
+
+            switch (_state) {
+                case STATE_WAITING_FOR_LOAD_FINISH:
+                    // Redirect case.
+                    // We expect loadCount == 1.
+                    if (_loadCount != 1) {
+                        NSLog(@"CDVWebViewDelegate: Detected redirect when loadCount=%ld", (long)_loadCount);
+                    }
+                    break;
+
+                case STATE_IDLE:
+                case STATE_IOS5_POLLING_FOR_LOAD_START:
+                case STATE_CANCELLED:
+                    // Page navigation start.
+                    _loadCount = 0;
+                    _state = STATE_WAITING_FOR_LOAD_START;
+                    break;
+
+                default:
+                    {
+                        NSString* description = [NSString stringWithFormat:@"CDVWebViewDelegate: Navigation started when state=%ld", (long)_state];
+                        NSLog(@"%@", description);
+                        _loadCount = 0;
+                        _state = STATE_WAITING_FOR_LOAD_START;
+                        if ([_delegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
+                            NSDictionary* errorDictionary = @{NSLocalizedDescriptionKey : description};
+                            NSError* error = [[NSError alloc] initWithDomain:@"CDVWKWebViewDelegate" code:1 userInfo:errorDictionary];
+                            [_delegate webView:webView didFailNavigation:nil withError:error];
+                        }
+                    }
+            }
+        } else {
+            // Deny invalid URLs so that we don't get the case where we go straight from
+            // webViewShouldLoad -> webViewDidFailLoad (messes up _loadCount).
+            shouldLoad = shouldLoad && [self shouldLoadRequest:request];
+        }
+        VerboseLog(@"webView decidePolicyForNavigationAction=%d (after) isTopLevelNavigation=%d state=%d loadCount=%d", shouldLoad, isTopLevelNavigation, _state, _loadCount);
+    }
+    if (shouldLoad) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+    } else {
+        decisionHandler(WKNavigationActionPolicyCancel);
+    }
+}
+
+- (void) webView:(WKWebView *) webView didStartProvisionalNavigation:(WKNavigation *) navigation
+{
+    VerboseLog(@"webView didStartProvisionalNavigation (before). state=%d loadCount=%d", _state, _loadCount);
+    BOOL fireCallback = NO;
+    switch (_state) {
+        case STATE_IDLE:
+            break;
+
+        case STATE_CANCELLED:
+            fireCallback = YES;
+            _state = STATE_WAITING_FOR_LOAD_FINISH;
+            _loadCount += 1;
+            break;
+
+        case STATE_WAITING_FOR_LOAD_START:
+            if (_loadCount != 0) {
+                NSLog(@"CDVWebViewDelegate: Unexpected loadCount in didStart. count=%ld", (long)_loadCount);
+            }
+            fireCallback = YES;
+            _state = STATE_WAITING_FOR_LOAD_FINISH;
+            _loadCount = 1;
+            break;
+
+        case STATE_WAITING_FOR_LOAD_FINISH:
+            _loadCount += 1;
+            break;
+
+        case STATE_IOS5_POLLING_FOR_LOAD_START:
+            [self pollForPageLoadStart:webView];
+            break;
+
+        case STATE_IOS5_POLLING_FOR_LOAD_FINISH:
+            [self pollForPageLoadFinish:webView];
+            break;
+
+        default:
+            NSLog(@"CDVWebViewDelegate: Unexpected didStart with state=%ld loadCount=%ld", (long)_state, (long)_loadCount);
+    }
+    VerboseLog(@"webView didStartProvisionalNavigation (after). state=%d loadCount=%d fireCallback=%d", _state, _loadCount, fireCallback);
+    if (fireCallback && [_delegate respondsToSelector:@selector(webView:didStartProvisionalNavigation:)]) {
+        [_delegate webView:webView didStartProvisionalNavigation:navigation];
+    }
+}
+
+- (void) webView:(WKWebView *) webView didFinishNavigation:(WKNavigation *) navigation
+{
+    VerboseLog(@"webView didFinishNavigation (before). state=%d loadCount=%d", _state, _loadCount);
+    BOOL fireCallback = NO;
+    switch (_state) {
+        case STATE_IDLE:
+            break;
+
+        case STATE_WAITING_FOR_LOAD_START:
+            NSLog(@"CDVWebViewDelegate: Unexpected didFinish while waiting for load start.");
+            break;
+
+        case STATE_WAITING_FOR_LOAD_FINISH:
+            if (_loadCount == 1) {
+                fireCallback = YES;
+                _state = STATE_IDLE;
+            }
+            _loadCount -= 1;
+            break;
+
+        case STATE_IOS5_POLLING_FOR_LOAD_START:
+            [self pollForPageLoadStart:webView];
+            break;
+
+        case STATE_IOS5_POLLING_FOR_LOAD_FINISH:
+            [self pollForPageLoadFinish:webView];
+            break;
+    }
+    VerboseLog(@"webView didFinishNavigation (after). state=%d loadCount=%d fireCallback=%d", _state, _loadCount, fireCallback);
+    if (fireCallback && [_delegate respondsToSelector:@selector(webView:didFinishNavigation:)]) {
+        [_delegate webView:webView didFinishNavigation:navigation];
+    }
+}
+
+- (void) webView:(WKWebView *) webView didFailNavigation:(WKNavigation *) navigation withError:(NSError *) error
+{
+    VerboseLog(@"webView didFailNavigation (before). state=%d loadCount=%d", _state, _loadCount);
+    BOOL fireCallback = NO;
+
+    switch (_state) {
+        case STATE_IDLE:
+            break;
+
+        case STATE_WAITING_FOR_LOAD_START:
+            if ([error code] == NSURLErrorCancelled) {
+                _state = STATE_CANCELLED;
+            } else {
+                _state = STATE_IDLE;
+            }
+            fireCallback = YES;
+            break;
+
+        case STATE_WAITING_FOR_LOAD_FINISH:
+            if ([error code] != NSURLErrorCancelled) {
+                if (_loadCount == 1) {
+                    _state = STATE_IDLE;
+                    fireCallback = YES;
+                }
+                _loadCount = -1;
+            } else {
+                fireCallback = YES;
+                _state = STATE_CANCELLED;
+                _loadCount -= 1;
+            }
+            break;
+
+        case STATE_IOS5_POLLING_FOR_LOAD_START:
+            [self pollForPageLoadStart:webView];
+            break;
+
+        case STATE_IOS5_POLLING_FOR_LOAD_FINISH:
+            [self pollForPageLoadFinish:webView];
+            break;
+    }
+    VerboseLog(@"webView didFailNavigation (after). state=%d loadCount=%d, fireCallback=%d", _state, _loadCount, fireCallback);
+    if (fireCallback && [_delegate respondsToSelector:@selector(webView:didFailNavigation:withError:)]) {
+        [_delegate webView:webView didFailNavigation:navigation withError:error];
+    }
+}
+
+- (NSString *) stringByEvaluatingJavaScriptFromString:(NSString *) script webView:(WKWebView *) webView
+{
+    __block NSString *resultString = nil;
+    __block BOOL finished = NO;
+    [webView evaluateJavaScript:script completionHandler:^(id result, NSError *error) {
+        if (error == nil) {
+            if (result != nil) {
+                resultString = [NSString stringWithFormat:@"%@", result];
+            }
+        } else {
+            NSLog(@"evaluateJavaScript error : %@", error.localizedDescription);
+        }
+        finished = YES;
+    }];
+    while (!finished) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+    }
+    return resultString;
+}
+
+@end

--- a/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewEngine.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewEngine.h
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Created by Bharath Hariharan on 7/15/16.
+ */
+
+#import "CDVPlugin.h"
+#import "CDVWebViewEngineProtocol.h"
+#import <WebKit/WebKit.h>
+
+@interface CDVWKWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol>
+
+@property (nonatomic, strong, readonly) id <WKNavigationDelegate> wkWebViewDelegate;
+
+@end

--- a/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewEngine.m
@@ -1,0 +1,182 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Created by Bharath Hariharan on 7/15/16.
+ */
+
+#import "CDVWKWebViewEngine.h"
+#import "CDVWKWebViewDelegate.h"
+#import "CDVWKWebViewNavigationDelegate.h"
+#import "NSDictionary+CordovaPreferences.h"
+
+#import <objc/message.h>
+
+@interface CDVWKWebViewEngine ()
+
+@property (nonatomic, strong, readwrite) UIView* engineWebView;
+@property (nonatomic, strong, readwrite) id <WKNavigationDelegate> wkWebViewDelegate;
+@property (nonatomic, strong, readwrite) CDVWKWebViewNavigationDelegate* navWebViewDelegate;
+
+@end
+
+@implementation CDVWKWebViewEngine
+
+@synthesize engineWebView = _engineWebView;
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super init];
+    if (self) {
+        self.engineWebView = [[WKWebView alloc] initWithFrame:frame];
+        NSLog(@"Using WKWebView");
+    }
+
+    return self;
+}
+
+- (void)pluginInitialize
+{
+    // viewController would be available now. we attempt to set all possible delegates to it, by default
+
+    WKWebView* wkWebView = (WKWebView*)_engineWebView;
+
+    if ([self.viewController conformsToProtocol:@protocol(WKNavigationDelegate)]) {
+        self.wkWebViewDelegate = [[CDVWKWebViewDelegate alloc] initWithDelegate:(id <WKNavigationDelegate>)self.viewController];
+        wkWebView.navigationDelegate = self.wkWebViewDelegate;
+    } else {
+        self.navWebViewDelegate = [[CDVWKWebViewNavigationDelegate alloc] initWithEnginePlugin:self];
+        self.wkWebViewDelegate = [[CDVWKWebViewDelegate alloc] initWithDelegate:self.navWebViewDelegate];
+        wkWebView.navigationDelegate = self.wkWebViewDelegate;
+    }
+
+    [self updateSettings:self.commandDelegate.settings];
+}
+
+- (void)evaluateJavaScript:(NSString*)javaScriptString completionHandler:(void (^)(id, NSError*))completionHandler
+{
+    [(WKWebView*) _engineWebView evaluateJavaScript:javaScriptString completionHandler:^(id result, NSError *error) {
+        if (completionHandler) {
+            completionHandler(result, error);
+        }
+    }];
+}
+
+- (id)loadRequest:(NSURLRequest*)request
+{
+    [(WKWebView*)_engineWebView loadRequest:request];
+    return nil;
+}
+
+- (id)loadHTMLString:(NSString*)string baseURL:(NSURL*)baseURL
+{
+    [(WKWebView*)_engineWebView loadHTMLString:string baseURL:baseURL];
+    return nil;
+}
+
+- (NSURL*)URL
+{
+    return [(WKWebView*)_engineWebView URL];
+}
+
+- (BOOL) canLoadRequest:(NSURLRequest*)request
+{
+    return (request != nil);
+}
+
+- (void)updateSettings:(NSDictionary*)settings
+{
+    WKWebView* wkWebView = (WKWebView*)_engineWebView;
+
+    wkWebView.configuration.allowsInlineMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowInlineMediaPlayback" defaultValue:NO];
+    wkWebView.configuration.mediaPlaybackRequiresUserAction = [settings cordovaBoolSettingForKey:@"MediaPlaybackRequiresUserAction" defaultValue:YES];
+    wkWebView.configuration.mediaPlaybackAllowsAirPlay = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
+    wkWebView.configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
+
+    id prefObj = nil;
+
+    // By default, DisallowOverscroll is false (thus bounce is allowed)
+    BOOL bounceAllowed = !([settings cordovaBoolSettingForKey:@"DisallowOverscroll" defaultValue:NO]);
+
+    // prevent webView from bouncing
+    if (!bounceAllowed) {
+        if ([wkWebView respondsToSelector:@selector(scrollView)]) {
+            ((UIScrollView*)[wkWebView scrollView]).bounces = NO;
+        } else {
+            for (id subview in self.webView.subviews) {
+                if ([[subview class] isSubclassOfClass:[UIScrollView class]]) {
+                    ((UIScrollView*)subview).bounces = NO;
+                }
+            }
+        }
+    }
+
+    NSString* decelerationSetting = [settings cordovaSettingForKey:@"UIWebViewDecelerationSpeed"];
+    if (![@"fast" isEqualToString:decelerationSetting]) {
+        [wkWebView.scrollView setDecelerationRate:UIScrollViewDecelerationRateNormal];
+    }
+
+    NSInteger paginationBreakingMode = 0; // default - UIWebPaginationBreakingModePage
+    prefObj = [settings cordovaSettingForKey:@"PaginationBreakingMode"];
+    if (prefObj != nil) {
+        NSArray* validValues = @[@"page", @"column"];
+        NSString* prefValue = [validValues objectAtIndex:0];
+
+        if ([prefObj isKindOfClass:[NSString class]]) {
+            prefValue = prefObj;
+        }
+
+        paginationBreakingMode = [validValues indexOfObject:[prefValue lowercaseString]];
+        if (paginationBreakingMode == NSNotFound) {
+            paginationBreakingMode = 0;
+        }
+    }
+}
+
+- (void)updateWithInfo:(NSDictionary*)info
+{
+    WKWebView* wkWebView = (WKWebView*)_engineWebView;
+
+    id <WKNavigationDelegate> wkWebViewDelegate = [info objectForKey:kCDVWebViewEngineWKNavigationDelegate];
+    NSDictionary* settings = [info objectForKey:kCDVWebViewEngineWebViewPreferences];
+
+    if (wkWebViewDelegate &&
+        [wkWebViewDelegate conformsToProtocol:@protocol(WKNavigationDelegate)]) {
+        self.wkWebViewDelegate = [[CDVWKWebViewDelegate alloc] initWithDelegate:(id <WKNavigationDelegate>)self.viewController];
+        wkWebView.navigationDelegate = self.wkWebViewDelegate;
+    }
+
+    if (settings && [settings isKindOfClass:[NSDictionary class]]) {
+        [self updateSettings:settings];
+    }
+}
+
+// This forwards the methods that are in the header that are not implemented here.
+// Both WKWebView and UIWebView implement the below:
+//     loadHTMLString:baseURL:
+//     loadRequest:
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+    return _engineWebView;
+}
+
+- (UIView*)webView
+{
+    return self.engineWebView;
+}
+
+@end

--- a/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewNavigationDelegate.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewNavigationDelegate.h
@@ -1,0 +1,31 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Created by Bharath Hariharan on 7/15/16.
+ */
+
+#import <WebKit/WebKit.h>
+#import "CDVWKWebViewEngine.h"
+
+@interface CDVWKWebViewNavigationDelegate : NSObject <WKNavigationDelegate>
+
+@property (nonatomic, weak) CDVPlugin* enginePlugin;
+
+- (instancetype)initWithEnginePlugin:(CDVPlugin*)enginePlugin;
+
+@end

--- a/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewNavigationDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWKWebViewEngine/CDVWKWebViewNavigationDelegate.m
@@ -1,0 +1,141 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Created by Bharath Hariharan on 7/15/16.
+ */
+
+#import "CDVWKWebViewNavigationDelegate.h"
+#import <Cordova/CDVViewController.h>
+#import <Cordova/CDVCommandDelegateImpl.h>
+#import <Cordova/CDVUserAgentUtil.h>
+#import <objc/message.h>
+
+@implementation CDVWKWebViewNavigationDelegate
+
+- (instancetype)initWithEnginePlugin:(CDVPlugin*)theEnginePlugin
+{
+    self = [super init];
+    if (self) {
+        self.enginePlugin = theEnginePlugin;
+    }
+
+    return self;
+}
+
+/**
+ When web application loads Add stuff to the DOM, mainly the user-defined settings from the Settings.plist file, and
+ the device's data such as device ID, platform version, etc.
+ */
+- (void) webView:(WKWebView *) webView didStartProvisionalNavigation:(WKNavigation *) navigation
+{
+    NSLog(@"Resetting plugins due to page load.");
+    CDVViewController* vc = (CDVViewController*)self.enginePlugin.viewController;
+
+    [vc.commandQueue resetRequestId];
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginResetNotification object:self.enginePlugin.webView]];
+}
+
+/**
+ Called when the webview finishes loading.  This stops the activity view.
+ */
+- (void) webView:(WKWebView *) theWebView didFinishNavigation:(WKNavigation *) navigation
+{
+    NSLog(@"Finished load of: %@", theWebView.URL);
+    CDVViewController* vc = (CDVViewController*)self.enginePlugin.viewController;
+
+    // It's safe to release the lock even if this is just a sub-frame that's finished loading.
+    [CDVUserAgentUtil releaseLock:vc.userAgentLockToken];
+
+    /*
+     * Hide the Top Activity THROBBER in the Battery Bar
+     */
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPageDidLoadNotification object:self.enginePlugin.webView]];
+}
+
+- (void) webView:(WKWebView *) webView didFailNavigation:(WKNavigation *) navigation withError:(NSError *) error
+{
+    [self webView:webView didFailLoadWithError:error];
+}
+
+- (void) webView:(WKWebView *) webView didFailProvisionalNavigation:(WKNavigation *) navigation withError:(NSError *) error
+{
+    [self webView:webView didFailLoadWithError:error];
+}
+
+- (void) webView:(WKWebView *) theWebView didFailLoadWithError:(NSError *) error
+{
+    CDVViewController* vc = (CDVViewController*)self.enginePlugin.viewController;
+
+    [CDVUserAgentUtil releaseLock:vc.userAgentLockToken];
+
+    NSString* message = [NSString stringWithFormat:@"Failed to load webpage with error: %@", [error localizedDescription]];
+    NSLog(@"%@", message);
+
+    NSURL* errorUrl = vc.errorURL;
+    if (errorUrl) {
+        errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] relativeToURL:errorUrl];
+        NSLog(@"%@", [errorUrl absoluteString]);
+        [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
+    }
+}
+
+- (BOOL)defaultResourcePolicyForURL:(NSURL*)url
+{
+    /*
+     * If a URL is being loaded that's a file url, just load it internally
+     */
+    if ([url isFileURL]) {
+        return YES;
+    }
+    
+    return NO;
+}
+
+- (void) webView:(WKWebView *) webView decidePolicyForNavigationAction:(WKNavigationAction *) navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy)) decisionHandler
+{
+    NSURL* url = navigationAction.request.URL;
+    CDVViewController* vc = (CDVViewController*)self.enginePlugin.viewController;
+
+    /*
+     * Execute any commands queued with cordova.exec() on the JS side.
+     * The part of the URL after gap:// is irrelevant.
+     */
+    if ([[url scheme] isEqualToString:@"gap"]) {
+        [vc.commandQueue fetchCommandsFromJs];
+        // The delegate is called asynchronously in this case, so we don't have to use
+        // flushCommandQueueWithDelayedJs (setTimeout(0)) as we do with hash changes.
+        [vc.commandQueue executePending];
+        decisionHandler(WKNavigationActionPolicyCancel);
+    }
+
+    /*
+     * Handle all other types of urls (tel:, sms:), and requests to load a url in the main webview.
+     */
+    BOOL shouldAllowNavigation = [self defaultResourcePolicyForURL:url];
+    if (shouldAllowNavigation) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+    } else {
+        [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
+    }
+    
+    decisionHandler(WKNavigationActionPolicyCancel);
+}
+
+@end

--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -61,6 +61,12 @@
 		7ED95D5A1AB9029B008C4574 /* NSMutableArray+QueueAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED95D341AB9029B008C4574 /* NSMutableArray+QueueAdditions.m */; };
 		A3B082D41BB15CEA00D8DC35 /* CDVGestureHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = A3B082D21BB15CEA00D8DC35 /* CDVGestureHandler.h */; };
 		A3B082D51BB15CEA00D8DC35 /* CDVGestureHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B082D31BB15CEA00D8DC35 /* CDVGestureHandler.m */; };
+		CE405C471D3DA85C00E6F889 /* CDVWKWebViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CE405C411D3DA85C00E6F889 /* CDVWKWebViewDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE405C481D3DA85C00E6F889 /* CDVWKWebViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CE405C421D3DA85C00E6F889 /* CDVWKWebViewDelegate.m */; };
+		CE405C491D3DA85C00E6F889 /* CDVWKWebViewEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = CE405C431D3DA85C00E6F889 /* CDVWKWebViewEngine.h */; };
+		CE405C4A1D3DA85C00E6F889 /* CDVWKWebViewEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = CE405C441D3DA85C00E6F889 /* CDVWKWebViewEngine.m */; };
+		CE405C4B1D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CE405C451D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.h */; };
+		CE405C4C1D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CE405C461D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -121,6 +127,12 @@
 		A3B082D21BB15CEA00D8DC35 /* CDVGestureHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVGestureHandler.h; sourceTree = "<group>"; };
 		A3B082D31BB15CEA00D8DC35 /* CDVGestureHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVGestureHandler.m; sourceTree = "<group>"; };
 		AA747D9E0F9514B9006C5449 /* CordovaLib_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CordovaLib_Prefix.pch; sourceTree = SOURCE_ROOT; };
+		CE405C411D3DA85C00E6F889 /* CDVWKWebViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDVWKWebViewDelegate.h; path = CDVWKWebViewEngine/CDVWKWebViewDelegate.h; sourceTree = "<group>"; };
+		CE405C421D3DA85C00E6F889 /* CDVWKWebViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDVWKWebViewDelegate.m; path = CDVWKWebViewEngine/CDVWKWebViewDelegate.m; sourceTree = "<group>"; };
+		CE405C431D3DA85C00E6F889 /* CDVWKWebViewEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDVWKWebViewEngine.h; path = CDVWKWebViewEngine/CDVWKWebViewEngine.h; sourceTree = "<group>"; };
+		CE405C441D3DA85C00E6F889 /* CDVWKWebViewEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDVWKWebViewEngine.m; path = CDVWKWebViewEngine/CDVWKWebViewEngine.m; sourceTree = "<group>"; };
+		CE405C451D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDVWKWebViewNavigationDelegate.h; path = CDVWKWebViewEngine/CDVWKWebViewNavigationDelegate.h; sourceTree = "<group>"; };
+		CE405C461D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDVWKWebViewNavigationDelegate.m; path = CDVWKWebViewEngine/CDVWKWebViewNavigationDelegate.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +191,7 @@
 		7ED95CF61AB9028C008C4574 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
+				CE405C401D3DA84B00E6F889 /* CDVWKWebViewEngine */,
 				A3B082D11BB15CEA00D8DC35 /* CDVGestureHandler */,
 				3093E2201B16D6A3003F381A /* CDVIntentAndNavigationFilter */,
 				7ED95CF71AB9028C008C4574 /* CDVHandleOpenURL */,
@@ -272,6 +285,19 @@
 			path = CDVGestureHandler;
 			sourceTree = "<group>";
 		};
+		CE405C401D3DA84B00E6F889 /* CDVWKWebViewEngine */ = {
+			isa = PBXGroup;
+			children = (
+				CE405C411D3DA85C00E6F889 /* CDVWKWebViewDelegate.h */,
+				CE405C421D3DA85C00E6F889 /* CDVWKWebViewDelegate.m */,
+				CE405C431D3DA85C00E6F889 /* CDVWKWebViewEngine.h */,
+				CE405C441D3DA85C00E6F889 /* CDVWKWebViewEngine.m */,
+				CE405C451D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.h */,
+				CE405C461D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.m */,
+			);
+			name = CDVWKWebViewEngine;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -299,6 +325,7 @@
 				7ED95D3A1AB9029B008C4574 /* CDVCommandDelegate.h in Headers */,
 				7ED95D391AB9029B008C4574 /* CDVAvailabilityDeprecated.h in Headers */,
 				7ED95D4E1AB9029B008C4574 /* CDVUserAgentUtil.h in Headers */,
+				CE405C4B1D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.h in Headers */,
 				7ED95D4A1AB9029B008C4574 /* CDVTimer.h in Headers */,
 				7ED95D3F1AB9029B008C4574 /* CDVConfigParser.h in Headers */,
 				7ED95D501AB9029B008C4574 /* CDVViewController.h in Headers */,
@@ -308,8 +335,10 @@
 				7E7F69B61ABA35D8007546F4 /* CDVLocalStorage.h in Headers */,
 				3093E2231B16D6A3003F381A /* CDVIntentAndNavigationFilter.h in Headers */,
 				7E7F69B81ABA368F007546F4 /* CDVUIWebViewEngine.h in Headers */,
+				CE405C491D3DA85C00E6F889 /* CDVWKWebViewEngine.h in Headers */,
 				7E7F69B91ABA3692007546F4 /* CDVHandleOpenURL.h in Headers */,
 				30193A511AE6350A0069A75F /* CDVUIWebViewNavigationDelegate.h in Headers */,
+				CE405C471D3DA85C00E6F889 /* CDVWKWebViewDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -370,6 +399,7 @@
 				7ED95D511AB9029B008C4574 /* CDVViewController.m in Sources */,
 				7ED95D581AB9029B008C4574 /* NSDictionary+CordovaPreferences.m in Sources */,
 				7ED95D371AB9029B008C4574 /* CDVAppDelegate.m in Sources */,
+				CE405C4A1D3DA85C00E6F889 /* CDVWKWebViewEngine.m in Sources */,
 				7ED95D0B1AB9028C008C4574 /* CDVUIWebViewDelegate.m in Sources */,
 				7ED95D3C1AB9029B008C4574 /* CDVCommandDelegateImpl.m in Sources */,
 				7ED95D041AB9028C008C4574 /* CDVJSON_private.m in Sources */,
@@ -387,8 +417,10 @@
 				7ED95D441AB9029B008C4574 /* CDVPlugin+Resources.m in Sources */,
 				7ED95D4D1AB9029B008C4574 /* CDVURLProtocol.m in Sources */,
 				7ED95D0D1AB9028C008C4574 /* CDVUIWebViewEngine.m in Sources */,
+				CE405C481D3DA85C00E6F889 /* CDVWKWebViewDelegate.m in Sources */,
 				7ED95D461AB9029B008C4574 /* CDVPlugin.m in Sources */,
 				7ED95D091AB9028C008C4574 /* CDVLocalStorage.m in Sources */,
+				CE405C4C1D3DA85C00E6F889 /* CDVWKWebViewNavigationDelegate.m in Sources */,
 				3093E2241B16D6A3003F381A /* CDVIntentAndNavigationFilter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This pull request adds a full implementation of the ```Cordova``` engine web view using ```WKWebView```. Currently, there's only a plugin that uses ```UIWebView```.