### PR TITLE
CB-12522 - Remove node 0.x support in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: "0.10"
-  - nodejs_version: "0.12"
   - nodejs_version: "4"
   - nodejs_version: "6"
 


### PR DESCRIPTION
### Platforms affected

Self

### What does this PR do?

Remove node 0.x support from CI

### What testing has been done on this change?

This PR is the test (for CI)

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
