### PR TITLE
CB-12098 (iOS) removed spaces 

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -425,7 +425,6 @@
 #else  
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 #endif
-
 {
     NSUInteger ret = 0;
 

--- a/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
@@ -98,7 +98,6 @@
 #else  
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 #endif
-
 {
     return [super supportedInterfaceOrientations];
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected
iOS
### What does this PR do?
12098 updates supported interface return types.  This PR is simply removing some extra spaces which were created when 12098 was initially submitted per @shazron 's suggestion
### What testing has been done on this change?
npm test

### Checklist
- [x ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ x] Added automated test coverage as appropriate for this change.
