### PR TITLE
CB-13191: (ios) Support marketing icon

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/bin/templates/project/__PROJECT_NAME__/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -121,6 +121,12 @@
       "scale" : "2x"
     },
     {
+      "size" : "1024x1024",
+      "idiom" : "ios-marketing",
+      "filename" : "icon-1024.png",
+      "scale" : "1x"
+    },
+    {
       "size" : "24x24",
       "idiom" : "watch",
       "scale" : "2x",

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -328,7 +328,8 @@ function mapIconResources (icons, iconsDir) {
         {dest: 'icon-72@2x.png', width: 144, height: 144},
         {dest: 'icon-50.png', width: 50, height: 50},
         {dest: 'icon-50@2x.png', width: 100, height: 100},
-        {dest: 'icon-83.5@2x.png', width: 167, height: 167}
+        {dest: 'icon-83.5@2x.png', width: 167, height: 167},
+        {dest: 'icon-1024.png', width: 1024, height: 1024}
     ];
 
     var pathMap = {};


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Adds support for the marketing icon. This is required for app submission since XCode 9.

### What testing has been done on this change?
Ran `cordova prepare` and made sure that the icon referenced from `config.xml`gets properly added and is displayed in XCode.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
