### PR TITLE
Fixed Get Apple OSX Version method

### DIFF
--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -63,7 +63,7 @@ exports.get_apple_osx_version = function () {
     return d.promise.then(function (output) {
         var regex = /[0-9]*\.[0-9]*/;
         var versions = [];
-        var regexOSX = /^OS X \d+/;
+        var regexOSX = /^macOS \d+/;
         output = output.split('\n');
         for (var i = 0; i < output.length; i++) {
             if (output[i].trim().match(regexOSX)) {


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
While working on an upcoming PR (#377 ) for improving the test coverage, I noticed that the `get_apple_osx_version` method has been returning `undefined`. 

After further investigation, the RegEx pattern has been looking for OSX SDK version `OS X` no longer exists since Xcode 8+ 

Example print outs:
**Xcode 7.3:** https://travis-ci.org/erisu/macos-test/jobs/395785417
**Xcode 8:** https://travis-ci.org/erisu/macos-test/jobs/395785418
**For other versions:** https://travis-ci.org/erisu/macos-test/builds/395785415

From the above print out, I determined that the RegEx pattern should be updated to `macOS`

### What testing has been done on this change?
- https://travis-ci.org/erisu/cordova-ios/builds/395835801
- https://ci.appveyor.com/project/erisu/cordova-ios/build/1.0.3

**Note:** Oddly Node 4 appears to be failing but I have submitted PR #375 to drop Node 4 support.

##~# Checklist

- ~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~