### PR TITLE
CB-12960 Run tests on Node 4.x and 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,25 @@
 language: objective-c
 osx_image: xcode8.3
 sudo: false
+env:
+  matrix:
+  - TRAVIS_NODE_VERSION: '4.2'
+  - TRAVIS_NODE_VERSION: '6.11'
 before_install:
-    - npm cache clean -f
-    - npm install -g n
-    - node --version
+- npm cache clean -f
+- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
+  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
+  install $TRAVIS_NODE_VERSION
+- node --version
 install:
-    - npm install
-    - npm install ios-deploy
-    - npm install -g codecov
+- npm install
+- npm install ios-deploy
+- npm install -g codecov
 script:
-    - npm run jshint
-    - npm run unit-tests
-    - npm run e2e-tests
-    - open -b com.apple.iphonesimulator    
-    - npm run objc-tests
-    - npm run cover
+- npm run jshint
+- npm run unit-tests
+- npm run e2e-tests
+- open -b com.apple.iphonesimulator    
+- npm run objc-tests
+- npm run cover
 after_script: codecov


### PR DESCRIPTION
This closes #323

### Platforms affected
iOS

### What does this PR do?
Adds node 4.x and 6.x run to Travis CI

### What testing has been done on this change?
See Travis build just under this PR

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
