### PR TITLE
Pin jasmine@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-node": "^5.1.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "jasmine": "^3.1.0",
+    "jasmine": "~3.1.0",
     "nodeunit": "^0.8.7",
     "nyc": "^12.0.2",
     "rewire": "^4.0.1",


### PR DESCRIPTION
### Platforms affected
ios (tests)

### What does this PR do?
This PR fixes the recent test failures on `master` branch. 

These tests are failing because of the latest `Jasmine@3.2.0` that has been released within the past 2 days. (https://github.com/jasmine/jasmine-npm/releases/tag/v3.2.0)

At the time the original PR was submitted and tested, Jasmine was at version `3.1.0`. On this version, all tests were passing. https://travis-ci.org/apache/cordova-ios/builds/412472891

By pinning Jasmine@3.1.0 in `package.json`, the tests will continue to pass.

### What testing has been done on this change?
- local `npm test`
- Travis CI: https://travis-ci.org/erisu/cordova-ios/builds/414529064
- AppVeyor: https://ci.appveyor.com/project/erisu/cordova-ios/build/1.0.34

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
