### PR TITLE
Prevent a memory leak when converting to JSON

### DIFF
--- a/CordovaLib/Classes/Private/CDVJSON_private.m
+++ b/CordovaLib/Classes/Private/CDVJSON_private.m
@@ -24,16 +24,18 @@
 
 - (NSString*)cdv_JSONString
 {
-    NSError* error = nil;
-    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:self
-                                                       options:0
-                                                         error:&error];
+    @autoreleasepool {
+        NSError* error = nil;
+        NSData* jsonData = [NSJSONSerialization dataWithJSONObject:self
+                                                           options:0
+                                                             error:&error];
 
-    if (error != nil) {
-        NSLog(@"NSArray JSONString error: %@", [error localizedDescription]);
-        return nil;
-    } else {
-        return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        if (error != nil) {
+            NSLog(@"NSArray JSONString error: %@", [error localizedDescription]);
+            return nil;
+        } else {
+            return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        }
     }
 }
 
@@ -43,16 +45,18 @@
 
 - (NSString*)cdv_JSONString
 {
-    NSError* error = nil;
-    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:self
-                                                       options:NSJSONWritingPrettyPrinted
-                                                         error:&error];
+    @autoreleasepool {
+        NSError* error = nil;
+        NSData* jsonData = [NSJSONSerialization dataWithJSONObject:self
+                                                           options:NSJSONWritingPrettyPrinted
+                                                             error:&error];
 
-    if (error != nil) {
-        NSLog(@"NSDictionary JSONString error: %@", [error localizedDescription]);
-        return nil;
-    } else {
-        return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        if (error != nil) {
+            NSLog(@"NSDictionary JSONString error: %@", [error localizedDescription]);
+            return nil;
+        } else {
+            return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        }
     }
 }
 
@@ -62,30 +66,34 @@
 
 - (id)cdv_JSONObject
 {
-    NSError* error = nil;
-    id object = [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding]
-                                                options:NSJSONReadingMutableContainers
-                                                  error:&error];
-    
-    if (error != nil) {
-        NSLog(@"NSString JSONObject error: %@, Malformed Data: %@", [error localizedDescription], self);
-    }
+    @autoreleasepool {   
+        NSError* error = nil;
+        id object = [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding]
+                                                    options:NSJSONReadingMutableContainers
+                                                      error:&error];
 
-    return object;
+        if (error != nil) {
+            NSLog(@"NSString JSONObject error: %@, Malformed Data: %@", [error localizedDescription], self);
+        }
+
+        return object;
+    }
 }
 
 - (id)cdv_JSONFragment
 {
-    NSError* error = nil;
-    id object = [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding]
-                                                options:NSJSONReadingAllowFragments
-                                                  error:&error];
+    @autoreleasepool {
+        NSError* error = nil;
+        id object = [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding]
+                                                    options:NSJSONReadingAllowFragments
+                                                      error:&error];
 
-    if (error != nil) {
-        NSLog(@"NSString JSONObject error: %@", [error localizedDescription]);
+        if (error != nil) {
+            NSLog(@"NSString JSONObject error: %@", [error localizedDescription]);
+        }
+
+        return object;
     }
-
-    return object;
 }
 
 @end


### PR DESCRIPTION
The use of JSONObjectWithData in these methods leaks 4KB each time when used for sending plugin results. Wrapping them in an autoreleasepool fixes this problem with no noticeable detrimental effects on performance.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Fixes a memory leak in CDVJSONSerializingPrivate methods

### What testing has been done on this change?
Using Instruments app on Mac, observed a 4KB increase in memory usage every time these methods were called that does not get released throughout the lifetime of the app. After implementing these changes,  the memory usage remains stable.
