### PR TITLE
CB-11771 Deep symlink directories to target project instead of linking the directory itself

### DIFF
--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -53,7 +53,8 @@ var handlers = {
             if (!fs.existsSync(srcFile)) throw new CordovaError('Cannot find resource file "' + srcFile + '" for plugin ' + plugin.id + ' in iOS platform');
             if (fs.existsSync(destFile)) throw new CordovaError('File already exists at detination "' + destFile + '" for resource file specified by plugin ' + plugin.id + ' in iOS platform');
             project.xcode.addResourceFile(path.join('Resources', path.basename(src)));
-            shell.cp('-R', srcFile, project.resources_dir);
+            var link = !!(options && options.link);
+            copyFile(plugin.dir, src, project.projectDir, destFile, link);
         },
         uninstall:function(obj, plugin, project, options) {
             var src = obj.src,
@@ -84,8 +85,8 @@ var handlers = {
                 targetDir = path.resolve(project.plugins_dir, plugin.id, path.basename(src));
             if (!fs.existsSync(srcFile)) throw new CordovaError('Cannot find framework "' + srcFile + '" for plugin ' + plugin.id + ' in iOS platform');
             if (fs.existsSync(targetDir)) throw new CordovaError('Framework "' + targetDir + '" for plugin ' + plugin.id + ' already exists in iOS platform');
-            shell.mkdir('-p', path.dirname(targetDir));
-            shell.cp('-R', srcFile, path.dirname(targetDir)); // frameworks are directories
+            var link = !!(options && options.link);
+            copyFile(plugin.dir, src, project.projectDir, targetDir, link); // frameworks are directories
             // CB-10773 translate back slashes to forward on win32
             var project_relative = fixPathSep(path.relative(project.projectDir, targetDir));
             var pbxFile = project.xcode.addFramework(project_relative, {customFramework: true});

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -70,7 +70,7 @@ var handlers = {
             if (!custom) {
                 var keepFrameworks = keep_these_frameworks;
 
-                if (keepFrameworks.indexOf(src) < 0) { 
+                if (keepFrameworks.indexOf(src) < 0) {
                     if (obj.type === 'podspec') {
                         //podspec handled in Api.js
                     } else {
@@ -110,7 +110,7 @@ var handlers = {
                             }
                         }
                     } else {
-                        //this should be refactored 
+                        //this should be refactored
                         project.frameworks[src] = project.frameworks[src] || 1;
                         project.frameworks[src]--;
                         if (project.frameworks[src] < 1) {
@@ -307,7 +307,7 @@ function copyFile (plugin_dir, src, project_dir, dest, link) {
         symlinkFileOrDirTree(src, dest);
     } else if (fs.statSync(src).isDirectory()) {
         // XXX shelljs decides to create a directory when -R|-r is used which sucks. http://goo.gl/nbsjq
-        shell.cp('-Rf', src+'/*', dest);
+        shell.cp('-Rf', path.join(src, '/*'), dest);
     } else {
         shell.cp('-f', src, dest);
     }

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -215,7 +215,16 @@ describe('ios plugin handler', function() {
                 var resources = copyArray(valid_resources);
                 var spy = spyOn(shell, 'cp');
                 install(resources[0], dummyPluginInfo, dummyProject);
-                expect(spy).toHaveBeenCalledWith('-R', path.join(dummyplugin, 'src', 'ios', 'DummyPlugin.bundle'), path.join(temp, 'SampleApp', 'Resources'));
+                expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'DummyPlugin.bundle'), path.join(temp, 'SampleApp', 'Resources', 'DummyPlugin.bundle'));
+            });
+            it('should symlink files to the right target location', function() {
+                var resources = copyArray(valid_resources);
+                var spy = spyOn(fs, 'symlinkSync');
+                install(resources[0], dummyPluginInfo, dummyProject, { link: true });
+                var src_bundle = path.join(dummyplugin, 'src', 'ios', 'DummyPlugin.bundle');
+                var dest_bundle = path.join(temp, 'SampleApp/Resources/DummyPlugin.bundle');
+                expect(spy).toHaveBeenCalledWith(path.relative(fs.realpathSync(path.dirname(dest_bundle)), src_bundle),
+                                                    dest_bundle);
             });
         });
 
@@ -256,8 +265,17 @@ describe('ios plugin handler', function() {
                     var frameworks = copyArray(valid_custom_frameworks);
                     var spy = spyOn(shell, 'cp');
                     install(frameworks[0], dummyPluginInfo, dummyProject);
-                    expect(spy).toHaveBeenCalledWith('-R', path.join(dummyplugin, 'src', 'ios', 'Custom.framework'),
-                                                     path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin'));
+                    expect(spy).toHaveBeenCalledWith('-Rf', path.join(dummyplugin, 'src', 'ios', 'Custom.framework', '*'),
+                                                     path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'));
+                });
+                it('should deep symlink files to the right target location', function() {
+                    var frameworks = copyArray(valid_custom_frameworks);
+                    var spy = spyOn(fs, 'symlinkSync');
+                    install(frameworks[0], dummyPluginInfo, dummyProject, { link: true });
+                    var src_binlib = path.join(dummyplugin, 'src', 'ios', 'Custom.framework', 'somebinlib');
+                    var dest_binlib = path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework/somebinlib');
+                    expect(spy).toHaveBeenCalledWith(path.relative(fs.realpathSync(path.dirname(dest_binlib)), src_binlib),
+                                                     dest_binlib);
                 });
             });
         });


### PR DESCRIPTION
When installing a plugin with custom library using the --link option the whole directory is symlinked and temporary
files leak into the original plugin directory on build. This leads to broken builds if the same plugin is linked in
2 projects targeting different Cordova versions.

fixes [CB-11771 Installing plugin with symlink option pollutes original directory with intermediate files](https://issues.apache.org/jira/browse/CB-11771)