### PR TITLE
CB-12577 - Fix module import warnings when using Cordova.framework (Carthage)

### DIFF
--- a/CordovaLib/Cordova/Cordova.h
+++ b/CordovaLib/Cordova/Cordova.h
@@ -27,6 +27,8 @@ FOUNDATION_EXPORT const unsigned char CordovaVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <Cordova/PublicHeader.h>
 
+#import <Cordova/CDV.h>
+#import <Cordova/CDVCommandDelegateImpl.h>
 #import <Cordova/CDVAvailability.h>
 #import <Cordova/CDVAvailabilityDeprecated.h>
 #import <Cordova/CDVAppDelegate.h>


### PR DESCRIPTION
### Platforms affected

self

### What does this PR do?

Remove warnings related to incomplete umbrella headers when using `@import Cordova;` after compiling Cordova.framework using Carthage.

### What testing has been done on this change?

Added Cordova.framework from the repo using Carthage, added the import, added a reference to CDVViewController, and built an iOS View app.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
