### PR TITLE
CB-13093: (iOS) Infinite looping when stressing navigation

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
@@ -256,11 +256,10 @@ static NSString *stripFragment(NSString* url)
                         NSLog(@"%@", description);
                         _loadCount = 0;
                         _state = STATE_WAITING_FOR_LOAD_START;
-                        if ([_delegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
-                            NSDictionary* errorDictionary = @{NSLocalizedDescriptionKey : description};
-                            NSError* error = [[NSError alloc] initWithDomain:@"CDVUIWebViewDelegate" code:1 userInfo:errorDictionary];
-                            [_delegate webView:webView didFailLoadWithError:error];
-                        }
+                                
+                        NSDictionary* errorDictionary = @{NSLocalizedDescriptionKey : description};
+                        NSError* error = [[NSError alloc] initWithDomain:@"CDVUIWebViewDelegate" code:1 userInfo:errorDictionary];
+                        [self webView:webView didFailLoadWithError:error];
                     }
             }
         } else {

--- a/tests/CordovaLibTests/CDVWebViewDelegateTests.m
+++ b/tests/CordovaLibTests/CDVWebViewDelegateTests.m
@@ -47,6 +47,8 @@
 // expose private interface
 - (BOOL)shouldLoadRequest:(NSURLRequest*)request;
 
+-(BOOL)webView:(UIWebView*)webView shouldStartLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType;
+
 @end
 
 @interface CDVWebViewDelegateTests : XCTestCase
@@ -63,6 +65,21 @@
 {
     [super tearDown];
 }
+
+- (void)testShouldLoadRequestWithStateWaitForStart
+{
+    NSInteger initialState = 1; // STATE_WAITING_FOR_LOAD_START;
+    NSInteger expectedState = 0; // STATE_IDLE;
+    
+    CDVWebViewDelegate2* wvd = [[CDVWebViewDelegate2 alloc] initWithDelegate:nil]; // not really testing delegate handling
+    wvd.state = initialState;
+    
+    // Testing a top-level navigation
+    [wvd webView:[UIWebView new] shouldStartLoadWithRequest:nil navigationType:UIWebViewNavigationTypeLinkClicked];
+    
+    XCTAssertTrue(wvd.state == expectedState, @"If the navigation started with state STATE_WAITING_FOR_LOAD_START then it must fail and the state should be STATE_IDLE");
+}
+
 
 - (void)testFailLoadStateCancelled
 {


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fix the navigations that starts with the STATE_WAITING_FOR_LOAD_START  by calling the self webview:didFailLoadWithError method instead of delegating it.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](https://issues.apache.org/jira/browse/CB-13093) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
