### PR TITLE
CB-12883 Add logging for malformed data

### DIFF
--- a/CordovaLib/Classes/Private/CDVJSON_private.m
+++ b/CordovaLib/Classes/Private/CDVJSON_private.m
@@ -66,9 +66,9 @@
     id object = [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding]
                                                 options:NSJSONReadingMutableContainers
                                                   error:&error];
-
+    
     if (error != nil) {
-        NSLog(@"NSString JSONObject error: %@", [error localizedDescription]);
+        NSLog(@"NSString JSONObject error: %@, Malformed Data: %@", [error localizedDescription], self);
     }
 
     return object;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### What does this PR do?

Prints the malformed data created by the process for further debugging.

### What testing has been done on this change?

Hard to reproduce, but sometimes the evaulateJavascript method on WKWebView creates a malformed JSON string. 

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
