### PR TITLE
 CB-14039: Inputs type text don't work on iOS

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
@@ -64,11 +64,7 @@
 
 - (void)handleLongPressGestures:(UILongPressGestureRecognizer*)sender
 {
-    if ([sender isEqual:self.lpgr]) {
-        if (sender.state == UIGestureRecognizerStateBegan) {
-            NSLog(@"Ignoring a longpress in order to suppress the magnifying glass.");
-        }
-    }
+    
 }
 
 @end

--- a/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
@@ -37,13 +37,13 @@
 
     self.lpgr = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGestures:)];
     self.lpgr.minimumPressDuration = 0.45f;
-    self.lpgr.allowableMovement = 100.0f;
+    self.lpgr.allowableMovement = 200.0f;
 
     // 0.45 is ok for 'regular longpress', 0.05-0.08 is required for '3D Touch longpress',
     // but since this will also kill onclick handlers (not ontouchend) it's optional.
     if ([self.commandDelegate.settings objectForKey:@"suppresses3dtouchgesture"] &&
         [[self.commandDelegate.settings objectForKey:@"suppresses3dtouchgesture"] boolValue]) {
-        self.lpgr.minimumPressDuration = 0.05f;
+        self.lpgr.minimumPressDuration = 0.15f;
     }
 
     NSArray *views = self.webView.subviews;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-14039

When users try to disable webview magnifying glass by using `<preference name="Suppresses3DTouchGesture" value="true" />`

## Expected Behavior

The inputs are clickable and the user can write.

## Actual Behavior

The inputs are not clickable and the user cannot write
Note: Sometimes the application opens the keyboard, but it's really difficult to get.

## Steps to Reproduce

Create a new project: phonegap create myApp
Add some inputs type text in the HTML
Run the application: phonegap run ios

## Result 

Issue was related with `<preference name="Suppresses3DTouchGesture" value="true" />`
This option was using extremely low value of minimumPressDuration that was suppressing onClick events etc. After experimenting on Iphone SE and Iphone 7 and simulators I found that values 0.15f do not interfere with onClick handlers. 
Additionally supplying this option were flooding application log with not useful messages.

## Visualization of the issue and fix

http://www.giphy.com/gifs/24FWgpvK4vqhN7oZnq

## Docs issue

Additionally I found that documentation do not reflect that state of the code.
Documentation states: 

" If this setting is true, SuppressesLongPressGesture will effectively be true as well."

Where in fact preferences are not connected and setting SuppressesLongPressGesture to false will mean that Suppresses3DTouchGesture value will be ignored.