### PR TITLE
CB-13824: (ios) Swift 4 support

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -662,6 +662,12 @@
     id obj = [self.pluginObjects objectForKey:className];
     if (!obj) {
         obj = [[NSClassFromString(className)alloc] initWithWebViewEngine:_webViewEngine];
+        if (!obj) {
+            NSString* fullClassName = [NSString stringWithFormat:@"%@.%@",
+                                       NSBundle.mainBundle.infoDictionary[@"CFBundleExecutable"],
+                                       className];
+            obj = [[NSClassFromString(fullClassName)alloc] initWithWebViewEngine:_webViewEngine];
+        }
 
         if (obj != nil) {
             [self registerPlugin:obj withClassName:className];


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fixes a bug that prevents (Swift) plugins from being instantiated when running in Xcode 9/Swift 4.

### What testing has been done on this change? 
Local verification with Xcode 9.2.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
