### PR TITLE
CB-13581 open ios simulator by using child_process

### DIFF
--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -20,7 +20,6 @@
 var Q = require('q');
 var path = require('path');
 var cp = require('child_process');
-// var iossim = require('ios-sim');
 var build = require('./build');
 var spawn = require('./spawn');
 var check_reqs = require('./check_reqs');

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -19,7 +19,8 @@
 
 var Q = require('q');
 var path = require('path');
-var iossim = require('ios-sim');
+var cp = require('child_process');
+// var iossim = require('ios-sim');
 var build = require('./build');
 var spawn = require('./spawn');
 var check_reqs = require('./check_reqs');
@@ -197,7 +198,15 @@ function deployToSim (appPath, target) {
 function startSim (appPath, target) {
     var logPath = path.join(cordovaPath, 'console.log');
 
-    return iossim.launch(appPath, 'com.apple.CoreSimulator.SimDeviceType.' + target, logPath, '--exit');
+    return iossimLaunch(appPath, 'com.apple.CoreSimulator.SimDeviceType.' + target, logPath, '--exit');
+}
+
+function iossimLaunch (app_path, devicetypeid, log, exit) {
+    var f = path.resolve(path.dirname(require.resolve('ios-sim')), 'bin', 'ios-sim');
+    var proc = cp.spawn(f, ['launch', app_path, '--devicetypeid', devicetypeid, '--log', log, exit]);
+    proc.stdout.on('data', (data) => {
+        console.log(data.toString());
+    });
 }
 
 function listDevices () {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

cordova-ios

### What does this PR do?

The command `cordova run ios --simulator` does not finish properly.
Because bin/templates/scripts/cordova/lib/run.js opens ios simulator by calling
```
iossim.launch(appPath, 'com.apple.CoreSimulator.SimDeviceType.' + target, logPath, '--exit');
```
Dut to the last argument `--exit`, ios-sim module will call `process.exit(0);` in ios-sim/src/lib.js.
Then the cordova command itself stops. 

This PR improves the issue.
By using child_process, the cordova command does not stop when ios-sim calls `process.exit(0)`.

### What testing has been done on this change?

Here is sample plugin. https://github.com/knight9999/cordova-plugin-promise-sample .
This plugin has a `after run` plugin hook.
This plugin shows following messages after the command `cordova run ios --emulator`.
```
--- start run ---
--- now count = 0 ---
--- now count = 1 ---
--- now count = 2 ---
--- now count = 3 ---
--- now count = 4 ---
--- now count = 5 ---
--- now count = 6 ---
--- now count = 7 ---
--- now count = 8 ---
--- now count = 9 ---
```
Before applying this PR, only the first message is shown. Because the cordova command stops due to the `process.exit(0)`.
After applying this PR,  the plugin works well.


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
