### PR TITLE
Modified xcodeProjDir to filter out files/folders that contain "._"

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -64,7 +64,17 @@ function Api (platform, platformRootDir, events) {
     var xcodeCordovaProj;
 
     try {
-        xcodeProjDir = fs.readdirSync(this.root).filter(function (e) { return e.match(/\.xcodeproj$/i); })[0];
+        
+        var xcodeProjDir_array = fs.readdirSync(this.root).filter(function (e) { return e.match(/\.xcodeproj$/i); });
+        if (xcodeProjDir_array.length > 1) {
+          for (var x = 0; x < xcodeProjDir_array.length; x++) {
+            if (xcodeProjDir_array[x].substring(0,2) === '._') {
+              xcodeProjDir_array.splice(x,1);
+            }
+          }
+        }
+        xcodeProjDir = xcodeProjDir_array[0];
+        
         if (!xcodeProjDir) {
             throw new CordovaError('The provided path "' + this.root + '" is not a Cordova iOS project.');
         }


### PR DESCRIPTION
I ran into an issue trying to add an ios plugin using a virtual machine.  The code would return an array for the xcodeProjDir and then of course use the wrong one.  It would use the one starting with "._ProjectName" which I believe is an MacOS hidden folder.  I attempted to install the plugin on OsX but because it's a virtual machine it still had those hidden folders.   I've made it so that it will filter those out while looking for the proper xCode project folder.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Windows (host) / OSx (guest) virtual machines

### What does this PR do?

Fixes a folder issue.  Before it would try to use an incorrect folder for the xCode project.

### What testing has been done on this change?

I made the change while trying to install a patch.  It should work the same as before as this code is only executed if there is more than one folder returned from searching the file system. 

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
