### PR TITLE
CB-11952 - Introduce buildFlag option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .*.sw?
+.vscode
 *.cso
 tmp
 *.mode1v3
@@ -13,6 +14,7 @@ node_modules/istanbul
 node_modules/.bin/cake
 node_modules/.bin/codecov
 node_modules/.bin/coffee
+node_modules/.bin/color-support
 node_modules/.bin/coveralls
 node_modules/.bin/escodegen
 node_modules/.bin/esgenerate
@@ -49,7 +51,10 @@ node_modules/argparse/
 node_modules/asn1/
 node_modules/assert-plus/
 node_modules/async/
+node_modules/asynckit/
 node_modules/aws-sign2/
+node_modules/aws4/
+node_modules/bcrypt-pbkdf/
 node_modules/bl/
 node_modules/bluebird/
 node_modules/boom/
@@ -63,6 +68,7 @@ node_modules/cli/
 node_modules/cliui/
 node_modules/codecov.io/
 node_modules/coffee-script/
+node_modules/color-support/
 node_modules/combined-stream/
 node_modules/commander/
 node_modules/console-browserify/
@@ -102,6 +108,7 @@ node_modules/fileset/
 node_modules/foreground-child/
 node_modules/forever-agent/
 node_modules/form-data/
+node_modules/fs.realpath/
 node_modules/gaze/
 node_modules/generate-function/
 node_modules/generate-object-property/
@@ -152,6 +159,7 @@ node_modules/oauth-sign/
 node_modules/only-shallow/
 node_modules/opener/
 node_modules/optimist/
+node_modules/optional/
 node_modules/optionator/
 node_modules/pinkie-promise/
 node_modules/pinkie/

--- a/bin/templates/scripts/cordova/build
+++ b/bin/templates/scripts/cordova/build
@@ -45,6 +45,7 @@ var buildOpts = nopt({
     'developmentTeam': String,
     'packageType': String,
     'buildConfig' : String,
+    'buildFlag' : [String, Array],
     'noSign' : Boolean
 }, { '-r': '--release', 'd' : '--verbose' }, args);
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -23,7 +23,8 @@ var Q     = require('q'),
     path  = require('path'),
     shell = require('shelljs'),
     spawn = require('./spawn'),
-    check_reqs = require('./check_reqs'),
+    optional = require('optional'),
+    check_reqs = optional('./check_reqs') || optional('../../../../lib/check_reqs'),
     fs = require('fs'),
     plist = require('plist');
 
@@ -31,6 +32,19 @@ var events = require('cordova-common').events;
 
 var projectPath = path.join(__dirname, '..', '..');
 var projectName = null;
+
+// These are regular expressions to detect if the user is changing any of the built-in xcodebuildArgs
+var buildFlagMatchers = {
+    'xcconfig' : /^\-xcconfig\s*(.*)$/,
+    'project' : /^\-project\s*(.*)/,
+    'archs' : /^(ARCHS=.*)/,
+    'target' : /^\-target\s*(.*)/,
+    'configuration' : /^\-configuration\s*(.*)/,
+    'sdk' : /^\-sdk\s*(.*)/,
+    'valid_archs' : /^(VALID_ARCHS=.*)/,
+    'configuration_build_dir' : /^(CONFIGURATION_BUILD_DIR=.*)/,
+    'shared_precomps_dir' : /^(SHARED_PRECOMPS_DIR=.*)/
+};
 
 module.exports.run = function (buildOpts) {
 
@@ -94,7 +108,7 @@ module.exports.run = function (buildOpts) {
         // remove the build/device folder before building
         return spawn('rm', [ '-rf', buildOutputDir ], projectPath)
         .then(function() {
-            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device);
+            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag);
             return spawn('xcodebuild', xcodebuildArgs, projectPath);
         });
 
@@ -199,33 +213,54 @@ module.exports.findXCodeProjectIn = findXCodeProjectIn;
  * @param  {Boolean} isDevice      Flag that specify target for package (device/emulator)
  * @return {Array}                 Array of arguments that could be passed directly to spawn method
  */
