### PR TITLE
CB-13290: (ios) Update splash screen mapping for missing devices

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Images.xcassets/LaunchImage.launchimage/Contents.json
+++ b/bin/templates/project/__PROJECT_NAME__/Images.xcassets/LaunchImage.launchimage/Contents.json
@@ -1,6 +1,24 @@
 {
   "images" : [
     {
+      "extent": "full-screen",
+      "idiom": "iphone",
+      "subtype": "2436h",
+      "filename": "Default-2436h.png",
+      "minimum-system-version": "11.0",
+      "orientation": "portrait",
+      "scale": "3x"
+    },
+    {
+      "extent": "full-screen",
+      "idiom": "iphone",
+      "subtype": "2436h",
+      "filename": "Default-Landscape-2436h.png",
+      "minimum-system-version": "11.0",
+      "orientation": "landscape",
+      "scale": "3x"
+    },
+    {
       "extent" : "full-screen",
       "idiom" : "iphone",
       "subtype" : "736h",
@@ -120,6 +138,7 @@
     {
       "orientation" : "landscape",
       "idiom" : "ipad",
+      "filename": "Default-Landscape~ipad.png",
       "extent" : "full-screen",
       "scale" : "1x"
     },
@@ -145,6 +164,7 @@
     {
       "orientation" : "landscape",
       "idiom" : "ipad",
+      "filename": "Default-Landscape@2x~ipad.png",
       "extent" : "full-screen",
       "scale" : "2x"
     }

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -411,7 +411,9 @@ function mapSplashScreenResources (splashScreens, splashScreensDir) {
         {dest: 'Default-568h@2x~iphone.png', width: 640, height: 1136},
         {dest: 'Default-667h.png', width: 750, height: 1334},
         {dest: 'Default-736h.png', width: 1242, height: 2208},
-        {dest: 'Default-Landscape-736h.png', width: 2208, height: 1242}
+        {dest: 'Default-Landscape-736h.png', width: 2208, height: 1242},
+        {dest: 'Default-2436h.png', width: 1125, height: 2436},
+        {dest: 'Default-Landscape-2436h.png', width: 2436, height: 1125}
     ];
 
     var pathMap = {};


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Adds splash screen support for iPhone X and other missing devices.

### What testing has been done on this change?
Created a project with all supported splash screens, opened in Xcode and viewed the Images.xcassets to see that the splash screens were correctly added.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
