### PR TITLE
CB-11970 - Support CocoaPod pod specification other than version

### DIFF
--- a/tests/spec/unit/Podfile.spec.js
+++ b/tests/spec/unit/Podfile.spec.js
@@ -101,6 +101,7 @@ describe('unit tests for Podfile module', function () {
 			podfile.addSpec('Foo', '1.0');
 			podfile.addSpec('Bar', '2.0');
 			podfile.addSpec('Baz', '3.0');
+			podfile.addSpec('Bla', ':configurations => [\'Debug\', \'Beta\']');
 
 			podfile.write();
 
@@ -109,11 +110,12 @@ describe('unit tests for Podfile module', function () {
 			expect(newPodfile.existsSpec('Foo')).toBe(true);
 			expect(newPodfile.existsSpec('Bar')).toBe(true);
 			expect(newPodfile.existsSpec('Baz')).toBe(true);
+			expect(newPodfile.existsSpec('Bla')).toBe(true);
 
 			expect(newPodfile.getSpec('Foo')).toBe(podfile.getSpec('Foo'));
 			expect(newPodfile.getSpec('Bar')).toBe(podfile.getSpec('Bar'));
 			expect(newPodfile.getSpec('Baz')).toBe(podfile.getSpec('Baz'));
-			
+			expect(newPodfile.getSpec('Bla')).toBe(podfile.getSpec('Bla'));
 		});
 
 		it ('runs before_install to install xcconfig paths', function () {


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Add support for CocoaPod specs that are not just versions, but other specifications.

i.e.
```
<framework src="MyPod" type="podspec" spec=":configurations => ['Debug', 'Beta']" />
<framework src="MyVersionedPod" type="podspec" spec="1.2" />
```

### What testing has been done on this change?

npm run unit-tests

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

