### PR TITLE
CB-11831 - Add missing LD_RUNPATH_SEARCH_PATHS setting to the Release build

### DIFF
--- a/bin/templates/project/__TEMP__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__TEMP__.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "__PROJECT_NAME__/__PROJECT_NAME__-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				PRODUCT_NAME = "__PROJECT_NAME__";
 			};
 			name = Release;


### PR DESCRIPTION
Swift support is enabled and working in the Debug build configuration, but it's broken in the Release build configuration.

This patch enables Swift plugins also on the Release build configuration.