### PR TITLE
CB-14145 pin more added bundled dependencies in 4.5.x only

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,14 +49,23 @@
     "node": ">=4"
   },
   "dependencies": {
+    "base64-js": "1.2.0",
     "cordova-common": "2.2.5",
+    "elementtree": "0.1.6",
+    "glob": "5.0.15",
     "ios-sim": "6.1.3",
     "nopt": "3.0.6",
     "plist": "2.1.0",
     "q": "1.5.1",
+    "sax": "0.3.5",
     "shelljs": "0.5.3",
+    "simple-plist": "0.2.1",
+    "stream-buffers": "2.2.0",
+    "tail": "0.4.0",
+    "uuid": "3.0.1",
     "xcode": "0.9.3",
-    "xml-escape": "1.1.0"
+    "xml-escape": "1.1.0",
+    "xmlbuilder": "8.2.2"
   },
   "bundledDependencies": [
     "abbrev",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### What does this PR do?

- pin some more bundled dependencies to clear the red highlights in `npm outdated --depth=0`

### What testing has been done on this change?

- `npm audit` with npm@6.2.0 (latest version) shows 0 vulnerabilities
- `npm i && npm t` passes on the following Node.js versions: deprecated Node.js 4 (npm 2.15.11), Node.js 6.14.3 (npm 3.10.10), Node.js 8.11.3 (npm 5.6.0), Node.js 10.7.0 (npm 6.1.0)
- using `cordova platform add brodybits/cordova-ios#cb-14145-pin-more-added-bundled-deps-in-patch-only` to add platform to new Cordova project and test on iOS simulator using `cordova run ios` succeeds on the following Node.js versions:
  - deprecated Node.js 4 (npm 2.15.11)
  - Node.js 8 (npm 5.6.0)

__CI testing:__

- [x] verify that `npm test` stages and other tests pass on Travis CI
- [x] verify that installation, `unit-tests`, etc. pass on AppVeyor CI

### Checklist

- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~