### PR TITLE
CB-12402 CB-12206 Properly encode app name to generate XML files

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -24,6 +24,7 @@ var shell = require('shelljs'),
     path = require('path'),
     fs = require('fs'),
     plist = require('plist'),
+    xmlescape = require('xml-escape'),
     ROOT = path.join(__dirname, '..', '..'),
     events = require('cordova-common').events;
 
@@ -145,10 +146,14 @@ function copyTemplateFiles(project_path, project_name, project_template_dir, pac
      * - ./__PROJECT_NAME__/Resources/__PROJECT_NAME__-info.plist
      * - ./__PROJECT_NAME__/Resources/__PROJECT_NAME__-Prefix.plist
      */
+
+    // https://issues.apache.org/jira/browse/CB-12402 - Encode XML characters properly
+    var project_name_xml_esc = xmlescape(project_name);
+    shell.sed('-i', /__PROJECT_NAME__/g, project_name_xml_esc, path.join(r+'.xcworkspace', 'contents.xcworkspacedata'));
+    shell.sed('-i', /__PROJECT_NAME__/g, project_name_xml_esc, path.join(r+'.xcworkspace', 'xcshareddata', 'xcschemes', project_name +'.xcscheme'));
+
     var project_name_esc = project_name.replace(/&/g, '\\&');
     shell.sed('-i', /__PROJECT_NAME__/g, project_name_esc, path.join(r+'.xcodeproj', 'project.pbxproj'));
-    shell.sed('-i', /__PROJECT_NAME__/g, project_name_esc, path.join(r+'.xcworkspace', 'contents.xcworkspacedata'));
-    shell.sed('-i', /__PROJECT_NAME__/g, project_name_esc, path.join(r+'.xcworkspace', 'xcshareddata', 'xcschemes', project_name +'.xcscheme'));
     shell.sed('-i', /__PROJECT_NAME__/g, project_name_esc, path.join(r, 'Classes', 'AppDelegate.h'));
     shell.sed('-i', /__PROJECT_NAME__/g, project_name_esc, path.join(r, 'Classes', 'AppDelegate.m'));
     shell.sed('-i', /__PROJECT_NAME__/g, project_name_esc, path.join(r, 'Classes', 'MainViewController.h'));

--- a/node_modules/xml-escape/LICENSE
+++ b/node_modules/xml-escape/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Michael Hernandez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/xml-escape/README.md
+++ b/node_modules/xml-escape/README.md
@@ -1,0 +1,38 @@
+xml-escape
+==========
+
+Escape XML in javascript (NodeJS)
+
+npm install xml-escape
+
+```javascript
+// Warning escape is a reserved word, so maybe best to use xmlescape for var name
+var xmlescape = require('xml-escape');
+
+xmlescape('"hello" \'world\' & false < true > -1');
+
+// output
+// '&quot;hello&quot; &apos;world&apos; &amp; false &lt; true &gt; -1'
+
+// don't escape some characters
+xmlescape('"hello" \'world\' & false < true > -1', '>"&')
+
+// output
+// '"hello" &apos;world&apos; & false &lt; true > -1'
+```
+
+
+There is also now an ignore function thanks to @jayflo
+
+```javascript
+esc = require('./');
+
+ignore = '"<&'
+// note you should never ignore an &
+output = esc('I am "<&not>" escaped', ignore)
+console.log(output)
+
+//I am "<&not&gt;" escaped
+```
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/miketheprogrammer/xml-escape/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/node_modules/xml-escape/index.js
+++ b/node_modules/xml-escape/index.js
@@ -1,0 +1,22 @@
+
+
+var escape = module.exports = function escape(string, ignore) {
+  var pattern;
+
+  if (string === null || string === undefined) return;
+
+  ignore = (ignore || '').replace(/[^&"<>\']/g, '');
+  pattern = '([&"<>\'])'.replace(new RegExp('[' + ignore + ']', 'g'), '');
+
+  return string.replace(new RegExp(pattern, 'g'), function(str, item) {
+            return escape.map[item];
+          })
+}
+
+var map = escape.map = {
+    '>': '&gt;'
+  , '<': '&lt;'
+  , "'": '&apos;'
+  , '"': '&quot;'
+  , '&': '&amp;'
+}

--- a/node_modules/xml-escape/package.json
+++ b/node_modules/xml-escape/package.json
@@ -1,0 +1,91 @@
+{
+  "_args": [
+    [
+      {
+        "raw": "xml-escape@^1.1.0",
+        "scope": null,
+        "escapedName": "xml-escape",
+        "name": "xml-escape",
+        "rawSpec": "^1.1.0",
+        "spec": ">=1.1.0 <2.0.0",
+        "type": "range"
+      }
+    ]
+  ],
+  "_from": "xml-escape@>=1.1.0 <2.0.0",
+  "_id": "xml-escape@1.1.0",
+  "_inCache": true,
+  "_location": "/xml-escape",
+  "_nodeVersion": "5.5.0",
+  "_npmOperationalInternal": {
+    "host": "packages-13-west.internal.npmjs.com",
+    "tmp": "tmp/xml-escape-1.1.0.tgz_1457961063163_0.10634087934158742"
+  },
+  "_npmUser": {
+    "name": "mhernandez",
+    "email": "michael.hernandez1988@gmail.com"
+  },
+  "_npmVersion": "3.3.12",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "xml-escape@^1.1.0",
+    "scope": null,
+    "escapedName": "xml-escape",
+    "name": "xml-escape",
+    "rawSpec": "^1.1.0",
+    "spec": ">=1.1.0 <2.0.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+  "_shasum": "3904c143fa8eb3a0030ec646d2902a2f1b706c44",
+  "_shrinkwrap": null,
+  "_spec": "xml-escape@^1.1.0",
+  "author": {
+    "name": "Michael Hernandez - michael.hernandez1988@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/miketheprogrammer/xml-escape/issues"
+  },
+  "dependencies": {},
+  "description": "Escape XML ",
+  "devDependencies": {
+    "tape": "~2.4.2"
+  },
+  "directories": {},
+  "dist": {
+    "shasum": "3904c143fa8eb3a0030ec646d2902a2f1b706c44",
+    "tarball": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz"
+  },
+  "gitHead": "c42a09afa81e645ca6881dbaf384d7f3c63735e4",
+  "homepage": "https://github.com/miketheprogrammer/xml-escape",
+  "keywords": [
+    "Escape",
+    "XML",
+    "Unesacpe",
+    "encoding",
+    "xml-escape"
+  ],
+  "license": "MIT License",
+  "main": "index.js",
+  "maintainers": [
+    {
+      "name": "mhernandez",
+      "email": "michael.hernandez1988@gmail.com"
+    }
+  ],
+  "name": "xml-escape",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/miketheprogrammer/xml-escape.git"
+  },
+  "scripts": {
+    "test": "node test.js"
+  },
+  "version": "1.1.0"
+}

--- a/node_modules/xml-escape/test.js
+++ b/node_modules/xml-escape/test.js
@@ -1,0 +1,29 @@
+var test = require('tape');
+var escape = require('./index');
+test("Characters should be escaped properly", function (t) {
+    t.plan(1);
+
+    t.equals(escape('" \' < > &'), '&quot; &apos; &lt; &gt; &amp;');
+})
+
+test("Module should respect ignore string", function (t) {
+    t.plan(3);
+
+    t.equals(escape('" \' < > &', '"'), '" &apos; &lt; &gt; &amp;');
+    t.equals(escape('" \' < > &', '>&'), '&quot; &apos; &lt; > &');
+    t.equals(escape('" \' < > &', '"\'<>&'), '" \' < > &');
+})
+
+test("Module should not escape random characters", function (t) {
+    t.plan(1);
+
+    t.equals(escape('<[whats up]>', '<]what'), '<[whats up]&gt;');
+})
+
+test("Module should not crash on null or undefined input", function (t) {
+    t.plan(3);
+
+    t.equals((escape("")), "");
+    t.doesNotThrow(function(){escape(null);}, TypeError);
+    t.doesNotThrow(function(){escape(undefined);}, TypeError);
+})

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "plist": "^1.2.0",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",
-    "xcode": "^0.8.5"
+    "xcode": "^0.8.5",
+    "xml-escape": "^1.1.0"
   },
   "bundledDependencies": [
     "cordova-common",
@@ -52,6 +53,7 @@
     "plist",
     "q",
     "shelljs",
-    "xcode"
+    "xcode",
+    "xml-escape"
   ]
 }

--- a/tests/spec/create.spec.js
+++ b/tests/spec/create.spec.js
@@ -102,6 +102,13 @@ describe('create', function() {
         createAndBuild(projectname, projectid);
     });
 
+    it('Test#008 : create project with ascii name, and spaces, ampersand(&)', function() {
+       var projectname = 'hello & world';
+       var projectid = 'com.test.app7';
+
+       createAndBuild(projectname, projectid);
+    });
+
 });
 
 describe('end-to-end list validation', function(){


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
self

### What does this PR do?
The build fails due to corrupted xml files at platforms/ios/<APPNAME>.xcworkspace/**. This PR adds logic to encode app name. 

### What testing has been done on this change?
Auto-test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
