### PR TITLE
package.json cleanup devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "coffee-script": "^1.7.1",
     "eslint": "^4.0.0",
     "eslint-config-semistandard": "^11.0.0",
     "eslint-config-standard": "^10.2.1",
@@ -44,8 +43,7 @@
     "jasmine": "~2.6.0",
     "nodeunit": "^0.8.7",
     "rewire": "^2.5.1",
-    "tmp": "^0.0.26",
-    "uncrustify": "^0.6.1"
+    "tmp": "^0.0.26"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### What does this PR do?

Removes devDependencies no longer needed from `package.json`:
- `coffee-script` (package name was deprecated in favor of `coffeescript`)
- `uncrustify`

~~includes plist@3 update proposed in #367~~

### What testing has been done on this change?

- `npm run unit-tests` passes
- starter project from `cordova create` with iOS platform added by `cordova platform add https://github.com/brodybits/cordova-ios#dev-dep-cleanup` runs on iOS simulator
- `npm test` stages passing on Travis CI in this PR

### Checklist
- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~
