### PR TITLE
CB-12582: exec purgeProjectFileCache when pod install

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -285,6 +285,7 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
             if (podfileFile.isDirty()) {
                 podfileFile.write();
                 events.emit('verbose', 'Running `pod install` (to install plugins)');
+                projectFile.purgeProjectFileCache(self.locations.root);
 
                 return podfileFile.install(check_reqs.check_cocoapods);
             } else {


### PR DESCRIPTION
CB-12582
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Cordova iOS 4.5.4

### What does this PR do?

Fix the pod install plugin (plugin with podspec framework) to work.

For example, phonegap-plugin-push plugin with `GoogleService-Info.plist`
(in config.xml, `<resource-file src="GoogleService-Info.plist" />` is added)

The case, 
```
cordova platform add ios@4.5.4
cordova plugin add phongegap-plugin-push
cordova prepare
cordova compile --device
```
 works well.
The case, 
```
cordova plugin add phonegap-plugin-push
cordova platform add ios@4.5.4
cordova prepare
cordova compile --device
```
does not work becuase the cordova overwrite project.pbxproj which is changed by pod install. 
This pull request fixes this issue.
 
### What testing has been done on this change?

Do in my local environment with cordova-ios 4.5.4

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
