### PR TITLE
CB-14045 - reinit url after app freezes

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -720,17 +720,24 @@
     }
 }
 
-- (void)checkAndReinitViewUrl
+- (bool)isUrlEmpty:(NSURL *)url
 {
-    NSString *loadedUrl = [[self.webViewEngine URL] absoluteString];
-    if (loadedUrl == (id) [NSNull null] || [loadedUrl length]==0 || [loadedUrl isEqualToString:@"about:blank"]) {
-        NSURL* appURL = [self appUrl];
-        
-        if (appURL) {
-            NSURLRequest* appReq = [NSURLRequest requestWithURL:appURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
-            [self.webViewEngine loadRequest:appReq];
-        }
+    if (!url || (url == (id) [NSNull null])) {
+        return true;
     }
+    NSString *urlAsString = [url absoluteString];
+    return (urlAsString == (id) [NSNull null] || [urlAsString length]==0 || [urlAsString isEqualToString:@"about:blank"]);
+}
+
+- (bool)checkAndReinitViewUrl
+{
+    NSURL* appURL = [self appUrl];
+    if ([self isUrlEmpty: [self.webViewEngine URL]] && ![self isUrlEmpty: appURL]) {
+        NSURLRequest* appReq = [NSURLRequest requestWithURL:appURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
+        [self.webViewEngine loadRequest:appReq];
+        return true;
+    }
+    return false;
 }
 
 /*
@@ -767,7 +774,7 @@
 - (void)onAppDidBecomeActive:(NSNotification*)notification
 {
     [self checkAndReinitViewUrl];
-// NSLog(@"%@",@"applicationDidBecomeActive");
+    // NSLog(@"%@",@"applicationDidBecomeActive");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('active');"];
 }
 

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -720,12 +720,26 @@
     }
 }
 
+- (void)checkAndReinitViewUrl
+{
+    NSString *loadedUrl = [[self.webViewEngine URL] absoluteString];
+    if (loadedUrl == (id) [NSNull null] || [loadedUrl length]==0 || [loadedUrl isEqualToString:@"about:blank"]) {
+        NSURL* appURL = [self appUrl];
+        
+        if (appURL) {
+            NSURLRequest* appReq = [NSURLRequest requestWithURL:appURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
+            [self.webViewEngine loadRequest:appReq];
+        }
+    }
+}
+
 /*
  This method is called to let your application know that it is about to move from the active to inactive state.
  You should use this method to pause ongoing tasks, disable timer, ...
  */
 - (void)onAppWillResignActive:(NSNotification*)notification
 {
+    [self checkAndReinitViewUrl];
     // NSLog(@"%@",@"applicationWillResignActive");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resign');" scheduledOnRunLoop:NO];
 }
@@ -737,6 +751,7 @@
  */
 - (void)onAppWillEnterForeground:(NSNotification*)notification
 {
+    [self checkAndReinitViewUrl];
     // NSLog(@"%@",@"applicationWillEnterForeground");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resume');"];
 
@@ -751,7 +766,8 @@
 // This method is called to let your application know that it moved from the inactive to active state.
 - (void)onAppDidBecomeActive:(NSNotification*)notification
 {
-    // NSLog(@"%@",@"applicationDidBecomeActive");
+    [self checkAndReinitViewUrl];
+// NSLog(@"%@",@"applicationDidBecomeActive");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('active');"];
 }
 
@@ -761,6 +777,7 @@
  */
 - (void)onAppDidEnterBackground:(NSNotification*)notification
 {
+    [self checkAndReinitViewUrl];
     // NSLog(@"%@",@"applicationDidEnterBackground");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('pause', null, true);" scheduledOnRunLoop:NO];
 }

--- a/tests/CordovaLibTests/CDVViewControllerTest.m
+++ b/tests/CordovaLibTests/CDVViewControllerTest.m
@@ -115,7 +115,7 @@
 
     appUrl = @"https://cordova.apache.org";
     viewController.startPage = appUrl;
-    [viewController.webViewEngine loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://cordova.apache.org"]]];
+    [viewController.webViewEngine loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:appUrl]]];
     XCTAssertTrue([viewController checkAndReinitViewUrl]);
 }
 

--- a/tests/CordovaLibTests/CDVViewControllerTest.m
+++ b/tests/CordovaLibTests/CDVViewControllerTest.m
@@ -26,6 +26,14 @@
 
 @end
 
+@interface CDVViewController ()
+
+// expose private interface
+- (bool)checkAndReinitViewUrl;
+- (bool)isUrlEmpty:(NSURL*)url;
+
+@end
+
 @implementation CDVViewControllerTest
 
 -(CDVViewController*)viewController{
@@ -87,6 +95,28 @@
     XCTAssertNil([viewController colorFromColorString:@"#12345"]);
     XCTAssertNil([viewController colorFromColorString:@"#1234567"]);
     XCTAssertNil([viewController colorFromColorString:@"#NOTHEX"]);
+}
+
+-(void)testIsUrlEmpty{
+    CDVViewController* viewController = [self viewController];
+    XCTAssertTrue([viewController isUrlEmpty:(id)[NSNull null]]);
+    XCTAssertTrue([viewController isUrlEmpty:nil]);
+    XCTAssertTrue([viewController isUrlEmpty:[NSURL URLWithString:@""]]);
+    XCTAssertTrue([viewController isUrlEmpty:[NSURL URLWithString:@"about:blank"]]);
+}
+
+-(void)testIfItLoadsAppUrlIfCurrentViewIsBlank{
+    CDVViewController* viewController = [self viewController];
+    
+    NSString* appUrl = @"about:blank";
+    NSString* html = @"<html><body></body></html>";
+    [viewController.webViewEngine loadHTMLString:html baseURL:[NSURL URLWithString:appUrl]];
+    XCTAssertFalse([viewController checkAndReinitViewUrl]);
+
+    appUrl = @"https://cordova.apache.org";
+    viewController.startPage = appUrl;
+    [viewController.webViewEngine loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://cordova.apache.org"]]];
+    XCTAssertTrue([viewController checkAndReinitViewUrl]);
 }
 
 @end


### PR DESCRIPTION
Hi!

We've stumbled on a similar issue to this: https://issues.apache.org/jira/browse/CB-14045 although for us it takes a bit longer (10h or so of app being in background).

In our case the app resumes in a half working state, where the web view has been reinitialised pointing to about:blank with only default Js api available and no cordova js. Then, cordova tries to emit those resume and other events but all of them fail as there is no cordova js var available.

this approach does not fix app getting into that state as I am not fully aware how does it do that (12h debugging cycle is pretty hard).. but it gets it out of the broken state by pointing the webview back to the app's url.


what do you think?

Thanks!