### PR TITLE
CB-12118 - Cordova run ios does not automatically deploy to device

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -84,7 +84,17 @@ module.exports.run = function (buildOpts) {
         }
     }
 
-    return check_reqs.run().then(function () {
+return require('./list-devices').run()
+   .then(function (devices) {
+        if (devices.length > 0 && !(buildOpts.emulator)) {
+            // we also explicitly set device flag in options as we pass
+            // those parameters to other api (build as an example)
+            buildOpts.device = true;
+            return check_reqs.check_ios_deploy();
+        }
+    }).then(function () {
+        return check_reqs.run();
+    }).then(function () {
         return findXCodeProjectIn(projectPath);
     }).then(function (name) {
         projectName = name;


### PR DESCRIPTION
### Platforms affected

self

### What does this PR do?

When you have a device connected, "cordova run ios" does not build for device, only for emulator.
The logic to detect that a device is connected is only in the run phase, not the build phase, thus it was failing.

### What testing has been done on this change?

Manual add of platform, then "cordova platform run ios" with device connected and disconnected, and adding "--emulator" and "--device" flag combinations.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

