### PR TITLE
Undefined error when calling run directly (not via the CLI)

### DIFF
--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -74,8 +74,12 @@ module.exports.run = function (runOptions) {
         if (useDevice) {
             return checkDeviceConnected().then(function () {
                 appPath = path.join(projectPath, 'build', 'device', projectName + '.app');
-                // argv.slice(2) removes node and run.js, filterSupportedArgs removes the run.js args
-                return deployToDevice(appPath, runOptions.target, filterSupportedArgs(runOptions.argv.slice(2)));
+                var extraArgs = [];
+                if (runOptions.argv) {
+                     // argv.slice(2) removes node and run.js, filterSupportedArgs removes the run.js args
+                     extraArgs = filterSupportedArgs(runOptions.argv.slice(2));
+                }
+                return deployToDevice(appPath, runOptions.target, extraArgs);
             }, function () {
                 // if device connection check failed use emulator then
                 return deployToSim(appPath, runOptions.target);


### PR DESCRIPTION
runOptions.argv is only supplied by the CLI.

This proposed change will prevent issues for projects which call this library directly.