### PR TITLE
CB-12405 - .ipa is uncompressed in preparation for 'run' command during a 'build', resulting in slow builds

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -207,35 +207,9 @@ return require('./list-devices').run()
           return spawn('xcodebuild', xcodearchiveArgs, projectPath);
         }
 
-        function unpackIPA() {
-            var ipafile = path.join(buildOutputDir, projectName + '.ipa');
-
-            // unpack the existing platform/ios/build/device/appname.ipa (zipfile), will create a Payload folder 
-            return spawn('unzip', [ '-o', '-qq', ipafile ], buildOutputDir);
-        }
-
-        function moveApp() {
-            var appFileInflated = path.join(buildOutputDir, 'Payload', projectName + '.app');
-            var appFile = path.join(buildOutputDir, projectName + '.app');
-            var payloadFolder = path.join(buildOutputDir, 'Payload');
-
-            // delete the existing platform/ios/build/device/appname.app 
-            return spawn('rm', [ '-rf', appFile ], buildOutputDir)
-                .then(function() {
-                    // move the platform/ios/build/device/Payload/appname.app to parent 
-                    return spawn('mv', [ '-f', appFileInflated, buildOutputDir ], buildOutputDir);
-                })
-                .then(function() {
-                    // delete the platform/ios/build/device/Payload folder
-                    return spawn('rm', [ '-rf', payloadFolder ], buildOutputDir);
-                });
-        }
-
         return Q.nfcall(fs.writeFile, exportOptionsPath, exportOptionsPlist, 'utf-8')
                 .then(checkSystemRuby)
-                .then(packageArchive)
-                .then(unpackIPA)
-                .then(moveApp);
+                .then(packageArchive);
     });
 };
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -69,10 +69,37 @@ module.exports.run = function (runOptions) {
         return build.findXCodeProjectIn(projectPath);
     }).then(function (projectName) {
         var appPath = path.join(projectPath, 'build', 'emulator', projectName + '.app');
+        var buildOutputDir = path.join(projectPath, 'build', 'device');
+
         // select command to run and arguments depending whether
         // we're running on device/emulator
         if (useDevice) {
-            return checkDeviceConnected().then(function () {
+            return checkDeviceConnected()
+            .then(function() {
+                // Unpack IPA
+                var ipafile = path.join(buildOutputDir, projectName + '.ipa');
+
+                // unpack the existing platform/ios/build/device/appname.ipa (zipfile), will create a Payload folder 
+                return spawn('unzip', [ '-o', '-qq', ipafile ], buildOutputDir);
+            })
+            .then(function() {
+                // Uncompress IPA (zip file)
+                var appFileInflated = path.join(buildOutputDir, 'Payload', projectName + '.app');
+                var appFile = path.join(buildOutputDir, projectName + '.app');
+                var payloadFolder = path.join(buildOutputDir, 'Payload');
+
+                // delete the existing platform/ios/build/device/appname.app 
+                return spawn('rm', [ '-rf', appFile ], buildOutputDir)
+                    .then(function() {
+                        // move the platform/ios/build/device/Payload/appname.app to parent 
+                        return spawn('mv', [ '-f', appFileInflated, buildOutputDir ], buildOutputDir);
+                    })
+                    .then(function() {
+                        // delete the platform/ios/build/device/Payload folder
+                        return spawn('rm', [ '-rf', payloadFolder ], buildOutputDir);
+                    });
+            })
+            .then(function() {
                 appPath = path.join(projectPath, 'build', 'device', projectName + '.app');
                 var extraArgs = [];
                 if (runOptions.argv) {


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Defer decompression of the .ipa archive (built during a `build`) to the `run` command.
This speeds up cloud builds where they don't need to run the .app.

### What testing has been done on this change?
Tested using:
```
cordova build
cordova build --emulator
cordova build --device
cordova run --emulator --nobuild
cordova run --device --nobuild
cordova run --emulator
cordova run --device
```

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
