### PR TITLE
CB-12287: Remove hardcoded simulator build destination

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -53,7 +53,33 @@ var buildFlagMatchers = {
     'shared_precomps_dir' : /^(SHARED_PRECOMPS_DIR=.*)/
 };
 
+/**
+ * Returns a promise that resolves to the default simulator target; the logic here
+ * matches what `cordova emulate ios` does. 
+ * 
+ * The return object has two properties: `name` (the Xcode destination name),
+ * `identifier` (the simctl identifier), and `simIdentifier` (essentially the cordova emulate target)
+ * 
+ * @return {Promise}
+ */
+function getDefaultSimulatorTarget() {
+    return require('./list-emulator-build-targets').run()
+    .then(function (emulators) {
+        var targetEmulator;
+        if (emulators.length > 0) {
+            targetEmulator = emulators[0];
+        }
+        emulators.forEach(function (emulator) {
+            if (emulator.name.indexOf('iPhone') === 0) {
+                targetEmulator = emulator;
+            }
+        });
+        return targetEmulator;
+    });
+}
+
 module.exports.run = function (buildOpts) {
+    var emulatorTarget = '';
 
     buildOpts = buildOpts || {};
 
@@ -93,6 +119,22 @@ return require('./list-devices').run()
             return check_reqs.check_ios_deploy();
         }
     }).then(function () {
+        // CB-12287: Determine the device we should target when building for a simulator
+        if (!buildOpts.device) {
+            var promise;
+            if (buildOpts.target) {
+                // a target was given to us, find the matching Xcode destination name
+                promise = require('./list-emulator-build-targets').targetForSimIdentifier(buildOpts.target);
+            } else {
+                // no target provided, pick a default one (matching our emulator logic)
+                promise = getDefaultSimulatorTarget();
+            }
+            return promise.then(function(theTarget) { 
+                emulatorTarget = theTarget.name;
+                events.emit('log', 'Building for ' + emulatorTarget + ' Simulator');
+            });
+        }
+    }).then(function () {
         return check_reqs.run();
     }).then(function () {
         return findXCodeProjectIn(projectPath);
@@ -125,7 +167,7 @@ return require('./list-devices').run()
         // remove the build/device folder before building
         return spawn('rm', [ '-rf', buildOutputDir ], projectPath)
         .then(function() {
-            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag);
+            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget);
             return spawn('xcodebuild', xcodebuildArgs, projectPath);
         });
 
@@ -224,13 +266,15 @@ module.exports.findXCodeProjectIn = findXCodeProjectIn;
 
 /**
  * Returns array of arguments for xcodebuild
- * @param  {String}  projectName   Name of xcode project
- * @param  {String}  projectPath   Path to project file. Will be used to set CWD for xcodebuild
- * @param  {String}  configuration Configuration name: debug|release
- * @param  {Boolean} isDevice      Flag that specify target for package (device/emulator)
- * @return {Array}                 Array of arguments that could be passed directly to spawn method
+ * @param  {String}  projectName    Name of xcode project
+ * @param  {String}  projectPath    Path to project file. Will be used to set CWD for xcodebuild
+ * @param  {String}  configuration  Configuration name: debug|release
+ * @param  {Boolean} isDevice       Flag that specify target for package (device/emulator)
+ * @param  {Array}   buildFlags
+ * @param  {String}  emulatorTarget Target for emulator (rather than default)
+ * @return {Array}                  Array of arguments that could be passed directly to spawn method
  */
