### PR TITLE
CB-11233 - Support installing frameworks into "Embedded Binaries" section of the Xcode project

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,4 +7,5 @@
   , "indent": 4
   , "unused": "vars"
   , "latedef": "nofunc"
+  , "esversion": "6"
 }

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -14,7 +14,7 @@
        specific language governing permissions and limitations
        under the License.
 */
-
+"use strict";
 var fs = require('fs');
 var path = require('path');
 var shell = require('shelljs');

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -14,7 +14,7 @@
        specific language governing permissions and limitations
        under the License.
 */
-"use strict";
+'use strict';
 var fs = require('fs');
 var path = require('path');
 var shell = require('shelljs');

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -100,9 +100,9 @@ var handlers = {
             var existsEmbedFrameworks = project.xcode.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks');
             if (!existsEmbedFrameworks && embed) {
                 events.emit('verbose', '"Embed Frameworks" Build Phase (Embedded Binaries) does not exist, creating it.');
-                project.xcode.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Embed Frameworks');
+                project.xcode.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Embed Frameworks', null, 'frameworks');
             }
-            let opt = { customFramework: true, embed: embed, link: link };
+            let opt = { customFramework: true, embed: embed, link: link, sign: true };
             events.emit('verbose', util.format('Adding custom framework to project... %s -> %s', src, JSON.stringify(opt)));
             project.xcode.addFramework(project_relative, opt);
             events.emit('verbose', util.format('Custom framework added to project. %s -> %s', src, JSON.stringify(opt)));

--- a/node_modules/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/node_modules/cordova-common/src/PluginInfo/PluginInfo.js
@@ -317,6 +317,7 @@ function PluginInfo(dirname) {
                 type: el.attrib.type,
                 parent: el.attrib.parent,
                 custom: isStrTrue(el.attrib.custom),
+                embed: isStrTrue(el.attrib.embed),
                 src: el.attrib.src,
                 spec: el.attrib.spec,
                 weak: isStrTrue(el.attrib.weak),

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
     "uncrustify": "^0.6.1"
   },
   "dependencies": {
-    "cordova-common": "^1.5.0",
+    "cordova-common": "^2.0.0",
     "ios-sim": "^5.0.12",
     "nopt": "^3.0.6",
     "plist": "^1.2.0",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",
-    "xcode": "^0.8.5",
+    "xcode": "^0.9.0",
     "xml-escape": "^1.1.0"
   },
   "bundledDependencies": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "uncrustify": "^0.6.1"
   },
   "dependencies": {
-    "cordova-common": "^2.0.0",
+    "cordova-common": "^1.5.0",
     "ios-sim": "^5.0.12",
     "nopt": "^3.0.6",
     "plist": "^1.2.0",

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -242,12 +242,12 @@ describe('ios plugin handler', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 install(frameworks[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addFramework)
-                    .toHaveBeenCalledWith('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework', { customFramework: true, embed: false, link: true });
+                    .toHaveBeenCalledWith('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework', { customFramework: true, embed: false, link: true, sign: true });
 
                 frameworks = copyArray(valid_embeddable_custom_frameworks);
                 install(frameworks[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addFramework)
-                    .toHaveBeenCalledWith('SampleApp/Plugins/org.test.plugins.dummyplugin/CustomEmbeddable.framework', { customFramework: true, embed: true, link: false });
+                    .toHaveBeenCalledWith('SampleApp/Plugins/org.test.plugins.dummyplugin/CustomEmbeddable.framework', { customFramework: true, embed: true, link: false, sign: true });
 
                 frameworks = copyArray(valid_weak_frameworks);
                 install(frameworks[0], dummyPluginInfo, dummyProject);

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -41,7 +41,10 @@ var dummy_id = dummyPluginInfo.id;
 var valid_source = dummyPluginInfo.getSourceFiles('ios'),
     valid_headers = dummyPluginInfo.getHeaderFiles('ios'),
     valid_resources = dummyPluginInfo.getResourceFiles('ios'),
-    valid_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return f.custom; });
+    valid_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return f.custom; }),
+    valid_embeddable_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return f.custom && f.embed; }),
+    valid_weak_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return !(f.custom) && f.weak; });
+    
 
 var faultyPluginInfo = new PluginInfo(faultyplugin);
 var invalid_source = faultyPluginInfo.getSourceFiles('ios');
