### PR TITLE
CB-12130 - Launch storyboard images are not updated or cleaned

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -685,7 +685,7 @@ function getLaunchStoryboardImagesDir(projectRoot, platformProjDir) {
  */
 function updateLaunchStoryboardImages(cordovaProject, locations) {
     var splashScreens = cordovaProject.projectConfig.getSplashScreens('ios');
-    var platformProjDir = locations.xcodeCordovaProj;
+    var platformProjDir = path.relative(cordovaProject.root, locations.xcodeCordovaProj);
     var launchStoryboardImagesDir = getLaunchStoryboardImagesDir(cordovaProject.root, platformProjDir);
 
     if (launchStoryboardImagesDir) {
@@ -712,7 +712,7 @@ function updateLaunchStoryboardImages(cordovaProject, locations) {
  */
 function cleanLaunchStoryboardImages(projectRoot, projectConfig, locations) {
     var splashScreens = projectConfig.getSplashScreens('ios');
-    var platformProjDir = locations.xcodeCordovaProj;
+    var platformProjDir = path.relative(projectRoot, locations.xcodeCordovaProj);
     var launchStoryboardImagesDir = getLaunchStoryboardImagesDir(projectRoot, platformProjDir);
     if (launchStoryboardImagesDir) {
         var resourceMap = mapLaunchStoryboardResources(splashScreens, launchStoryboardImagesDir);


### PR DESCRIPTION
Launch storyboard images were not updated or cleaned in
`updateLaunchStoryboardImages()` or `cleanLaunchStoryboardImages()`
because the check for `Images.xcassets` in
`getLaunchStoryboardImagesDir()` failed.

The reason was that the `platformProjDir` and `projectRoot` were
joined, while both were relative to the root directory. So the
resulting directory was non-sensical. This changes makes
`platformProjDir` relative to `cordovaProject.root`, which matches the
same check in `updateSplashScreens()` and `updateIcons()`.