-function getXcodeBuildArgs(projectName, projectPath, configuration, isDevice, buildFlags) {
+function getXcodeBuildArgs(projectName, projectPath, configuration, isDevice, buildFlags, emulatorTarget) {
     var xcodebuildArgs;
     var options;
     var buildActions;
@@ -274,7 +318,7 @@ function getXcodeBuildArgs(projectName, projectPath, configuration, isDevice, bu
             '-scheme', customArgs.scheme || projectName,
             '-configuration', customArgs.configuration || configuration,
             '-sdk', customArgs.sdk || 'iphonesimulator',
-            '-destination', customArgs.destination || 'platform=iOS Simulator,name=iPhone 5s'
+            '-destination', customArgs.destination || 'platform=iOS Simulator,name=' + emulatorTarget
         ];
         buildActions = [ 'build' ];
         settings = [

--- a/bin/templates/scripts/cordova/lib/list-emulator-build-targets
+++ b/bin/templates/scripts/cordova/lib/list-emulator-build-targets
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+/*jshint node: true*/
+
+var Q = require('q'),
+    exec = require('child_process').exec;
+
+/**
+ * Returns a list of available simulator build targets of the form
+ * 
+ *     [
+ *         { name: <xcode-destination-name>,
+ *           identifier: <simctl-identifier>,
+ *           simIdentifier: <cordova emulate target>
+ *         }
+ *     ]
+ * 
+ */
+function listEmulatorBuildTargets () {
+    return Q.nfcall(exec, 'xcrun simctl list --json')
+    .then(function(stdio) {
+        return JSON.parse(stdio[0]);
+    })
+    .then(function(simInfo) {
+        var devices = simInfo.devices;
+        var deviceTypes = simInfo.devicetypes;
+        return deviceTypes.reduce(function (typeAcc, deviceType) {
+            if (!deviceType.name.match(/^[iPad|iPhone]/)) {
+                // ignore targets we don't support (like Apple Watch or Apple TV)
+                return typeAcc;
+            }
+            var availableDevices = Object.keys(devices).reduce(function (availAcc, deviceCategory) {
+                var availableDevicesInCategory = devices[deviceCategory];
+                availableDevicesInCategory.forEach(function (device) {
+                    if (device.name === deviceType.name.replace(/\-inch/g, ' inch') && 
+                        device.availability.toLowerCase().indexOf('unavailable') < 0) {
+                            availAcc.push(device);
+                        }
+                });
+                return availAcc;
+            }, []);
+            // we only want device types that have at least one available device
+            // (regardless of OS); this filters things out like iPhone 4s, which
+            // is present in deviceTypes, but probably not available on the user's
+            // system.
+            if (availableDevices.length > 0) {
+                typeAcc.push(deviceType);
+            }
+            return typeAcc;
+        }, []);
+    })
+    .then(function(filteredTargets) {
+        // the simIdentifier, or cordova emulate target name, is the very last part
+        // of identifier.
+        return filteredTargets.map(function (target) {
+            var identifierPieces = target.identifier.split(".");
+            target.simIdentifier = identifierPieces[identifierPieces.length-1];
+            return target;
+        });
+    });
+}
+
+exports.run = listEmulatorBuildTargets;
+
+/**
+ * Given a simIdentifier, return the matching target.
+ * 
+ * @param {string} simIdentifier       a target, like "iPhone-SE"
+ * @return {Object}                    the matching target, or undefined if no match
+ */
+exports.targetForSimIdentifier = function(simIdentifier) {
+    return listEmulatorBuildTargets()
+    .then(function(targets) {
+        return targets.reduce(function(acc, target) {
+            if (!acc && target.simIdentifier.toLowerCase() === simIdentifier.toLowerCase()) {
+                acc = target;
+            }
+            return acc;
+        }, undefined);
+    });
+}
+
+// Check if module is started as separate script.
+// If so, then invoke main method and print out results.
+if (!module.parent) {
+    listEmulatorBuildTargets().then(function (targets) {
+        console.log(JSON.stringify(targets, null, 2));
+    });
+}

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -110,7 +110,7 @@ describe('build', function () {
 
         it('should generate appropriate args for simulator', function(done) {
             var isDevice = false;
-            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null);
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null, 'iPhone 5s');
             expect(args[0]).toEqual('-xcconfig');
             expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
             expect(args[2]).toEqual('-workspace');
@@ -160,7 +160,7 @@ describe('build', function () {
             var isDevice = false;
             var buildFlags = '-archivePath TestArchivePathFlag';
 
-            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags, 'iPhone 5s');
             expect(args[0]).toEqual('-xcconfig');
             expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
             expect(args[2]).toEqual('-workspace');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS 4.3.1 and below

### What does this PR do?

In `cordova-ios@4.3.1` and below, the Xcode build destination when building for a simulator is hardcoded as "iPhone 5s". This works as long as the user has an iPhone 5s simulator installed, but if they remove it, the build process breaks.

This PR follows the same logic as `cordova emulate ios` in choosing a default destination, but also respects `--target` if specified. For example:

```
    $ cordova emulate ios       # will currently select iPhone SE simulator to build against and emulate
    $ cordova emulate ios --target="iPhone-7-Plus"  # will build against and emulate on the iPhone 7+
```

If there are no simulators available, the behavior is undefined, but Xcode wouldn't be able to build either.

### What testing has been done on this change?

Manual tests and `npm test`

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
    - Note: a couple of tests were modified so that they could pass, but they don't actually test this issue. Tests covering the inner logic will come in a separate PR