@@ -239,7 +242,17 @@ describe('ios plugin handler', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 install(frameworks[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addFramework)
-                    .toHaveBeenCalledWith('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework', {customFramework:true});
+                    .toHaveBeenCalledWith('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework', { customFramework: true, embed: false, link: true });
+
+                frameworks = copyArray(valid_embeddable_custom_frameworks);
+                install(frameworks[0], dummyPluginInfo, dummyProject);
+                expect(dummyProject.xcode.addFramework)
+                    .toHaveBeenCalledWith('SampleApp/Plugins/org.test.plugins.dummyplugin/CustomEmbeddable.framework', { customFramework: true, embed: true, link: false });
+
+                frameworks = copyArray(valid_weak_frameworks);
+                install(frameworks[0], dummyPluginInfo, dummyProject);
+                expect(dummyProject.xcode.addFramework)
+                    .toHaveBeenCalledWith(path.join('src','ios','libsqlite3.dylib'), { customFramework: false, embed: false, link: true, weak: true });
             });
 
             // TODO: Add more tests to cover the cases:

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -252,7 +252,7 @@ describe('ios plugin handler', function() {
                 frameworks = copyArray(valid_weak_frameworks);
                 install(frameworks[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addFramework)
-                    .toHaveBeenCalledWith(path.join('src','ios','libsqlite3.dylib'), { customFramework: false, embed: false, link: true, weak: true });
+                    .toHaveBeenCalledWith('src/ios/libsqlite3.dylib', { customFramework: false, embed: false, link: true, weak: true });
             });
 
             // TODO: Add more tests to cover the cases:

--- a/tests/spec/unit/fixtures/org.test.plugins.dummyplugin/plugin.xml
+++ b/tests/spec/unit/fixtures/org.test.plugins.dummyplugin/plugin.xml
@@ -62,5 +62,6 @@
         <framework src="src/ios/libsqlite3.dylib" />
         <framework src="src/ios/libsqlite3.dylib" weak="true" />
         <framework src="src/ios/Custom.framework" custom="true" />
+        <framework src="src/ios/CustomEmbeddable.framework" custom="true" embed="true" />
     </platform>
 </plugin>

--- a/tests/spec/unit/fixtures/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/someFheader.h
+++ b/tests/spec/unit/fixtures/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/someFheader.h
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/someFheader.h

--- a/tests/spec/unit/fixtures/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/somebinlib
+++ b/tests/spec/unit/fixtures/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/somebinlib
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/somebinlib

--- a/tests/spec/unit/fixtures/test-config.xml
+++ b/tests/spec/unit/fixtures/test-config.xml
@@ -68,7 +68,7 @@
 
     <allow-navigation href="https://*.server23.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" requires-certificate-transparency="false"/>
     <allow-navigation href="https://*.server24.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" requires-certificate-transparency="false"/>
-    <allow-navigation href="https://*.server24-1.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true"requires-certificate-transparency="true" />
+    <allow-navigation href="https://*.server24-1.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" requires-certificate-transparency="true" />
     <allow-navigation href="https://*.server24-2.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" requires-certificate-transparency="true"/>
 
     <!-- http, no subdomain, with attribute differences -->


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Support the "embed" attribute for the `<framework>` tag of plugin.xml to facilitate installing custom iOS frameworks into the Embedded Binaries section of the Xcode project for the iOS platform

### What testing has been done on this change?

Added unit tests.

### Other notes

Complementary PR: https://github.com/apache/cordova-lib/pull/535
I manually updated PluginInfo.js in the cordova-common bundledDependency for tests to pass.

### Checklist

- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-XXXX"
- [X] Added automated test coverage as appropriate for this change.
