### PR TITLE
CB-11895: openURL: is deprecated on iOS 10

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
@@ -118,7 +118,18 @@
             // only allow-intent if it's a UIWebViewNavigationTypeLinkClicked (anchor tag) OR
             // it's a UIWebViewNavigationTypeOther, and it's an internal link
             if ([[self class] shouldOpenURLRequest:request navigationType:navigationType]){
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
+                // CB-11895; openURL with a single parameter is deprecated in iOS 10
+                // see https://useyourloaf.com/blog/openurl-deprecated-in-ios10
+                if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+                    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+                } else {
+                    [[UIApplication sharedApplication] openURL:url];
+                }
+#else
+                // fall back if on older SDK
                 [[UIApplication sharedApplication] openURL:url];
+#endif
             }
             
             // consume the request (i.e. no error) if it wasn't handled above


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### What does this PR do?

Addresses deprecation of openURL: in iOS 10 by using openURL:options:completionHandler: instead.

### What testing has been done on this change?

- CI Testing OK
- Tested in sim on 10.3 and 9.3 & verified appropriate methods were called

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
    - not applicable to this change
