### PR TITLE
WIP: README.md drop support for Xcode pre-9.0 - WIP FOR DISCUSSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ Cordova iOS is an iOS application library that allows for Cordova-based projects
 
 Requires:
 
-* Xcode 8.x or greater. Download it at [http://developer.apple.com/downloads](http://developer.apple.com/downloads) or the [Mac App Store](http://itunes.apple.com/us/app/xcode/id497799835?mt=12).
+* Xcode 9.0 or greater. Download it at [http://developer.apple.com/downloads](http://developer.apple.com/downloads) or the [Mac App Store](http://itunes.apple.com/us/app/xcode/id497799835?mt=12).
 * [node.js](https://nodejs.org)
+
+NOTICE: Xcode 10 (in beta as of this writing) is currently not supported,
+with known issue ([CB-14192](https://issues.apache.org/jira/browse/CB-14192)).
 
 :warning: Report issues on the [Apache Cordova issue tracker](https://issues.apache.org/jira/issues/?jql=project%20%3D%20CB%20AND%20status%20in%20%28Open%2C%20%22In%20Progress%22%2C%20Reopened%29%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20%22iOS%22%20ORDER%20BY%20priority%20DESC%2C%20summary%20ASC%2C%20updatedDate%20DESC)
 


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

- Drop support for Xcode pre-9.0 in README.md
- add notice that Xcode 10 (beta) is not supported, with known issue ref:
  - <https://issues.apache.org/jira/browse/CB-14192>
  - apache/cordova-docs#862
  - #378 (proposed workaround solution for Xcode 10)

TODO:
- [ ] needs discussion
- [ ] raise JIRA issue if agreed
- [ ] update in cordova-docs
- [ ] check if we should drop support for Xcode pre-9.0 in `bin` and `tests`?

### What testing has been done on this change?

TODO

### Checklist

TODO:

- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- ~~Added automated test coverage as appropriate for this change.~~