### PR TITLE
CB-13523: Pass automaticProvisioning to build step

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -171,7 +171,7 @@ module.exports.run = function (buildOpts) {
             // remove the build/device folder before building
             return spawn('rm', [ '-rf', buildOutputDir ], projectPath)
                 .then(function () {
-                    var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget);
+                    var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget, buildOpts.automaticProvisioning);
                     return spawn('xcodebuild', xcodebuildArgs, projectPath);
                 });
 
@@ -268,9 +268,10 @@ module.exports.findXCodeProjectIn = findXCodeProjectIn;
  * @param  {Boolean} isDevice       Flag that specify target for package (device/emulator)
  * @param  {Array}   buildFlags
  * @param  {String}  emulatorTarget Target for emulator (rather than default)
+ * @param  {Boolean} autoProvisioning   Whether to allow Xcode to automatically update provisioning
  * @return {Array}                  Array of arguments that could be passed directly to spawn method
  */
-function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, buildFlags, emulatorTarget) {
+function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, buildFlags, emulatorTarget, autoProvisioning) {
     var xcodebuildArgs;
     var options;
     var buildActions;
@@ -306,6 +307,10 @@ function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, b
         // This is preferable to just ignoring the flags that the user has passed in.
         if (customArgs.sdk) {
             customArgs.otherFlags = customArgs.otherFlags.concat(['-sdk', customArgs.sdk]);
+        }
+
+        if (autoProvisioning) {
+            options = options.concat(['-allowProvisioningUpdates']);
         }
     } else { // emulator
         options = [

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -181,6 +181,29 @@ describe('build', function () {
             expect(args.length).toEqual(17);
             done();
         });
+
+        it('should generate appropriate args for automatic provisioning', function (done) {
+            var isDevice = true;
+            var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null, null, true);
+            expect(args[0]).toEqual('-xcconfig');
+            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
+            expect(args[2]).toEqual('-workspace');
+            expect(args[3]).toEqual('TestProjectName.xcworkspace');
+            expect(args[4]).toEqual('-scheme');
+            expect(args[5]).toEqual('TestProjectName');
+            expect(args[6]).toEqual('-configuration');
+            expect(args[7]).toEqual('TestConfiguration');
+            expect(args[8]).toEqual('-destination');
+            expect(args[9]).toEqual('generic/platform=iOS');
+            expect(args[10]).toEqual('-archivePath');
+            expect(args[11]).toEqual('TestProjectName.xcarchive');
+            expect(args[12]).toEqual('-allowProvisioningUpdates');
+            expect(args[13]).toEqual('archive');
+            expect(args[14]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
+            expect(args[15]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
+            expect(args.length).toEqual(16);
+            done();
+        });
     });
 
     describe('getXcodeArchiveArgs method', function () {


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Passes `-allowProvisioningUpdates` to the build/archive step. We are already passing it to the export step (https://github.com/apache/cordova-ios/pull/347) but it's also worth having it here.

### What testing has been done on this change?
Testing on Ayogo's Jenkins instance and was able to successfully make an iOS build without any manual steps to set up certificates or provisioning profiles.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
