### PR TITLE
CB-10078 fixed by refreshing cached userAgent on version bump

### DIFF
--- a/CordovaLib/Classes/Public/CDVUserAgentUtil.m
+++ b/CordovaLib/Classes/Public/CDVUserAgentUtil.m
@@ -45,7 +45,9 @@ static NSMutableArray* gPendingSetUserAgentBlocks = nil;
         NSString* localeStr = [[NSLocale currentLocale] localeIdentifier];
         // Record the model since simulator can change it without re-install (CB-5420).
         NSString* model = [UIDevice currentDevice].model;
-        NSString* systemAndLocale = [NSString stringWithFormat:@"%@ %@ %@", model, systemVersion, localeStr];
+        // Record the version of the app so that we can bust the cache when it changes (CB-10078)
+        NSString* appVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
+        NSString* systemAndLocale = [NSString stringWithFormat:@"%@ %@ %@ %@", appVersion, model, systemVersion, localeStr];
 
         NSString* cordovaUserAgentVersion = [userDefaults stringForKey:kCdvUserAgentVersionKey];
         gOriginalUserAgent = [userDefaults stringForKey:kCdvUserAgentKey];


### PR DESCRIPTION
Adds app version to the list of items that invalidates the cached user agent.