### PR TITLE
CB-11243 - Added failing tests

### DIFF
--- a/tests/spec/unit/fixtures/test-config-2.xml
+++ b/tests/spec/unit/fixtures/test-config-2.xml
@@ -11,6 +11,8 @@
 
     <platform name="ios">
         <preference name="orientation" value="all" />
+        <preference name="target-device" value="handset" />
+        <preference name="deployment-target" value="8.0" />
     </platform>
 
     <access origin="http://*.apache.org" />

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -106,6 +106,36 @@ describe('prepare', function () {
             // restore cfg2 original name
             cfg2.name = cfg2OriginalName;
         });
+        it('should write target-device preference', function(done) {
+            var cfg2OriginalName = cfg2.name;
+            cfg2.name = function() { return 'SampleApp'; }; // new config does *not* have a name change
+
+            wrapper(updateProject(cfg2, p.locations), done, function() {
+                var xcode = require('xcode');
+                var proj = new xcode.project(p.locations.pbxproj);
+                proj.parseSync();
+                var prop = proj.getBuildProperty('TARGETED_DEVICE_FAMILY');
+                expect(prop).toEqual('"1"'); // 1 is handset
+
+                // restore cfg2 original name
+                cfg2.name = cfg2OriginalName;
+            });
+        });
+        it('should write deployment-target preference', function(done) {
+            var cfg2OriginalName = cfg2.name;
+            cfg2.name = function() { return 'SampleApp'; }; // new config does *not* have a name change
+
+            wrapper(updateProject(cfg2, p.locations), done, function() {
+                var xcode = require('xcode');
+                var proj = new xcode.project(p.locations.pbxproj);
+                proj.parseSync();
+                var prop = proj.getBuildProperty('IPHONEOS_DEPLOYMENT_TARGET'); 
+                expect(prop).toEqual('8.0');
+
+                // restore cfg2 original name
+                cfg2.name = cfg2OriginalName;
+            });
+        });
         it('should write out the app id to info plist as CFBundleIdentifier', function(done) {
             var orig = cfg.getAttribute;
             cfg.getAttribute = function(name) {


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Added failing tests for `target-device` and `deployment-target` preferences on cordova-ios. 

### What testing has been done on this change?

`npm run unit-tests`

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

