### PR TITLE
CB-11712 - <name> changes in config.xml does a 'search and replace all' for occurrences of the old name with the new name in the pbxproj

### DIFF
--- a/tests/spec/unit/fixtures/dummyProj/config.xml
+++ b/tests/spec/unit/fixtures/dummyProj/config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <widget id="io.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-    <name>HelloCordova</name>
+    <name>SampleApp</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.
     </description>


### PR DESCRIPTION
The error message looks like this:
```
Error: The product name change (<name> tag) in config.xml is not supported dynamically.
To change your product name, you have to remove, then add your ios platform again.
Make sure you save your plugins beforehand using `cordova plugin save`.
       	cordova plugin save
       	cordova platform rm ios
       	cordova platform add ios
```

Not sure if I'm supposed to be hardcoding `cordova` for downstream distributions.