### PR TITLE
CB-13510: (iOS) Removed clipboard workaround, which was braking copy/paste functional iOS 11

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -739,6 +739,15 @@
 {
     // NSLog(@"%@",@"applicationWillEnterForeground");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resume');"];
+    
+    if (!IsAtLeastiOSVersion((@"11.0"))) {
+        /** Clipboard fix **/
+        UIPasteboard* pasteboard = [UIPasteboard generalPasteboard];
+        NSString* string = pasteboard.string;
+        if (string) {
+            [pasteboard setValue:string forPasteboardType:@"public.text"];
+        }
+    }
 }
 
 // This method is called to let your application know that it moved from the inactive to active state.

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -739,13 +739,6 @@
 {
     // NSLog(@"%@",@"applicationWillEnterForeground");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resume');"];
-
-    /** Clipboard fix **/
-    UIPasteboard* pasteboard = [UIPasteboard generalPasteboard];
-    NSString* string = pasteboard.string;
-    if (string) {
-        [pasteboard setValue:string forPasteboardType:@"public.text"];
-    }
 }
 
 // This method is called to let your application know that it moved from the inactive to active state.

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -740,7 +740,7 @@
     // NSLog(@"%@",@"applicationWillEnterForeground");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resume');"];
     
-    if (!IsAtLeastiOSVersion((@"11.0"))) {
+    if (!IsAtLeastiOSVersion(@"11.0")) {
         /** Clipboard fix **/
         UIPasteboard* pasteboard = [UIPasteboard generalPasteboard];
         NSString* string = pasteboard.string;


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Removed `[pasteboard setValue:string forPasteboardType:@"public.text"]` clipboard workaround, which is not need in iOS 11, but breaking copy/past functionality from outside the app (i.e notes/safari) into (Cordova) consumer app using native UI as well.

### What testing has been done on this change?
Manually tested copy/pastes functionality for both cordova (web UI) components as well as with native UI in a container app.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database. [CB-13510](https://issues.apache.org/jira/browse/CB-13510)
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.