### PR TITLE
CB-12675 - Travis xcode 8.3. os-x image fails an e2e test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8.3
 sudo: false
 before_install:
     - npm cache clean -f


### PR DESCRIPTION
### Platforms affected

self

### What does this PR do?

Updates the os-x image on Travis to Xcode 8.3

### What testing has been done on this change?

this PR is the test. 

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
