### PR TITLE
CB-11860 - Update packaging strategy for Xcode 8

### DIFF
--- a/bin/templates/scripts/cordova/build
+++ b/bin/templates/scripts/cordova/build
@@ -43,6 +43,7 @@ var buildOpts = nopt({
     'codeSignResourceRules': String,
     'provisioningProfile': String,
     'developmentTeam': String,
+    'packageType': String,
     'buildConfig' : String,
     'noSign' : Boolean
 }, { '-r': '--release', 'd' : '--verbose' }, args);

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -89,8 +89,15 @@ module.exports.run = function (buildOpts) {
         events.emit('log','\tConfiguration: ' + configuration);
         events.emit('log','\tPlatform: ' + (buildOpts.device ? 'device' : 'emulator'));
 
-        var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device);
-        return spawn('xcodebuild', xcodebuildArgs, projectPath);
+        var buildOutputDir = path.join(projectPath, 'build', 'device');
+
+        // remove the build/device folder before building
+        return spawn('rm', [ '-rf', buildOutputDir ], projectPath)
+        .then(function() {
+            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device);
+            return spawn('xcodebuild', xcodebuildArgs, projectPath);
+        });
+
     }).then(function () {
         if (!buildOpts.device || buildOpts.noSign) {
             return;

--- a/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
+++ b/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
@@ -208,7 +208,6 @@
 				686357A4141002F100DF4CF2 /* Sources */,
 				686357A5141002F100DF4CF2 /* Frameworks */,
 				686357A6141002F100DF4CF2 /* Resources */,
-				686357A7141002F100DF4CF2 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -289,19 +288,6 @@
 			shellPath = /bin/sh;
 			shellScript = "cp ../../CordovaLib/cordova.js \"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/www/cordova.js\"";
 			showEnvVarsInLog = 0;
-		};
-		686357A7141002F100DF4CF2 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Background info on the mailing list: https://lists.apache.org/thread.html/85a715681471c774821d76a90ec288943eca1a4bb0a267ba299d2eb3@%3Cdev.cordova.apache.org%3E

Mostly just opened for review now, and getting any feedback or comments. Tests will probably fail, and will be updated after review.

A note that using xcodebuild for exporting the archive requires using the system installation of Ruby, so if you're an RVM user then you'll need to `rvm use system` first. I'm looking to see if there's a way we can work around this.

/cc @shazron 