### PR TITLE
CB-12247: Hard link instead of soft linking

### DIFF
--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -304,7 +304,7 @@ function copyFile (plugin_dir, src, project_dir, dest, link) {
     shell.mkdir('-p', path.dirname(dest));
 
     if (link) {
-        symlinkFileOrDirTree(src, dest);
+        linkFileOrDirTree(src, dest);
     } else if (fs.statSync(src).isDirectory()) {
         // XXX shelljs decides to create a directory when -R|-r is used which sucks. http://goo.gl/nbsjq
         shell.cp('-Rf', path.join(src, '/*'), dest);
@@ -322,7 +322,7 @@ function copyNewFile (plugin_dir, src, project_dir, dest, link) {
     copyFile(plugin_dir, src, project_dir, dest, !!link);
 }
 
-function symlinkFileOrDirTree(src, dest) {
+function linkFileOrDirTree(src, dest) {
     if (fs.existsSync(dest)) {
         shell.rm('-Rf', dest);
     }
@@ -330,11 +330,11 @@ function symlinkFileOrDirTree(src, dest) {
     if (fs.statSync(src).isDirectory()) {
         shell.mkdir('-p', dest);
         fs.readdirSync(src).forEach(function(entry) {
-            symlinkFileOrDirTree(path.join(src, entry), path.join(dest, entry));
+            linkFileOrDirTree(path.join(src, entry), path.join(dest, entry));
         });
     }
     else {
-        fs.symlinkSync(path.relative(fs.realpathSync(path.dirname(dest)), src), dest);
+        fs.linkSync(src, dest);
     }
 }
 

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -217,14 +217,13 @@ describe('ios plugin handler', function() {
                 install(resources[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'DummyPlugin.bundle'), path.join(temp, 'SampleApp', 'Resources', 'DummyPlugin.bundle'));
             });
-            it('should symlink files to the right target location', function() {
+            it('should link files to the right target location', function() {
                 var resources = copyArray(valid_resources);
-                var spy = spyOn(fs, 'symlinkSync');
+                var spy = spyOn(fs, 'linkSync');
                 install(resources[0], dummyPluginInfo, dummyProject, { link: true });
                 var src_bundle = path.join(dummyplugin, 'src', 'ios', 'DummyPlugin.bundle');
                 var dest_bundle = path.join(temp, 'SampleApp/Resources/DummyPlugin.bundle');
-                expect(spy).toHaveBeenCalledWith(path.relative(fs.realpathSync(path.dirname(dest_bundle)), src_bundle),
-                                                    dest_bundle);
+                expect(spy).toHaveBeenCalledWith(src_bundle, dest_bundle);
             });
         });
 
@@ -268,14 +267,13 @@ describe('ios plugin handler', function() {
                     expect(spy).toHaveBeenCalledWith('-Rf', path.join(dummyplugin, 'src', 'ios', 'Custom.framework', '*'),
                                                      path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'));
                 });
-                it('should deep symlink files to the right target location', function() {
+                it('should deep link files to the right target location', function() {
                     var frameworks = copyArray(valid_custom_frameworks);
-                    var spy = spyOn(fs, 'symlinkSync');
+                    var spy = spyOn(fs, 'linkSync');
                     install(frameworks[0], dummyPluginInfo, dummyProject, { link: true });
                     var src_binlib = path.join(dummyplugin, 'src', 'ios', 'Custom.framework', 'somebinlib');
                     var dest_binlib = path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework/somebinlib');
-                    expect(spy).toHaveBeenCalledWith(path.relative(fs.realpathSync(path.dirname(dest_binlib)), src_binlib),
-                                                     dest_binlib);
+                    expect(spy).toHaveBeenCalledWith(src_binlib, dest_binlib);
                 });
             });
         });
@@ -470,21 +468,21 @@ describe('ios plugin handler', function() {
                     expect(spy).toHaveBeenCalledWith('-rf', frameworkPath);
                 });
             });
-            
+
             describe('without custom="true" attribute ', function() {
-                it('should decrease framework counter after uninstallation', function() {  
+                it('should decrease framework counter after uninstallation', function() {
                     var install = pluginHandlers.getInstaller('framework');
                     var dummyNonCustomFrameworks =  dummyPluginInfo.getFrameworks('ios').filter(function(f) {
                         return !f.custom;
                     });
                     var dummyFramework = dummyNonCustomFrameworks[0];
                     install(dummyFramework, dummyPluginInfo, dummyProject);
-                    install(dummyFramework, dummyPluginInfo, dummyProject); 
-                    var frameworkName = Object.keys(dummyProject.frameworks)[0]; 
+                    install(dummyFramework, dummyPluginInfo, dummyProject);
+                    var frameworkName = Object.keys(dummyProject.frameworks)[0];
                     expect(dummyProject.frameworks[frameworkName]).toEqual(2);
                     uninstall(dummyFramework, dummyPluginInfo, dummyProject);
-                    expect(dummyProject.frameworks[frameworkName]).toEqual(1);                  
-                    uninstall(dummyFramework, dummyPluginInfo, dummyProject); 
+                    expect(dummyProject.frameworks[frameworkName]).toEqual(1);
+                    uninstall(dummyFramework, dummyPluginInfo, dummyProject);
                     expect(dummyProject.frameworks[frameworkName]).not.toBeDefined();
                 });
             });


### PR DESCRIPTION
Softlinking resource files (.wav files [for example](https://github.com/apache/cordova-plugin-dialogs/tree/master/src/ios/CDVNotification.bundle)) leads to some unexpected behavior. Said resource files are stored as symbolic links inside the .ipa and the app cannot be installed on iOS 10.
Instead of creating symbolic link create regular links - it is better than copying the files performance-wise and the solution is more robust.

Part of the fix for [CB-12247: Symlinking resource files leads to inability to install app on iOS 10](https://issues.apache.org/jira/browse/CB-12247)