### PR TITLE
CB-12571 - Podfile gets overwritten and some dependencies disappear.

### DIFF
--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -66,7 +66,7 @@ Podfile.prototype.__parseForPods = function(text) {
     //     pod 'Foobar', '1.2'
     //     pod 'Foobar', 'abc 123 1.2'
     //     pod 'PonyDebugger', :configurations => ['Debug', 'Beta']
-    var podRE = new RegExp('pod \'(\\w+)\'\\s*,?\\s*(.*)');
+    var podRE = new RegExp('pod \'([^\']*)\'\\s*,?\\s*(.*)');
 
     // only grab lines that don't have the pod spec'
     return arr.filter(function(line) {

--- a/tests/spec/unit/Podfile.spec.js
+++ b/tests/spec/unit/Podfile.spec.js
@@ -101,6 +101,8 @@ describe('unit tests for Podfile module', function () {
 			podfile.addSpec('Foo', '1.0');
 			podfile.addSpec('Bar', '2.0');
 			podfile.addSpec('Baz', '3.0');
+			podfile.addSpec('Foo-Baz', '4.0');
+			podfile.addSpec('Foo~Baz@!%@!%!', '5.0');
 			podfile.addSpec('Bla', ':configurations => [\'Debug\', \'Beta\']');
 
 			podfile.write();
@@ -110,11 +112,15 @@ describe('unit tests for Podfile module', function () {
 			expect(newPodfile.existsSpec('Foo')).toBe(true);
 			expect(newPodfile.existsSpec('Bar')).toBe(true);
 			expect(newPodfile.existsSpec('Baz')).toBe(true);
+			expect(newPodfile.existsSpec('Foo-Baz')).toBe(true);
+			expect(newPodfile.existsSpec('Foo~Baz@!%@!%!')).toBe(true);
 			expect(newPodfile.existsSpec('Bla')).toBe(true);
 
 			expect(newPodfile.getSpec('Foo')).toBe(podfile.getSpec('Foo'));
 			expect(newPodfile.getSpec('Bar')).toBe(podfile.getSpec('Bar'));
 			expect(newPodfile.getSpec('Baz')).toBe(podfile.getSpec('Baz'));
+			expect(newPodfile.getSpec('Foo-Baz')).toBe(podfile.getSpec('Foo-Baz'));
+			expect(newPodfile.getSpec('Foo~Baz@!%@!%!')).toBe(podfile.getSpec('Foo~Baz@!%@!%!'));
 			expect(newPodfile.getSpec('Bla')).toBe(podfile.getSpec('Bla'));
 		});
 


### PR DESCRIPTION
### Platforms affected

self

### What does this PR do?

Fix reading of pods with non-alphanumeric characters in the name from Podfile

### What testing has been done on this change?

Added unit tests

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
