### PR TITLE
CB-11729 - template file MainViewController.m has deprecated override shouldAutorotateToInterfaceOrientation

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
@@ -84,18 +84,27 @@
     // e.g. self.myOutlet = nil;
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
-{
-    // Return YES for supported orientations
-    return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];
-}
-
 /* Comment out the block below to over-ride */
 
 /*
 - (UIWebView*) newCordovaViewWithFrame:(CGRect)bounds
 {
     return[super newCordovaViewWithFrame:bounds];
+}
+
+- (NSUInteger)supportedInterfaceOrientations 
+{
+    return [super supportedInterfaceOrientations];
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation 
+{
+    return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+}
+
+- (BOOL)shouldAutorotate 
+{
+    return [super shouldAutorotate];
 }
 */
 


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?

Remove unused selector in MainViewController subclass, add in comments the new overrides available.

### What testing has been done on this change?

Local build

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
