### PR TITLE
spec cover apple version functions (covers GH-376 update)

### DIFF
--- a/tests/spec/unit/versions.spec.js
+++ b/tests/spec/unit/versions.spec.js
@@ -1,0 +1,54 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+var rewire = require('rewire');
+var versions = rewire('../../../bin/templates/scripts/cordova/lib/versions');
+
+// These tests can not run on windows.
+if (process.platform === 'darwin') {
+    describe('versions', function () {
+        describe('get_apple_ios_version method', () => {
+            it('should have found ios version.', (done) => {
+                var _console = versions.__get__('console');
+                var logSpy = jasmine.createSpy('logSpy');
+                versions.__set__('console', {log: logSpy});
+
+                versions.get_apple_ios_version().then(() => {
+                    expect(logSpy).not.toHaveBeenCalledWith(undefined);
+                    versions.__set__('console', _console);
+                    done();
+                });
+            });
+        });
+
+        describe('get_apple_osx_version method', () => {
+            it('should have found osx version.', (done) => {
+                var _console = versions.__get__('console');
+                var logSpy = jasmine.createSpy('logSpy');
+                versions.__set__('console', {log: logSpy});
+
+                versions.get_apple_osx_version().then(() => {
+                    expect(logSpy).not.toHaveBeenCalledWith(undefined);
+                    versions.__set__('console', _console);
+                    done();
+                });
+            });
+        });
+    });
+}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### What does this PR do?

- cover apple version functions in spec, as needed to cover the GH-376 update that I already merged into `master`

(was part of GH-377 by @erisu)

### What testing has been done on this change?

- [x] `npm run unit-tests` passes on local machine (also on deprecated Node.js 4 version)
- [x] `npm test` items pass on Travis CI _(also on deprecated Node.js 4 version)_
- [x] `npm run unit-tests` passes on AppVeyor CI _(also on deprecated Node.js 4 version)_

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- [x] Added automated test coverage as appropriate for this change.