### PR TITLE
CB-12127 - Add buildFlag support in build.json

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -76,7 +76,7 @@ module.exports.run = function (buildOpts) {
             var buildType = buildOpts.release ? 'release' : 'debug';
             var config = buildConfig.ios[buildType];
             if(config) {
-                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType'].forEach(
+                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag'].forEach(
                     function(key) {
                         buildOpts[key] = buildOpts[key] || config[key];
                     });


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Add build.json support for the "buildFlag" key. The value for the key can be an array or a string. Analogous to the "buildFlag" command line option.

### What testing has been done on this change?

Manual testing.


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.

