### PR TITLE
CB-14074 ios: Remove Node 4 support from CI & package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,27 @@ sudo: false
 
 env:
   matrix:
-  - TRAVIS_NODE_VERSION: '4.8.7'
-  - TRAVIS_NODE_VERSION: '6.13'
-  - TRAVIS_NODE_VERSION: '8'
-  - TRAVIS_NODE_VERSION: '10'
+    - TRAVIS_NODE_VERSION: '6'
+    - TRAVIS_NODE_VERSION: '8'
+    - TRAVIS_NODE_VERSION: '10'
 
 before_install:
-- npm cache clean -f
-- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
-  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
-  install $TRAVIS_NODE_VERSION
-- node --version
+  - nvm install $TRAVIS_NODE_VERSION
 
 install:
-- npm install
-- npm install ios-deploy
-- npm install -g codecov
+  - npm install
+  - npm install ios-deploy
+  - npm install -g codecov
 
 script:
-    - npm run unit-tests
-    - npm run e2e-tests
-    - open -b com.apple.iphonesimulator    
-    - npm run objc-tests
-    - npm run cover
-    - npm run eslint
+  - node --version
+  - npm --version
+  - npm run unit-tests
+  - npm run e2e-tests
+  - open -b com.apple.iphonesimulator
+  - npm run objc-tests
+  - npm run cover
+  - npm run eslint
 
 after_script:
-    - codecov
+  - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
   - nodejs_version: "10"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
     "tmp": "^0.0.26"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
+  "engineStrict": true,
   "dependencies": {
     "cordova-common": "2.1.0",
     "ios-sim": "^6.1.2",


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
- Drops Node 4 from travis and appveyor
- Increase the engine requirement of node in package.json
- Added engineStrict to package.json. (Match with other platforms e.g cordova-android)
- Cleanup .travis.yml

### What testing has been done on this change?
- https://travis-ci.org/erisu/cordova-ios/builds/395831324
- https://ci.appveyor.com/project/erisu/cordova-ios/build/1.0.1

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
