### PR TITLE
CB-6274 Added support for BackgroundColor preference

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.h
+++ b/CordovaLib/Classes/Public/CDVViewController.h
@@ -79,6 +79,7 @@
 - (NSString*)appURLScheme;
 - (NSURL*)errorURL;
 
+- (UIColor*)colorFromColorString:(NSString*)colorString;
 - (NSArray*)parseInterfaceOrientations:(NSArray*)orientations;
 - (BOOL)supportsOrientation:(UIInterfaceOrientation)orientation;
 

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -393,12 +393,26 @@
 
 - (UIColor*)colorFromColorString:(NSString*)colorString
 {
+    // No value, nothing to do
+    if (!colorString) {
+        return nil;
+    }
+    
+    // Validate format
+    NSError* error = NULL;
+    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:@"^(#[0-9A-F]{3}|(0x|#)([0-9A-F]{2})?[0-9A-F]{6})$" options:NSRegularExpressionCaseInsensitive error:&error];
+    NSUInteger countMatches = [regex numberOfMatchesInString:colorString options:0 range:NSMakeRange(0, [colorString length])];
+    
+    if (!countMatches) {
+        return nil;
+    }
+    
     // #FAB to #FFAABB
     if ([colorString hasPrefix:@"#"] && [colorString length] == 4) {
         NSString* r = [colorString substringWithRange:NSMakeRange(1, 1)];
         NSString* g = [colorString substringWithRange:NSMakeRange(2, 1)];
         NSString* b = [colorString substringWithRange:NSMakeRange(3, 1)];
-        colorString = [NSString stringWithFormat:@"0x%@%@%@%@%@%@", r, r, g, g, b, b];
+        colorString = [NSString stringWithFormat:@"#%@%@%@%@%@%@", r, r, g, g, b, b];
     }
     
     // #RRGGBB to 0xRRGGBB

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -341,6 +341,12 @@
             }
         }
     }];
+    
+    // /////////////////
+    
+    NSString* bgColorString = [self.settings cordovaSettingForKey:@"BackgroundColor"];
+    UIColor* bgColor = [self colorFromColorString:bgColorString];
+    [self.webView setBackgroundColor:bgColor];
 }
 
 -(void)viewWillAppear:(BOOL)animated
@@ -383,6 +389,38 @@
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVViewWillTransitionToSizeNotification object:[NSValue valueWithCGSize:size]]];
+}
+
+- (UIColor*)colorFromColorString:(NSString*)colorString
+{
+    // #FAB to #FFAABB
+    if ([colorString hasPrefix:@"#"] && [colorString length] == 4) {
+        NSString* r = [colorString substringWithRange:NSMakeRange(1, 1)];
+        NSString* g = [colorString substringWithRange:NSMakeRange(2, 1)];
+        NSString* b = [colorString substringWithRange:NSMakeRange(3, 1)];
+        colorString = [NSString stringWithFormat:@"0x%@%@%@%@%@%@", r, r, g, g, b, b];
+    }
+    
+    // #RRGGBB to 0xRRGGBB
+    colorString = [colorString stringByReplacingOccurrencesOfString:@"#" withString:@"0x"];
+    
+    // 0xRRGGBB to 0xAARRGGBB
+    if ([colorString hasPrefix:@"0x"] && [colorString length] == 8) {
+        colorString = [@"0xFF" stringByAppendingString:[colorString substringFromIndex:2]];
+    }
+    
+    // 0xAARRGGBB to int
+    unsigned colorValue = 0;
+    NSScanner *scanner = [NSScanner scannerWithString:colorString];
+    if (![scanner scanHexInt:&colorValue]) {
+        return nil;
+    }
+    
+    // int to UIColor
+    return [UIColor colorWithRed:((float)((colorValue & 0x00FF0000) >> 16))/255.0
+                           green:((float)((colorValue & 0x0000FF00) >>  8))/255.0
+                            blue:((float)((colorValue & 0x000000FF) >>  0))/255.0
+                           alpha:((float)((colorValue & 0xFF000000) >> 24))/255.0];
 }
 
 - (NSArray*)parseInterfaceOrientations:(NSArray*)orientations

--- a/tests/CordovaLibTests/CDVViewControllerTest.m
+++ b/tests/CordovaLibTests/CDVViewControllerTest.m
@@ -65,5 +65,29 @@
     [self doTestInitWithConfigFile:configFileRelativePath expectedSettingValue:CDVViewControllerTestSettingValueCustom];
 }
 
+-(void)testColorFromColorString{
+    CDVViewController* viewController = [self viewController];
+    
+    // Comparison values: #FFAABB and #99FFAABB
+    UIColor* referenceColor = [UIColor colorWithRed:255.0/255.0 green:170.0/255.0 blue:187.0/255.0 alpha:1.0];
+    UIColor* referenceColorAlpha = [UIColor colorWithRed:255.0/255.0 green:170.0/255.0 blue:187.0/255.0 alpha:0.6];
+    
+    // Valid values
+    XCTAssertTrue([[viewController colorFromColorString:@"#FAB"] isEqual:referenceColor]);
+    XCTAssertTrue([[viewController colorFromColorString:@"#FFAABB"] isEqual:referenceColor]);
+    XCTAssertTrue([[viewController colorFromColorString:@"0xFFAABB"] isEqual:referenceColor]);
+    XCTAssertTrue([[viewController colorFromColorString:@"#99FFAABB"] isEqual:referenceColorAlpha]);
+    XCTAssertTrue([[viewController colorFromColorString:@"0x99FFAABB"] isEqual:referenceColorAlpha]);
+    
+    // Invalid values
+    XCTAssertNil([viewController colorFromColorString:nil]);
+    XCTAssertNil([viewController colorFromColorString:@"black"]);
+    XCTAssertNil([viewController colorFromColorString:@"0xFAB"]);
+    XCTAssertNil([viewController colorFromColorString:@"#1234"]);
+    XCTAssertNil([viewController colorFromColorString:@"#12345"]);
+    XCTAssertNil([viewController colorFromColorString:@"#1234567"]);
+    XCTAssertNil([viewController colorFromColorString:@"#NOTHEX"]);
+}
+
 @end
 


### PR DESCRIPTION
Supports #RGB #RRGGBB #AARRGGBB 0xRRGGBB and 0xAARRGGBB as noted in CB-6273. Fails gracefully for invalid color values (bg remains white).