### PR TITLE
CB-14076: (ios) Setting UIWebViewDelegate on CDVWebViewEngineProtocol doesn't work

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewEngine.m
@@ -176,7 +176,7 @@
 
     if (uiWebViewDelegate &&
         [uiWebViewDelegate conformsToProtocol:@protocol(UIWebViewDelegate)]) {
-        self.uiWebViewDelegate = [[CDVUIWebViewDelegate alloc] initWithDelegate:(id <UIWebViewDelegate>)self.viewController];
+        self.uiWebViewDelegate = [[CDVUIWebViewDelegate alloc] initWithDelegate:(id <UIWebViewDelegate>)uiWebViewDelegate];
         uiWebView.delegate = self.uiWebViewDelegate;
     }
 


### PR DESCRIPTION
Attempts to use `CDVWebViewEngineProtocol::updateWithInfo` to set a new `UIWebViewDelegate` were not working; instead of setting the passed in delegate, it was setting the `CDVViewController` instance as the delegate instead.

### Platforms affected

cordova-ios

### What does this PR do?

This commit fixes the `CDVWebViewEngine` class so that the proper delegate is ultimately passed in to the `UIWebView` when calling `updateWithInfo`.

### What testing has been done on this change?

I used the code to create a new test app, to which I applied a test plugin which attempts to set the `UIWebViewDelegate`. I verified that I was able to successfully set the delegate, and receive the events from the `UIWebView`.

I also ran `npm test` and verified all tests passed.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
