### PR TITLE
Expose CDVCommandStatus enum to Swift

### DIFF
--- a/CordovaLib/Classes/Public/CDVPluginResult.h
+++ b/CordovaLib/Classes/Public/CDVPluginResult.h
@@ -20,18 +20,35 @@
 #import <Foundation/Foundation.h>
 #import "CDVAvailability.h"
 
-typedef enum {
-    CDVCommandStatus_NO_RESULT = 0,
-    CDVCommandStatus_OK,
-    CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION,
-    CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION,
-    CDVCommandStatus_INSTANTIATION_EXCEPTION,
-    CDVCommandStatus_MALFORMED_URL_EXCEPTION,
-    CDVCommandStatus_IO_EXCEPTION,
-    CDVCommandStatus_INVALID_ACTION,
-    CDVCommandStatus_JSON_EXCEPTION,
-    CDVCommandStatus_ERROR
-} CDVCommandStatus;
+typedef NS_ENUM(NSUInteger, CDVCommandStatus) {
+    CDVCommandStatus_NO_RESULT NS_SWIFT_NAME(noResult) = 0,
+    CDVCommandStatus_OK NS_SWIFT_NAME(ok),
+    CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION NS_SWIFT_NAME(classNotFoundException),
+    CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION NS_SWIFT_NAME(illegalAccessException),
+    CDVCommandStatus_INSTANTIATION_EXCEPTION NS_SWIFT_NAME(instantiationException),
+    CDVCommandStatus_MALFORMED_URL_EXCEPTION NS_SWIFT_NAME(malformedUrlException),
+    CDVCommandStatus_IO_EXCEPTION NS_SWIFT_NAME(ioException),
+    CDVCommandStatus_INVALID_ACTION NS_SWIFT_NAME(invalidAction),
+    CDVCommandStatus_JSON_EXCEPTION NS_SWIFT_NAME(jsonException),
+    CDVCommandStatus_ERROR NS_SWIFT_NAME(error)
+};
+
+// This exists to preserve compatibility with early Swift plugins, who are
+// using CDVCommandStatus as ObjC-style constants rather than as Swift enum
+// values.
+// This declares extern'ed constants (implemented in CDVPluginResult.m)
+#define SWIFT_ENUM_COMPAT_HACK(enumVal) extern const CDVCommandStatus SWIFT_##enumVal NS_SWIFT_NAME(enumVal)
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_NO_RESULT);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_OK);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INSTANTIATION_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_MALFORMED_URL_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_IO_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INVALID_ACTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_JSON_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ERROR);
+#undef SWIFT_ENUM_COMPAT_HACK
 
 @interface CDVPluginResult : NSObject {}
 

--- a/CordovaLib/Classes/Public/CDVPluginResult.m
+++ b/CordovaLib/Classes/Public/CDVPluginResult.m
@@ -21,6 +21,23 @@
 #import "CDVJSON_private.h"
 #import "CDVDebug.h"
 
+// This exists to preserve compatibility with early Swift plugins, who are
+// using CDVCommandStatus as ObjC-style constants rather than as Swift enum
+// values.
+// These constants alias the enum values back to their previous names.
+#define SWIFT_ENUM_COMPAT_HACK(enumVal) const CDVCommandStatus SWIFT_##enumVal NS_SWIFT_NAME(enumVal) = enumVal
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_NO_RESULT);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_OK);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INSTANTIATION_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_MALFORMED_URL_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_IO_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INVALID_ACTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_JSON_EXCEPTION);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ERROR);
+#undef SWIFT_ENUM_COMPAT_HACK
+
 @interface CDVPluginResult ()
 
 - (CDVPluginResult*)initWithStatus:(CDVCommandStatus)statusOrdinal message:(id)theMessage;


### PR DESCRIPTION
This allows Swift plugins to write code like 

``` swift
CDVPluginResult(status: .error)
```

rather than 

``` swift
CDVPluginResult(status: CDVCommandStatus_ERROR)
```

Its use in Objective C is unchanged, but ~this is a **API breaking change** as far as Swift plugins are concerned (so we'd be looking at cordova-ios 6 to land this)~ I've hacked it to support both the existing name and the "friendly" name in Swift, at the cost of the code making sense 😕 
