### PR TITLE
support for creating Xcode9 style exportOptions.plist 

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -197,7 +197,7 @@ module.exports.run = function (buildOpts) {
             }
 
             if (buildOpts.provisioningProfile && bundleIdentifier) {
-                exportOptions.provisioningProfiles = { [bundleIdentifier]:String(buildOpts.provisioningProfile)};
+                exportOptions.provisioningProfiles = { [ bundleIdentifier ]:String(buildOpts.provisioningProfile)};
                 exportOptions.signingStyle = 'manual';
             }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -182,7 +182,7 @@ module.exports.run = function (buildOpts) {
 
             var locations = {
                 root: projectPath,
-                pbxproj: path.join(projectPath, projectName, 'project.pbxproj')
+                pbxproj: path.join(projectPath, projectName + '.xcodeproj', 'project.pbxproj')
             };
 
             var bundleIdentifier = projectFile.parse(locations).getPackageName();

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -98,7 +98,7 @@ module.exports.run = function (buildOpts) {
             var buildType = buildOpts.release ? 'release' : 'debug';
             var config = buildConfig.ios[buildType];
             if (config) {
-                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag', 'bundleIdentifier'].forEach(
+                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag'].forEach(
                     function (key) {
                         buildOpts[key] = buildOpts[key] || config[key];
                     });

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -97,7 +97,7 @@ module.exports.run = function (buildOpts) {
             var buildType = buildOpts.release ? 'release' : 'debug';
             var config = buildConfig.ios[buildType];
             if (config) {
-                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag', 'bundleIdentifier'].forEach(
+                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag'].forEach(
                     function (key) {
                         buildOpts[key] = buildOpts[key] || config[key];
                     });

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -96,7 +96,7 @@ module.exports.run = function (buildOpts) {
             var buildType = buildOpts.release ? 'release' : 'debug';
             var config = buildConfig.ios[buildType];
             if (config) {
-                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag'].forEach(
+                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag', 'bundleIdentifier'].forEach(
                     function (key) {
                         buildOpts[key] = buildOpts[key] || config[key];
                     });
@@ -187,6 +187,15 @@ module.exports.run = function (buildOpts) {
 
             if (buildOpts.developmentTeam) {
                 exportOptions.teamID = buildOpts.developmentTeam;
+            }
+     
+            if (buildOpts.provisioningProfile && buildOpts.bundleIdentifier) {               
+                exportOptions.provisioningProfiles = { [buildOpts.bundleIdentifier]  : String(buildOpts.provisioningProfile) };
+                exportOptions.signingStyle = 'manual';
+            }
+
+            if(buildOpts.codeSignIdentity) {
+                exportOptions.signingCertificate = buildOpts.codeSignIdentity;
             }
 
             var exportOptionsPlist = plist.build(exportOptions);

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -26,6 +26,8 @@ var plist = require('plist');
 var util = require('util');
 
 var check_reqs = require('./check_reqs');
+var projectFile = require('./projectFile');
+var self = this;
 
 var events = require('cordova-common').events;
 
@@ -179,6 +181,9 @@ module.exports.run = function (buildOpts) {
                 return;
             }
 
+            var project = projectFile.parse(self.locations);
+            var pkgName = project.getPackageName();
+
             var exportOptions = {'compileBitcode': false, 'method': 'development'};
 
             if (buildOpts.packageType) {
@@ -189,12 +194,12 @@ module.exports.run = function (buildOpts) {
                 exportOptions.teamID = buildOpts.developmentTeam;
             }
      
-            if (buildOpts.provisioningProfile && buildOpts.bundleIdentifier) {               
-                exportOptions.provisioningProfiles = { [buildOpts.bundleIdentifier]  : String(buildOpts.provisioningProfile) };
+            if (pkgName && buildOpts.provisioningProfile) {               
+                exportOptions.provisioningProfiles = {[pkgName]: buildOpts.provisioningProfile};
                 exportOptions.signingStyle = 'manual';
             }
 
-            if(buildOpts.codeSignIdentity) {
+            if (buildOpts.codeSignIdentity) {
                 exportOptions.signingCertificate = buildOpts.codeSignIdentity;
             }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -192,6 +192,10 @@ module.exports.run = function (buildOpts) {
                 exportOptions.method = buildOpts.packageType;
             }
 
+            if (buildOpts.iCloudContainerEnvironment) {
+                exportOptions.iCloudContainerEnvironment = buildOpts.iCloudContainerEnvironment;
+            }
+
             if (buildOpts.developmentTeam) {
                 exportOptions.teamID = buildOpts.developmentTeam;
             }

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -197,7 +197,7 @@ module.exports.run = function (buildOpts) {
             }
 
             if (buildOpts.provisioningProfile && bundleIdentifier) {
-                exportOptions.provisioningProfiles = {[bundleIdentifier]:String(buildOpts.provisioningProfile)};
+                exportOptions.provisioningProfiles = { [bundleIdentifier]:String(buildOpts.provisioningProfile)};
                 exportOptions.signingStyle = 'manual';
             }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -197,7 +197,7 @@ module.exports.run = function (buildOpts) {
             }
 
             if (buildOpts.provisioningProfile && bundleIdentifier) {
-                exportOptions.provisioningProfiles = { [ bundleIdentifier ]:String(buildOpts.provisioningProfile)};
+                exportOptions.provisioningProfiles = { [ bundleIdentifier ]: String(buildOpts.provisioningProfile) };
                 exportOptions.signingStyle = 'manual';
             }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -186,7 +186,6 @@ module.exports.run = function (buildOpts) {
             };
 
             var bundleIdentifier = projectFile.parse(locations).getPackageName();
-            
             var exportOptions = {'compileBitcode': false, 'method': 'development'};
 
             if (buildOpts.packageType) {
@@ -196,13 +195,13 @@ module.exports.run = function (buildOpts) {
             if (buildOpts.developmentTeam) {
                 exportOptions.teamID = buildOpts.developmentTeam;
             }
-     
-            if (buildOpts.provisioningProfile && bundleIdentifier) {               
-                exportOptions.provisioningProfiles = { [bundleIdentifier]  : String(buildOpts.provisioningProfile) };
+
+            if (buildOpts.provisioningProfile && bundleIdentifier) {
+                exportOptions.provisioningProfiles = {[bundleIdentifier]:String(buildOpts.provisioningProfile)};
                 exportOptions.signingStyle = 'manual';
             }
 
-            if(buildOpts.codeSignIdentity) {
+            if (buildOpts.codeSignIdentity) {
                 exportOptions.signingCertificate = buildOpts.codeSignIdentity;
             }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -97,7 +97,7 @@ module.exports.run = function (buildOpts) {
             var buildType = buildOpts.release ? 'release' : 'debug';
             var config = buildConfig.ios[buildType];
             if (config) {
-                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag'].forEach(
+                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag', 'iCloudContainerEnvironment'].forEach(
                     function (key) {
                         buildOpts[key] = buildOpts[key] || config[key];
                     });

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -180,9 +180,6 @@ module.exports.run = function (buildOpts) {
                 return;
             }
 
-            console.log('projectPath:' + projectPath);
-            console.log('projectName:' + projectName);
-
             var locations = {
                 root: projectPath,
                 pbxproj: path.join(projectPath, projectName, 'project.pbxproj')

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -26,8 +26,6 @@ var plist = require('plist');
 var util = require('util');
 
 var check_reqs = require('./check_reqs');
-var projectFile = require('./projectFile');
-var self = this;
 
 var events = require('cordova-common').events;
 
@@ -98,7 +96,7 @@ module.exports.run = function (buildOpts) {
             var buildType = buildOpts.release ? 'release' : 'debug';
             var config = buildConfig.ios[buildType];
             if (config) {
-                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag'].forEach(
+                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag', 'bundleIdentifier'].forEach(
                     function (key) {
                         buildOpts[key] = buildOpts[key] || config[key];
                     });
@@ -181,9 +179,6 @@ module.exports.run = function (buildOpts) {
                 return;
             }
 
-            var project = projectFile.parse(self.locations);
-            var pkgName = project.getPackageName();
-
             var exportOptions = {'compileBitcode': false, 'method': 'development'};
 
             if (buildOpts.packageType) {
@@ -194,12 +189,12 @@ module.exports.run = function (buildOpts) {
                 exportOptions.teamID = buildOpts.developmentTeam;
             }
      
-            if (pkgName && buildOpts.provisioningProfile) {               
-                exportOptions.provisioningProfiles = {[pkgName]: buildOpts.provisioningProfile};
+            if (buildOpts.provisioningProfile && buildOpts.bundleIdentifier) {               
+                exportOptions.provisioningProfiles = { [buildOpts.bundleIdentifier]  : String(buildOpts.provisioningProfile) };
                 exportOptions.signingStyle = 'manual';
             }
 
-            if (buildOpts.codeSignIdentity) {
+            if(buildOpts.codeSignIdentity) {
                 exportOptions.signingCertificate = buildOpts.codeSignIdentity;
             }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -26,6 +26,7 @@ var plist = require('plist');
 var util = require('util');
 
 var check_reqs = require('./check_reqs');
+var projectFile = require('./projectFile');
 
 var events = require('cordova-common').events;
 
@@ -179,6 +180,16 @@ module.exports.run = function (buildOpts) {
                 return;
             }
 
+            console.log('projectPath:' + projectPath);
+            console.log('projectName:' + projectName);
+
+            var locations = {
+                root: projectPath,
+                pbxproj: path.join(projectPath, projectName, 'project.pbxproj')
+            };
+
+            var bundleIdentifier = projectFile.parse(locations).getPackageName();
+            
             var exportOptions = {'compileBitcode': false, 'method': 'development'};
 
             if (buildOpts.packageType) {
@@ -189,8 +200,8 @@ module.exports.run = function (buildOpts) {
                 exportOptions.teamID = buildOpts.developmentTeam;
             }
      
-            if (buildOpts.provisioningProfile && buildOpts.bundleIdentifier) {               
-                exportOptions.provisioningProfiles = { [buildOpts.bundleIdentifier]  : String(buildOpts.provisioningProfile) };
+            if (buildOpts.provisioningProfile && bundleIdentifier) {               
+                exportOptions.provisioningProfiles = { [bundleIdentifier]  : String(buildOpts.provisioningProfile) };
                 exportOptions.signingStyle = 'manual';
             }
 


### PR DESCRIPTION
…e meta data contained in build.json.
See example below, please note that the provisioning profile can be the name or UUID of the profile.  Name is preferred for maintenence, as UUID changes each time to regenerate the profile.
```
{
    "ios": {
        "debug": {
            "codeSignIdentity": "iPhone Developer",
            "developmentTeam":"YOURTEAMID",
            "provisioningProfile": "provisioning profile name or UUID",
            "packageType": "development"
        },
        "release": {
            "codeSignIdentity": "iPhone Distribution",
            "developmentTeam":"YOURTEAMID",
            "provisioningProfile": "provisioning profile name or UUID",
            "packageType": "ad-hoc"
        }
    }
}
```
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Fixes Xcode9 command line build with explicit/manual provisioning

### What testing has been done on this change?
Tested on Trane's software suite CI build scripts.   There is currently a bug open CB-13315,  this issue is also being reported on various blogs including stack overflow: https://stackoverflow.com/questions/46344443/after-upgrading-to-xcode-9-cordova-app-wont-build-error-70-requires-provisio/46370957#46370957

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.