### PR TITLE
CB-8980: Ensure copied resource-files are cleaned

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -489,7 +489,7 @@ function updateFileResources(cordovaProject, locations) {
 
 function cleanFileResources(projectRoot, projectConfig, locations) {
     const platformDir = path.relative(projectRoot, locations.root);
-    const files = projectConfig.getFileResources('ios');
+    const files = projectConfig.getFileResources('ios', true);
     if (files.length > 0) {
         events.emit('verbose', 'Cleaning resource files at ' + platformDir);
 


### PR DESCRIPTION
Requires https://github.com/apache/cordova-lib/pull/547 for the intended functionality, but is safe to merge even without it.

Addresses the point 1 of https://github.com/apache/cordova-android/pull/321#issuecomment-294985346 where `resource-file` targets were not getting cleaned.