### PR TITLE
CB-9789: Support setting the default app locale

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -369,7 +369,7 @@ function updateIcons(cordovaProject, locations) {
 }
 
 function cleanIcons(projectRoot, projectConfig, locations) {
-    var icons = projectConfig.getIcons('android');
+    var icons = projectConfig.getIcons('ios');
     if (icons.length > 0) {
         var platformProjDir = path.relative(projectRoot, locations.xcodeCordovaProj);
         var iconsDir = getIconsDir(projectRoot, platformProjDir);
@@ -440,7 +440,7 @@ function updateSplashScreens(cordovaProject, locations) {
 }
 
 function cleanSplashScreens(projectRoot, projectConfig, locations) {
-    var splashScreens = projectConfig.getSplashScreens('android');
+    var splashScreens = projectConfig.getSplashScreens('ios');
     if (splashScreens.length > 0) {
         var platformProjDir = path.relative(projectRoot, locations.xcodeCordovaProj);
         var splashScreensDir = getSplashScreensDir(projectRoot, platformProjDir);

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -174,7 +174,7 @@ function updateProject(platformConfig, locations) {
     // because node and shell scripts handles unicode symbols differently
     // We need to normalize the name to NFD form since iOS uses NFD unicode form
     var name = unorm.nfd(platformConfig.name());
-    var pkg = platformConfig.ios_CFBundleIdentifier() || platformConfig.packageName();
+    var pkg = platformConfig.getAttribute('ios-CFBundleIdentifier') || platformConfig.packageName();
     var version = platformConfig.version();
 
     var originalName = path.basename(locations.xcodeCordovaProj);
@@ -186,8 +186,12 @@ function updateProject(platformConfig, locations) {
 
     // Update version (bundle version)
     infoPlist['CFBundleShortVersionString'] = version;
-    var CFBundleVersion = platformConfig.ios_CFBundleVersion() || default_CFBundleVersion(version);
+    var CFBundleVersion = platformConfig.getAttribute('ios-CFBundleVersion') || default_CFBundleVersion(version);
     infoPlist['CFBundleVersion'] = CFBundleVersion;
+
+    if (platformConfig.getAttribute('defaultlocale')) {
+        infoPlist['CFBundleDevelopmentRegion'] = platformConfig.getAttribute('defaultlocale');
+    }
 
     // replace Info.plist ATS entries according to <access> and <allow-navigation> config.xml entries
     var ats = writeATSEntries(platformConfig);

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -115,13 +115,27 @@ describe('prepare', function () {
             });
         });
         it('should write out the app id to info plist as CFBundleIdentifier', function(done) {
-            cfg.ios_CFBundleIdentifier = function() { return null; };
+            var orig = cfg.getAttribute;
+            cfg.getAttribute = function(name) {
+                if (name == 'ios-CFBundleIdentifier') {
+                    return null;
+                }
+                return orig.call(this, name);
+            };
+
             wrapper(updateProject(cfg, p.locations), done, function() {
                 expect(plist.build.mostRecentCall.args[0].CFBundleIdentifier).toEqual('testpkg');
             });
         });
         it('should write out the app id to info plist as CFBundleIdentifier with ios-CFBundleIdentifier', function(done) {
-            cfg.ios_CFBundleIdentifier = function() { return 'testpkg_ios'; };
+            var orig = cfg.getAttribute;
+            cfg.getAttribute = function(name) {
+                if (name == 'ios-CFBundleIdentifier') {
+                    return 'testpkg_ios';
+                }
+                return orig.call(this, name);
+            };
+
             wrapper(updateProject(cfg, p.locations), done, function() {
                 expect(plist.build.mostRecentCall.args[0].CFBundleIdentifier).toEqual('testpkg_ios');
             });


### PR DESCRIPTION
This allows adding a `defaultlocale="XX"` attribute to the `widget` tag in config.xml to set the CFBundleDevelopmentRegion to a different language. This allows native UI (like the camera plugin) to use a non-English locale.

Requires https://github.com/apache/cordova-lib/pull/466
References https://github.com/cordova/cordova-discuss/issues/25

/cc @jasongin for the bugfix in `cleanIcons` and `cleanSplashScreens`