### PR TITLE
CB-13523: Add flag for Xcode-managed provisioning

### DIFF
--- a/bin/templates/scripts/cordova/build
+++ b/bin/templates/scripts/cordova/build
@@ -42,6 +42,7 @@ var buildOpts = nopt({
     'codeSignIdentity': String,
     'codeSignResourceRules': String,
     'provisioningProfile': String,
+    'automaticProvisioning': Boolean,
     'developmentTeam': String,
     'packageType': String,
     'buildConfig' : String,

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -97,7 +97,7 @@ module.exports.run = function (buildOpts) {
             var buildType = buildOpts.release ? 'release' : 'debug';
             var config = buildConfig.ios[buildType];
             if (config) {
-                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag', 'iCloudContainerEnvironment'].forEach(
+                ['codeSignIdentity', 'codeSignResourceRules', 'provisioningProfile', 'developmentTeam', 'packageType', 'buildFlag', 'iCloudContainerEnvironment', 'automaticProvisioning'].forEach(
                     function (key) {
                         buildOpts[key] = buildOpts[key] || config[key];
                     });
@@ -225,7 +225,7 @@ module.exports.run = function (buildOpts) {
             }
 
             function packageArchive () {
-                var xcodearchiveArgs = getXcodeArchiveArgs(projectName, projectPath, buildOutputDir, exportOptionsPath);
+                var xcodearchiveArgs = getXcodeArchiveArgs(projectName, projectPath, buildOutputDir, exportOptionsPath, buildOpts.automaticProvisioning);
                 return spawn('xcodebuild', xcodearchiveArgs, projectPath);
             }
 
@@ -337,15 +337,16 @@ function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, b
  * @param  {String}  projectPath        Path to project file. Will be used to set CWD for xcodebuild
  * @param  {String}  outputPath         Output directory to contain the IPA
  * @param  {String}  exportOptionsPath  Path to the exportOptions.plist file
+ * @param  {Boolean} autoProvisioning   Whether to allow Xcode to automatically update provisioning
  * @return {Array}                      Array of arguments that could be passed directly to spawn method
  */
-function getXcodeArchiveArgs (projectName, projectPath, outputPath, exportOptionsPath) {
+function getXcodeArchiveArgs (projectName, projectPath, outputPath, exportOptionsPath, autoProvisioning) {
     return [
         '-exportArchive',
         '-archivePath', projectName + '.xcarchive',
         '-exportOptionsPlist', exportOptionsPath,
         '-exportPath', outputPath
-    ];
+    ].concat(autoProvisioning ? ['-allowProvisioningUpdates'] : []);
 }
 
 function parseBuildFlag (buildFlag, args) {

--- a/bin/templates/scripts/cordova/run
+++ b/bin/templates/scripts/cordova/run
@@ -45,6 +45,7 @@ var opts = nopt({
     'codeSignIdentity': String,
     'codeSignResourceRules': String,
     'provisioningProfile': String,
+    'automaticProvisioning': Boolean,
     'buildConfig' : String,
     'noSign' : Boolean
 }, { 'd' : '--verbose' }, args);

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -199,6 +199,20 @@ describe('build', function () {
             expect(archiveArgs.length).toEqual(7);
             done();
         });
+
+        it('should generate the appropriate arguments for automatic provisioning', function (done) {
+            var archiveArgs = getXcodeArchiveArgs('TestProjectName', testProjectPath, '/test/output/path', '/test/export/options/path', true);
+            expect(archiveArgs[0]).toEqual('-exportArchive');
+            expect(archiveArgs[1]).toEqual('-archivePath');
+            expect(archiveArgs[2]).toEqual('TestProjectName.xcarchive');
+            expect(archiveArgs[3]).toEqual('-exportOptionsPlist');
+            expect(archiveArgs[4]).toEqual('/test/export/options/path');
+            expect(archiveArgs[5]).toEqual('-exportPath');
+            expect(archiveArgs[6]).toEqual('/test/output/path');
+            expect(archiveArgs[7]).toEqual('-allowProvisioningUpdates');
+            expect(archiveArgs.length).toEqual(8);
+            done();
+        });
     });
 
     describe('parseBuildFlag method', function () {


### PR DESCRIPTION
### Platforms affected
iOS with Xcode 9

### What does this PR do?
This adds a `automaticProvisioning` option to the build config which passes flags to xcodebuild during the exporting step that allow it to automatically create and update provisioning profiles for automatic code signing.

I don't love that we're adding even more random stuff to the build config, but I suspect most people don't want this to be enabled by default.

### What testing has been done on this change?
Added a case to existing spec tests.

Tested with a Cordova project at work and confirmed to be working.

### Checklist
- [x] Reported [CB-13523](https://issues.apache.org/jira/browse/CB-13523)
- [x] Commit message follows the format
- [x] Added automated test coverage as appropriate for this change.
