### PR TITLE
CB-11703 - travis ci setup is still using 0.10.32 node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: objective-c
 sudo: false
-node_js:
-  - "4.2"
-  - "6.0"
+before_install:
+    - npm cache clean -f
+    - npm install -g n
+    - n stable
+    - node --version
 install:
     - npm install
     - npm install ios-deploy


### PR DESCRIPTION
installs npm module `n` and sets it to the `stable` version of node, which is 6.x currently