### PR TITLE
CB-12009 - <resource-file> target attribute ignored on iOS when installing a Cordova plugin

### DIFF
--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -49,18 +49,34 @@ var handlers = {
     'resource-file':{
         install:function(obj, plugin, project, options) {
             var src = obj.src,
-                srcFile = path.resolve(plugin.dir, src),
-                destFile = path.resolve(project.resources_dir, path.basename(src));
-            if (!fs.existsSync(srcFile)) throw new CordovaError('Cannot find resource file "' + srcFile + '" for plugin ' + plugin.id + ' in iOS platform');
-            if (fs.existsSync(destFile)) throw new CordovaError('File already exists at detination "' + destFile + '" for resource file specified by plugin ' + plugin.id + ' in iOS platform');
-            project.xcode.addResourceFile(path.join('Resources', path.basename(src)));
+                target = obj.target,
+                srcFile = path.resolve(plugin.dir, src);
+
+            if (!target) {
+                target = path.basename(src);
+            }
+            var destFile = path.resolve(project.resources_dir, target);
+
+            if (!fs.existsSync(srcFile)) {
+                throw new CordovaError('Cannot find resource file "' + srcFile + '" for plugin ' + plugin.id + ' in iOS platform');
+            }
+            if (fs.existsSync(destFile)) {
+                throw new CordovaError('File already exists at destination "' + destFile + '" for resource file specified by plugin ' + plugin.id + ' in iOS platform');
+            }
+            project.xcode.addResourceFile(path.join('Resources', target));
             var link = !!(options && options.link);
             copyFile(plugin.dir, src, project.projectDir, destFile, link);
         },
         uninstall:function(obj, plugin, project, options) {
             var src = obj.src,
-                destFile = path.resolve(project.resources_dir, path.basename(src));
-            project.xcode.removeResourceFile(path.join('Resources', path.basename(src)));
+                target = obj.target;
+
+            if (!target) {
+                target = path.basename(src);
+            }
+            var destFile = path.resolve(project.resources_dir, target);
+
+            project.xcode.removeResourceFile(path.join('Resources', target));
             shell.rm('-rf', destFile);
         }
     },

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -206,7 +206,7 @@ describe('ios plugin handler', function() {
                 fs.writeFileSync(target, 'some bs', 'utf-8');
                 expect(function() {
                     install(resources[0], dummyPluginInfo, dummyProject);
-                }).toThrow(new Error('File already exists at detination "' + target + '" for resource file specified by plugin ' + dummyPluginInfo.id + ' in iOS platform'));
+                }).toThrow(new Error('File already exists at destination "' + target + '" for resource file specified by plugin ' + dummyPluginInfo.id + ' in iOS platform'));
             });
             it('Test 016 : should call into xcodeproj\'s addResourceFile', function() {
                 var resources = copyArray(valid_resources);


### PR DESCRIPTION
### Platforms affected

self

### What does this PR do?

Fix bug where <resource-file> `target` attribute in plugin.xml was being ignored.

### What testing has been done on this change?

npm test, local adding of plugin with target attribute

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