-function getXcodeBuildArgs(projectName, projectPath, configuration, isDevice) {
+function getXcodeBuildArgs(projectName, projectPath, configuration, isDevice, buildFlags) {
     var xcodebuildArgs;
+    var options;
+    var buildActions = [ 'build' ];
+    var settings;
+    var customArgs = {};
+    customArgs.otherFlags = [];
+
+    if (buildFlags) {
+        if (typeof buildFlags === 'string' || buildFlags instanceof String) {
+            parseBuildFlag(buildFlags, customArgs);
+        } else { // buildFlags is an Array of strings
+            buildFlags.forEach( function(flag) {
+                parseBuildFlag(flag, customArgs);
+            });
+        }
+    }
+    
     if (isDevice) {
-        xcodebuildArgs = [
-            '-xcconfig', path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
-            '-workspace', projectName + '.xcworkspace',
-            '-scheme', projectName,
-            '-configuration', configuration,
-            '-destination', 'generic/platform=iOS',
-            '-archivePath', projectName + '.xcarchive',
-            'archive',
-            'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'device'),
-            'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
+        options = [
+            '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
+            '-project',  customArgs.project || projectName + '.xcodeproj',
+            customArgs.archs || 'ARCHS=armv7 arm64',
+            '-target', customArgs.target || projectName,
+            '-configuration', customArgs.configuration || configuration,
+            '-sdk', customArgs.sdk || 'iphoneos'
+        ];
+        settings = [
+            customArgs.valid_archs || 'VALID_ARCHS=armv7 arm64',
+            customArgs.configuration_build_dir || 'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'device'),
+            customArgs.shared_precomps_dir || 'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
         ];
     } else { // emulator
-        xcodebuildArgs = [
-            '-xcconfig', path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
-            '-workspace', projectName + '.xcworkspace',
-            '-scheme', projectName ,
-            '-configuration', configuration,
-            '-sdk', 'iphonesimulator',
-            '-destination', 'platform=iOS Simulator,name=iPhone 5s',
-            'build',
-            'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'emulator'),
-            'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
+        options = [
+            '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
+            '-project', customArgs.project || projectName + '.xcodeproj',
+            customArgs.archs || 'ARCHS=x86_64 i386',
+            '-target', customArgs.target || projectName,
+            '-configuration', customArgs.configuration || configuration,
+            '-sdk', customArgs.sdk || 'iphonesimulator'
+        ];
+        settings = [
+            customArgs.valid_archs || 'VALID_ARCHS=x86_64 i386',
+            customArgs.configuration_build_dir || 'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'emulator'),
+            customArgs.shared_precomps_dir || 'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
         ];
     }
+    xcodebuildArgs = options.concat(buildActions).concat(settings).concat(customArgs.otherFlags);
     return xcodebuildArgs;
 }
 
@@ -247,6 +282,31 @@ function getXcodeArchiveArgs(projectName, projectPath, outputPath, exportOptions
   ];
 }
 
+function parseBuildFlag(buildFlag, args) {
+    var matched;
+    for (var key in buildFlagMatchers) {
+        var found = buildFlag.match(buildFlagMatchers[key]);
+        if (found) {
+            matched = true;
+            // found[0] is the whole match, found[1] is the first match in parentheses.
+            args[key] = found[1];
+            events.emit('warn','Overriding xcodebuildArg: ', buildFlag);
+        }
+    }
+
+    if (!matched) {
+        // If the flag starts with a '-' then it is an xcodebuild built-in option or a
+        // user-defined setting. The regex makes sure that we don't split a user-defined
+        // setting that is wrapped in quotes. 
+        if (buildFlag[0] === '-' && !buildFlag.match(/^.*=(\".*\")|(\'.*\')$/)) {
+            args.otherFlags = args.otherFlags.concat(buildFlag.split(' '));
+            events.emit('warn','Adding xcodebuildArg: ', buildFlag.split(' '));
+        } else {
+            args.otherFlags.push(buildFlag);
+            events.emit('warn','Adding xcodebuildArg: ', buildFlag);
+        }
+    }
+}
 
 // help/usage function
 module.exports.help = function help() {

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -24,7 +24,8 @@ var Q     = require('q'),
     shell = require('shelljs'),
     spawn = require('./spawn'),
     fs = require('fs'),
-    plist = require('plist');
+    plist = require('plist'),
+    util = require('util');
 
 var check_reqs;
 try {
@@ -296,7 +297,7 @@ function parseBuildFlag(buildFlag, args) {
             matched = true;
             // found[0] is the whole match, found[1] is the first match in parentheses.
             args[key] = found[1];
-            events.emit('warn','Overriding xcodebuildArg: ', buildFlag);
+            events.emit('warn', util.format('Overriding xcodebuildArg: %s', buildFlag));
         }
     }
 
@@ -306,10 +307,10 @@ function parseBuildFlag(buildFlag, args) {
         // setting that is wrapped in quotes. 
         if (buildFlag[0] === '-' && !buildFlag.match(/^.*=(\".*\")|(\'.*\')$/)) {
             args.otherFlags = args.otherFlags.concat(buildFlag.split(' '));
-            events.emit('warn','Adding xcodebuildArg: ', buildFlag.split(' '));
+            events.emit('warn', util.format('Adding xcodebuildArg: %s', buildFlag.split(' ')));
         } else {
             args.otherFlags.push(buildFlag);
-            events.emit('warn','Adding xcodebuildArg: ', buildFlag);
+            events.emit('warn', util.format('Adding xcodebuildArg: %s', buildFlag));
         }
     }
 }

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -23,10 +23,16 @@ var Q     = require('q'),
     path  = require('path'),
     shell = require('shelljs'),
     spawn = require('./spawn'),
-    optional = require('optional'),
-    check_reqs = optional('./check_reqs') || optional('../../../../lib/check_reqs'),
     fs = require('fs'),
     plist = require('plist');
+
+var check_reqs;
+try {
+    check_reqs = require('./check_reqs');
+} catch (err) {
+    // For unit tests, check_reqs.js is not a sibling to build.js
+    check_reqs = require('../../../../lib/check_reqs');
+}
 
 var events = require('cordova-common').events;
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -43,12 +43,11 @@ var projectName = null;
 // These are regular expressions to detect if the user is changing any of the built-in xcodebuildArgs
 var buildFlagMatchers = {
     'xcconfig' : /^\-xcconfig\s*(.*)$/,
-    'project' : /^\-project\s*(.*)/,
-    'archs' : /^(ARCHS=.*)/,
-    'target' : /^\-target\s*(.*)/,
+    'workspace' : /^\-workspace\s*(.*)/,
+    'scheme' : /^\-scheme\s*(.*)/,
     'configuration' : /^\-configuration\s*(.*)/,
+    'destination' : /^\-destination\s*(.*)/,
     'sdk' : /^\-sdk\s*(.*)/,
-    'valid_archs' : /^(VALID_ARCHS=.*)/,
     'configuration_build_dir' : /^(CONFIGURATION_BUILD_DIR=.*)/,
     'shared_precomps_dir' : /^(SHARED_PRECOMPS_DIR=.*)/
 };
@@ -241,28 +240,26 @@ function getXcodeBuildArgs(projectName, projectPath, configuration, isDevice, bu
     if (isDevice) {
         options = [
             '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
-            '-project',  customArgs.project || projectName + '.xcodeproj',
-            customArgs.archs || 'ARCHS=armv7 arm64',
-            '-target', customArgs.target || projectName,
+            '-workspace',  customArgs.workspace || projectName + '.xcworkspace',
+            '-scheme', customArgs.scheme || projectName,
             '-configuration', customArgs.configuration || configuration,
-            '-sdk', customArgs.sdk || 'iphoneos'
+            '-sdk', customArgs.sdk || 'iphoneos',
+            '-destination', customArgs.destination || 'generic/platform=iOS'
         ];
         settings = [
-            customArgs.valid_archs || 'VALID_ARCHS=armv7 arm64',
             customArgs.configuration_build_dir || 'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'device'),
             customArgs.shared_precomps_dir || 'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
         ];
     } else { // emulator
         options = [
             '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
-            '-project', customArgs.project || projectName + '.xcodeproj',
-            customArgs.archs || 'ARCHS=x86_64 i386',
-            '-target', customArgs.target || projectName,
+            '-workspace', customArgs.project || projectName + '.xcworkspace',
+            '-scheme', customArgs.scheme || projectName,
             '-configuration', customArgs.configuration || configuration,
-            '-sdk', customArgs.sdk || 'iphonesimulator'
+            '-sdk', customArgs.sdk || 'iphonesimulator',
+            '-destination', customArgs.destination || 'platform=iOS Simulator,name=iPhone 5s'
         ];
         settings = [
-            customArgs.valid_archs || 'VALID_ARCHS=x86_64 i386',
             customArgs.configuration_build_dir || 'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'emulator'),
             customArgs.shared_precomps_dir || 'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
         ];

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cordova-common": "^1.4.0",
     "ios-sim": "^5.0.7",
     "nopt": "^3.0.6",
+    "optional": "^0.1.3",
     "plist": "^1.2.0",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "cordova-common": "^1.4.0",
     "ios-sim": "^5.0.7",
     "nopt": "^3.0.6",
-    "optional": "^0.1.3",
     "plist": "^1.2.0",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -1,0 +1,255 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+var path = require('path');
+var rewire = require('rewire');
+var build = rewire('../../../bin/templates/scripts/cordova/lib/build');
+
+describe('build', function () {
+    var testProjectPath = path.join('/test', 'project', 'path');
+
+    describe('getXcodeBuildArgs method', function() {
+
+        var getXcodeBuildArgs = build.__get__('getXcodeBuildArgs');
+        build.__set__('__dirname', path.join('/test', 'dir'));
+
+        it('should generate appropriate args if a single buildFlag is passed in', function(done) {
+            var isDevice = true;
+            var buildFlags = '-xcconfig TestXcconfigFlag';
+
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
+            expect(args[0]).toEqual('-xcconfig');
+            expect(args[1]).toEqual('TestXcconfigFlag');
+            expect(args[2]).toEqual('-project');
+            expect(args[3]).toEqual('TestProjectName.xcodeproj');
+            expect(args[4]).toEqual('ARCHS=armv7 arm64');
+            expect(args[5]).toEqual('-target');
+            expect(args[6]).toEqual('TestProjectName');
+            expect(args[7]).toEqual('-configuration');
+            expect(args[8]).toEqual('TestConfiguration');
+            expect(args[9]).toEqual('-sdk');
+            expect(args[10]).toEqual('iphoneos');
+            expect(args[11]).toEqual('build');
+            expect(args[12]).toEqual('VALID_ARCHS=armv7 arm64');
+            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
+            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
+            expect(args.length).toEqual(15);
+            done();
+        });
+
+        it('should generate appropriate args if buildFlags are passed in', function(done) {
+            var isDevice = true;
+            var buildFlags = [
+                '-xcconfig TestXcconfigFlag',
+                '-project TestProjectFlag',
+                'ARCHS=TestArchsFlag',
+                '-target TestTargetFlag',
+                '-configuration TestConfigurationFlag',
+                '-sdk TestSdkFlag',
+                'VALID_ARCHS=TestValidArchsFlag',
+                'CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag',
+                'SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag'
+            ];
+
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
+            expect(args[0]).toEqual('-xcconfig');
+            expect(args[1]).toEqual('TestXcconfigFlag');
+            expect(args[2]).toEqual('-project');
+            expect(args[3]).toEqual('TestProjectFlag');
+            expect(args[4]).toEqual('ARCHS=TestArchsFlag');
+            expect(args[5]).toEqual('-target');
+            expect(args[6]).toEqual('TestTargetFlag');
+            expect(args[7]).toEqual('-configuration');
+            expect(args[8]).toEqual('TestConfigurationFlag');
+            expect(args[9]).toEqual('-sdk');
+            expect(args[10]).toEqual('TestSdkFlag');
+            expect(args[11]).toEqual('build');
+            expect(args[12]).toEqual('VALID_ARCHS=TestValidArchsFlag');
+            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag');
+            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag');
+            expect(args.length).toEqual(15);
+            done();
+        });
+
+        it('should generate appropriate args for device', function(done) {
+            var isDevice = true;
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null);
+            expect(args[0]).toEqual('-xcconfig');
+            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
+            expect(args[2]).toEqual('-project');
+            expect(args[3]).toEqual('TestProjectName.xcodeproj');
+            expect(args[4]).toEqual('ARCHS=armv7 arm64');
+            expect(args[5]).toEqual('-target');
+            expect(args[6]).toEqual('TestProjectName');
+            expect(args[7]).toEqual('-configuration');
+            expect(args[8]).toEqual('TestConfiguration');
+            expect(args[9]).toEqual('-sdk');
+            expect(args[10]).toEqual('iphoneos');
+            expect(args[11]).toEqual('build');
+            expect(args[12]).toEqual('VALID_ARCHS=armv7 arm64');
+            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
+            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
+            expect(args.length).toEqual(15);
+            done();
+        });
+
+        it('should generate appropriate args for simulator', function(done) {
+            var isDevice = false;
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null);
+            expect(args[0]).toEqual('-xcconfig');
+            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
+            expect(args[2]).toEqual('-project');
+            expect(args[3]).toEqual('TestProjectName.xcodeproj');
+            expect(args[4]).toEqual('ARCHS=x86_64 i386');
+            expect(args[5]).toEqual('-target');
+            expect(args[6]).toEqual('TestProjectName');
+            expect(args[7]).toEqual('-configuration');
+            expect(args[8]).toEqual('TestConfiguration');
+            expect(args[9]).toEqual('-sdk');
+            expect(args[10]).toEqual('iphonesimulator');
+            expect(args[11]).toEqual('build');
+            expect(args[12]).toEqual('VALID_ARCHS=x86_64 i386');
+            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'));
+            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
+            expect(args.length).toEqual(15);
+            done();
+        });
+    });
+
+    describe('getXcodeArchiveArgs method', function() {
+
+        var getXcodeArchiveArgs = build.__get__('getXcodeArchiveArgs');
+
+        it('should generate the appropriate arguments', function(done) {
+            var archiveArgs = getXcodeArchiveArgs('TestProjectName', testProjectPath, '/test/output/path', '/test/export/options/path');
+            expect(archiveArgs[0]).toEqual('-exportArchive');
+            expect(archiveArgs[1]).toEqual('-archivePath');
+            expect(archiveArgs[2]).toEqual('TestProjectName.xcarchive');
+            expect(archiveArgs[3]).toEqual('-exportOptionsPlist');
+            expect(archiveArgs[4]).toEqual('/test/export/options/path');
+            expect(archiveArgs[5]).toEqual('-exportPath');
+            expect(archiveArgs[6]).toEqual('/test/output/path');
+            expect(archiveArgs.length).toEqual(7);
+            done();
+        });
+    });
+
+    describe('parseBuildFlag method', function() {
+
+        var parseBuildFlag = build.__get__('parseBuildFlag');
+
+        it('should detect an xcconfig change', function(done) {
+            var buildFlag = '-xcconfig /path/to/config';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.xcconfig).toEqual('/path/to/config');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect a project change', function(done) {
+            var buildFlag = '-project MyTestProject';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.project).toEqual('MyTestProject');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect an archs change', function(done) {
+            var buildFlag = 'ARCHS=NotRealArchitectures';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.archs).toEqual('ARCHS=NotRealArchitectures');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect a target change', function(done) {
+            var buildFlag = '-target MyTestTarget';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.target).toEqual('MyTestTarget');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect a configuration change', function(done) {
+            var buildFlag = '-configuration MyTestConfiguration';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.configuration).toEqual('MyTestConfiguration');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect an sdk change', function(done) {
+            var buildFlag = '-sdk NotARealSDK';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.sdk).toEqual('NotARealSDK');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect a valid_archs change', function(done) {
+            var buildFlag = 'VALID_ARCHS=NotRealArchitectures';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.valid_archs).toEqual('VALID_ARCHS=NotRealArchitectures');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect a configuration_build_dir change', function(done) {
+            var buildFlag = 'CONFIGURATION_BUILD_DIR=/path/to/fake/config/build/dir';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.configuration_build_dir).toEqual('CONFIGURATION_BUILD_DIR=/path/to/fake/config/build/dir');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect a shared_precomps_dir change', function(done) {
+            var buildFlag = 'SHARED_PRECOMPS_DIR=/path/to/fake/shared/precomps/dir';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.shared_precomps_dir).toEqual('SHARED_PRECOMPS_DIR=/path/to/fake/shared/precomps/dir');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should parse arbitrary build settings', function(done) {
+            var buildFlag = 'MY_ARBITRARY_BUILD_SETTING=ValueOfArbitraryBuildSetting';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.otherFlags[0]).toEqual('MY_ARBITRARY_BUILD_SETTING=ValueOfArbitraryBuildSetting');
+            expect(args.otherFlags.length).toEqual(1);
+            done();
+        });
+        it('should parse userdefaults', function(done) {
+            var buildFlag = '-myuserdefault=TestUserDefaultValue';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.otherFlags[0]).toEqual('-myuserdefault=TestUserDefaultValue');
+            expect(args.otherFlags.length).toEqual(1);
+            done();
+        });
+        it('should parse settings with a space', function(done) {
+            var buildFlag = '-anotherxcodebuildsetting withASpace';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.otherFlags[0]).toEqual('-anotherxcodebuildsetting');
+            expect(args.otherFlags[1]).toEqual('withASpace');
+            expect(args.otherFlags.length).toEqual(2);
+            done();
+        });
+    });
+});

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -36,17 +36,17 @@ describe('build', function () {
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
             expect(args[0]).toEqual('-xcconfig');
             expect(args[1]).toEqual('TestXcconfigFlag');
-            expect(args[2]).toEqual('-project');
-            expect(args[3]).toEqual('TestProjectName.xcodeproj');
-            expect(args[4]).toEqual('ARCHS=armv7 arm64');
-            expect(args[5]).toEqual('-target');
-            expect(args[6]).toEqual('TestProjectName');
-            expect(args[7]).toEqual('-configuration');
-            expect(args[8]).toEqual('TestConfiguration');
-            expect(args[9]).toEqual('-sdk');
-            expect(args[10]).toEqual('iphoneos');
-            expect(args[11]).toEqual('build');
-            expect(args[12]).toEqual('VALID_ARCHS=armv7 arm64');
+            expect(args[2]).toEqual('-workspace');
+            expect(args[3]).toEqual('TestProjectName.xcworkspace');
+            expect(args[4]).toEqual('-scheme');
+            expect(args[5]).toEqual('TestProjectName');
+            expect(args[6]).toEqual('-configuration');
+            expect(args[7]).toEqual('TestConfiguration');
+            expect(args[8]).toEqual('-sdk');
+            expect(args[9]).toEqual('iphoneos');
+            expect(args[10]).toEqual('-destination');
+            expect(args[11]).toEqual('generic/platform=iOS');
+            expect(args[12]).toEqual('build');
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
             expect(args.length).toEqual(15);
@@ -57,12 +57,11 @@ describe('build', function () {
             var isDevice = true;
             var buildFlags = [
                 '-xcconfig TestXcconfigFlag',
-                '-project TestProjectFlag',
-                'ARCHS=TestArchsFlag',
-                '-target TestTargetFlag',
+                '-workspace TestWorkspaceFlag',
+                '-scheme TestSchemeFlag',
                 '-configuration TestConfigurationFlag',
                 '-sdk TestSdkFlag',
-                'VALID_ARCHS=TestValidArchsFlag',
+                '-destination TestDestinationFlag',
                 'CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag',
                 'SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag'
             ];
@@ -70,17 +69,17 @@ describe('build', function () {
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
             expect(args[0]).toEqual('-xcconfig');
             expect(args[1]).toEqual('TestXcconfigFlag');
-            expect(args[2]).toEqual('-project');
-            expect(args[3]).toEqual('TestProjectFlag');
-            expect(args[4]).toEqual('ARCHS=TestArchsFlag');
-            expect(args[5]).toEqual('-target');
-            expect(args[6]).toEqual('TestTargetFlag');
-            expect(args[7]).toEqual('-configuration');
-            expect(args[8]).toEqual('TestConfigurationFlag');
-            expect(args[9]).toEqual('-sdk');
-            expect(args[10]).toEqual('TestSdkFlag');
-            expect(args[11]).toEqual('build');
-            expect(args[12]).toEqual('VALID_ARCHS=TestValidArchsFlag');
+            expect(args[2]).toEqual('-workspace');
+            expect(args[3]).toEqual('TestWorkspaceFlag');
+            expect(args[4]).toEqual('-scheme');
+            expect(args[5]).toEqual('TestSchemeFlag');
+            expect(args[6]).toEqual('-configuration');
+            expect(args[7]).toEqual('TestConfigurationFlag');
+            expect(args[8]).toEqual('-sdk');
+            expect(args[9]).toEqual('TestSdkFlag');
+            expect(args[10]).toEqual('-destination');
+            expect(args[11]).toEqual('TestDestinationFlag');
+            expect(args[12]).toEqual('build');
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag');
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag');
             expect(args.length).toEqual(15);
@@ -92,17 +91,17 @@ describe('build', function () {
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null);
             expect(args[0]).toEqual('-xcconfig');
             expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
-            expect(args[2]).toEqual('-project');
-            expect(args[3]).toEqual('TestProjectName.xcodeproj');
-            expect(args[4]).toEqual('ARCHS=armv7 arm64');
-            expect(args[5]).toEqual('-target');
-            expect(args[6]).toEqual('TestProjectName');
-            expect(args[7]).toEqual('-configuration');
-            expect(args[8]).toEqual('TestConfiguration');
-            expect(args[9]).toEqual('-sdk');
-            expect(args[10]).toEqual('iphoneos');
-            expect(args[11]).toEqual('build');
-            expect(args[12]).toEqual('VALID_ARCHS=armv7 arm64');
+            expect(args[2]).toEqual('-workspace');
+            expect(args[3]).toEqual('TestProjectName.xcworkspace');
+            expect(args[4]).toEqual('-scheme');
+            expect(args[5]).toEqual('TestProjectName');
+            expect(args[6]).toEqual('-configuration');
+            expect(args[7]).toEqual('TestConfiguration');
+            expect(args[8]).toEqual('-sdk');
+            expect(args[9]).toEqual('iphoneos');
+            expect(args[10]).toEqual('-destination');
+            expect(args[11]).toEqual('generic/platform=iOS');
+            expect(args[12]).toEqual('build');
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
             expect(args.length).toEqual(15);
@@ -114,17 +113,17 @@ describe('build', function () {
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null);
             expect(args[0]).toEqual('-xcconfig');
             expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
-            expect(args[2]).toEqual('-project');
-            expect(args[3]).toEqual('TestProjectName.xcodeproj');
-            expect(args[4]).toEqual('ARCHS=x86_64 i386');
-            expect(args[5]).toEqual('-target');
-            expect(args[6]).toEqual('TestProjectName');
-            expect(args[7]).toEqual('-configuration');
-            expect(args[8]).toEqual('TestConfiguration');
-            expect(args[9]).toEqual('-sdk');
-            expect(args[10]).toEqual('iphonesimulator');
-            expect(args[11]).toEqual('build');
-            expect(args[12]).toEqual('VALID_ARCHS=x86_64 i386');
+            expect(args[2]).toEqual('-workspace');
+            expect(args[3]).toEqual('TestProjectName.xcworkspace');
+            expect(args[4]).toEqual('-scheme');
+            expect(args[5]).toEqual('TestProjectName');
+            expect(args[6]).toEqual('-configuration');
+            expect(args[7]).toEqual('TestConfiguration');
+            expect(args[8]).toEqual('-sdk');
+            expect(args[9]).toEqual('iphonesimulator');
+            expect(args[10]).toEqual('-destination');
+            expect(args[11]).toEqual('platform=iOS Simulator,name=iPhone 5s');
+            expect(args[12]).toEqual('build');
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'));
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
             expect(args.length).toEqual(15);
@@ -162,27 +161,19 @@ describe('build', function () {
             expect(args.otherFlags.length).toEqual(0);
             done();
         });
-        it('should detect a project change', function(done) {
-            var buildFlag = '-project MyTestProject';
+        it('should detect a workspace change', function(done) {
+            var buildFlag = '-workspace MyTestWorkspace';
             var args = { 'otherFlags': [] };
             parseBuildFlag(buildFlag, args);
-            expect(args.project).toEqual('MyTestProject');
+            expect(args.workspace).toEqual('MyTestWorkspace');
             expect(args.otherFlags.length).toEqual(0);
             done();
         });
-        it('should detect an archs change', function(done) {
-            var buildFlag = 'ARCHS=NotRealArchitectures';
+        it('should detect a scheme change', function(done) {
+            var buildFlag = '-scheme MyTestScheme';
             var args = { 'otherFlags': [] };
             parseBuildFlag(buildFlag, args);
-            expect(args.archs).toEqual('ARCHS=NotRealArchitectures');
-            expect(args.otherFlags.length).toEqual(0);
-            done();
-        });
-        it('should detect a target change', function(done) {
-            var buildFlag = '-target MyTestTarget';
-            var args = { 'otherFlags': [] };
-            parseBuildFlag(buildFlag, args);
-            expect(args.target).toEqual('MyTestTarget');
+            expect(args.scheme).toEqual('MyTestScheme');
             expect(args.otherFlags.length).toEqual(0);
             done();
         });
@@ -202,11 +193,11 @@ describe('build', function () {
             expect(args.otherFlags.length).toEqual(0);
             done();
         });
-        it('should detect a valid_archs change', function(done) {
-            var buildFlag = 'VALID_ARCHS=NotRealArchitectures';
+        it('should detect a destination change', function(done) {
+            var buildFlag = '-destination MyTestDestination';
             var args = { 'otherFlags': [] };
             parseBuildFlag(buildFlag, args);
-            expect(args.valid_archs).toEqual('VALID_ARCHS=NotRealArchitectures');
+            expect(args.destination).toEqual('MyTestDestination');
             expect(args.otherFlags.length).toEqual(0);
             done();
         });

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -42,11 +42,11 @@ describe('build', function () {
             expect(args[5]).toEqual('TestProjectName');
             expect(args[6]).toEqual('-configuration');
             expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-sdk');
-            expect(args[9]).toEqual('iphoneos');
-            expect(args[10]).toEqual('-destination');
-            expect(args[11]).toEqual('generic/platform=iOS');
-            expect(args[12]).toEqual('build');
+            expect(args[8]).toEqual('-destination');
+            expect(args[9]).toEqual('generic/platform=iOS');
+            expect(args[10]).toEqual('-archivePath');
+            expect(args[11]).toEqual('TestProjectName.xcarchive');
+            expect(args[12]).toEqual('archive');
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
             expect(args.length).toEqual(15);
@@ -60,8 +60,8 @@ describe('build', function () {
                 '-workspace TestWorkspaceFlag',
                 '-scheme TestSchemeFlag',
                 '-configuration TestConfigurationFlag',
-                '-sdk TestSdkFlag',
                 '-destination TestDestinationFlag',
+                '-archivePath TestArchivePathFlag',
                 'CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag',
                 'SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag'
             ];
@@ -75,11 +75,11 @@ describe('build', function () {
             expect(args[5]).toEqual('TestSchemeFlag');
             expect(args[6]).toEqual('-configuration');
             expect(args[7]).toEqual('TestConfigurationFlag');
-            expect(args[8]).toEqual('-sdk');
-            expect(args[9]).toEqual('TestSdkFlag');
-            expect(args[10]).toEqual('-destination');
-            expect(args[11]).toEqual('TestDestinationFlag');
-            expect(args[12]).toEqual('build');
+            expect(args[8]).toEqual('-destination');
+            expect(args[9]).toEqual('TestDestinationFlag');
+            expect(args[10]).toEqual('-archivePath');
+            expect(args[11]).toEqual('TestArchivePathFlag');
+            expect(args[12]).toEqual('archive');
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag');
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag');
             expect(args.length).toEqual(15);
@@ -97,11 +97,11 @@ describe('build', function () {
             expect(args[5]).toEqual('TestProjectName');
             expect(args[6]).toEqual('-configuration');
             expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-sdk');
-            expect(args[9]).toEqual('iphoneos');
-            expect(args[10]).toEqual('-destination');
-            expect(args[11]).toEqual('generic/platform=iOS');
-            expect(args[12]).toEqual('build');
+            expect(args[8]).toEqual('-destination');
+            expect(args[9]).toEqual('generic/platform=iOS');
+            expect(args[10]).toEqual('-archivePath');
+            expect(args[11]).toEqual('TestProjectName.xcarchive');
+            expect(args[12]).toEqual('archive');
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
             expect(args.length).toEqual(15);
@@ -127,6 +127,58 @@ describe('build', function () {
             expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'));
             expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
             expect(args.length).toEqual(15);
+            done();
+        });
+
+        it('should add matched flags that are not overriding for device', function(done) {
+            var isDevice = true;
+            var buildFlags = '-sdk TestSdkFlag';
+
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
+            expect(args[0]).toEqual('-xcconfig');
+            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
+            expect(args[2]).toEqual('-workspace');
+            expect(args[3]).toEqual('TestProjectName.xcworkspace');
+            expect(args[4]).toEqual('-scheme');
+            expect(args[5]).toEqual('TestProjectName');
+            expect(args[6]).toEqual('-configuration');
+            expect(args[7]).toEqual('TestConfiguration');
+            expect(args[8]).toEqual('-destination');
+            expect(args[9]).toEqual('generic/platform=iOS');
+            expect(args[10]).toEqual('-archivePath');
+            expect(args[11]).toEqual('TestProjectName.xcarchive');
+            expect(args[12]).toEqual('archive');
+            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
+            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
+            expect(args[15]).toEqual('-sdk');
+            expect(args[16]).toEqual('TestSdkFlag');
+            expect(args.length).toEqual(17);
+            done();
+        });
+
+        it('should add matched flags that are not overriding for simulator', function(done) {
+            var isDevice = false;
+            var buildFlags = '-archivePath TestArchivePathFlag';
+
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
+            expect(args[0]).toEqual('-xcconfig');
+            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
+            expect(args[2]).toEqual('-workspace');
+            expect(args[3]).toEqual('TestProjectName.xcworkspace');
+            expect(args[4]).toEqual('-scheme');
+            expect(args[5]).toEqual('TestProjectName');
+            expect(args[6]).toEqual('-configuration');
+            expect(args[7]).toEqual('TestConfiguration');
+            expect(args[8]).toEqual('-sdk');
+            expect(args[9]).toEqual('iphonesimulator');
+            expect(args[10]).toEqual('-destination');
+            expect(args[11]).toEqual('platform=iOS Simulator,name=iPhone 5s');
+            expect(args[12]).toEqual('build');
+            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'));
+            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
+            expect(args[15]).toEqual('-archivePath');
+            expect(args[16]).toEqual('TestArchivePathFlag');
+            expect(args.length).toEqual(17);
             done();
         });
     });
@@ -198,6 +250,14 @@ describe('build', function () {
             var args = { 'otherFlags': [] };
             parseBuildFlag(buildFlag, args);
             expect(args.destination).toEqual('MyTestDestination');
+            expect(args.otherFlags.length).toEqual(0);
+            done();
+        });
+        it('should detect an archivePath change', function(done) {
+            var buildFlag = '-archivePath MyTestArchivePath';
+            var args = { 'otherFlags': [] };
+            parseBuildFlag(buildFlag, args);
+            expect(args.archivePath).toEqual('MyTestArchivePath');
             expect(args.otherFlags.length).toEqual(0);
             done();
         });


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?

- adds buildFlag option for passing args to xcodebuild
- There can be multiple --buildFlag declarations
- Warns if buildFlag would override a built-in setting

### What testing has been done on this change?

- Added unit tests for build.js
- I have tried this out with by passing various legal and illegal flags using the --buildFlag option. I used the xcodebuild man page to develop test cases.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
