### PR TITLE
CB-14141: Don't duplicate resource files in xcodeproj

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -497,7 +497,11 @@ function updateFileResources (cordovaProject, locations) {
         let targetPath = path.join(project.resources_dir, target);
         targetPath = path.relative(cordovaProject.root, targetPath);
 
-        project.xcode.addResourceFile(target);
+        if (!fs.existsSync(targetPath)) {
+            project.xcode.addResourceFile(target);
+        } else {
+            events.emit('warn', 'Overwriting existing resource file at ' + targetPath);
+        }
 
         resourceMap[targetPath] = src;
     });


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
When copying a resource-file to a target that already exists, don't add it to the xcodeproj file a second time.

My particular scenario is that I wanted to overwrite CDVLaunchScreen.storyboard and it was getting added to the xcodeproj twice and causing weird failures.

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-14141) in the JIRA database
- [x] Commit message follows the format
- [ ] Added automated test coverage as appropriate for this change.
