### PR TITLE
CB-11243: Fix target-device and deployment-target preferences

### DIFF
--- a/bin/templates/project/__TEMP__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__TEMP__.xcodeproj/project.pbxproj
@@ -303,7 +303,9 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "__PROJECT_NAME__/__PROJECT_NAME__-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				PRODUCT_NAME = "__PROJECT_NAME__";
 			};
 			name = Debug;
@@ -323,7 +325,9 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "__PROJECT_NAME__/__PROJECT_NAME__-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				PRODUCT_NAME = "__PROJECT_NAME__";
 			};
 			name = Release;

--- a/bin/templates/scripts/cordova/build.xcconfig
+++ b/bin/templates/scripts/cordova/build.xcconfig
@@ -23,9 +23,7 @@
 //
 
 HEADER_SEARCH_PATHS = "$(TARGET_BUILD_DIR)/usr/local/lib/include" "$(OBJROOT)/UninstalledProducts/include" "$(OBJROOT)/UninstalledProducts/$(PLATFORM_NAME)/include" "$(BUILT_PRODUCTS_DIR)"
-IPHONEOS_DEPLOYMENT_TARGET = 8.0
 OTHER_LDFLAGS = -ObjC
-TARGETED_DEVICE_FAMILY = 1,2
 
 // Type of signing identity used for codesigning, resolves to first match of given type.
 // "iPhone Developer": Development builds (default, local only; iOS Development certificate) or "iPhone Distribution": Distribution builds (Adhoc/In-House/AppStore; iOS Distribution certificate)

--- a/tests/spec/unit/fixtures/test-config-2.xml
+++ b/tests/spec/unit/fixtures/test-config-2.xml
@@ -11,6 +11,8 @@
 
     <platform name="ios">
         <preference name="orientation" value="all" />
+        <preference name="target-device" value="handset" />
+        <preference name="deployment-target" value="8.0" />
     </platform>
 
     <access origin="http://*.apache.org" />


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?

Fixes target-device and deployment-target preferences. There are several bugs reporting this issue. [CB-11243](https://issues.apache.org/jira/browse/CB-11243) [CB-11399](https://issues.apache.org/jira/browse/CB-11399) [CB-11772](https://issues.apache.org/jira/browse/CB-11772) [CB-11732](https://issues.apache.org/jira/browse/CB-11732)

This change adds `IPHONEOS_DEPLOYMENT_TARGET` and `TARGETED_DEVICE_FAMILY` back to the project file. This is necessary for the preferences to work until [CB-11468](https://issues.apache.org/jira/browse/CB-11468) is completed.


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

