### PR TITLE
CB-12473 - Delete the correct build output folder

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -120,7 +120,7 @@ return require('./list-devices').run()
         events.emit('log','\tConfiguration: ' + configuration);
         events.emit('log','\tPlatform: ' + (buildOpts.device ? 'device' : 'emulator'));
 
-        var buildOutputDir = path.join(projectPath, 'build', 'device');
+        var buildOutputDir = path.join(projectPath, 'build', (buildOpts.device ? 'device' : 'emulator'));
 
         // remove the build/device folder before building
         return spawn('rm', [ '-rf', buildOutputDir ], projectPath)


### PR DESCRIPTION
### Platforms affected
iOS (Simulator, mostly)

### What does this PR do?
Ensures that when building for the simulator, device builds are not deleted.

### What testing has been done on this change?
All unit tests passing.