### PR TITLE
Removal of xcconfig build flag

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -36,7 +36,6 @@ var projectName = null;
 // These are regular expressions to detect if the user is changing any of the built-in xcodebuildArgs
 /* eslint-disable no-useless-escape */
 var buildFlagMatchers = {
-    'xcconfig': /^\-xcconfig\s*(.*)$/,
     'workspace': /^\-workspace\s*(.*)/,
     'scheme': /^\-scheme\s*(.*)/,
     'configuration': /^\-configuration\s*(.*)/,
@@ -291,7 +290,6 @@ function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, b
 
     if (isDevice) {
         options = [
-            '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
             '-workspace', customArgs.workspace || projectName + '.xcworkspace',
             '-scheme', customArgs.scheme || projectName,
             '-configuration', customArgs.configuration || configuration,
@@ -314,7 +312,6 @@ function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, b
         }
     } else { // emulator
         options = [
-            '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
             '-workspace', customArgs.project || projectName + '.xcworkspace',
             '-scheme', customArgs.scheme || projectName,
             '-configuration', customArgs.configuration || configuration,

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -31,32 +31,31 @@ describe('build', function () {
 
         it('should generate appropriate args if a single buildFlag is passed in', function (done) {
             var isDevice = true;
-            var buildFlags = '-xcconfig TestXcconfigFlag';
+            var buildFlags = '';
 
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
-            expect(args[0]).toEqual('-xcconfig');
-            expect(args[1]).toEqual('TestXcconfigFlag');
-            expect(args[2]).toEqual('-workspace');
-            expect(args[3]).toEqual('TestProjectName.xcworkspace');
-            expect(args[4]).toEqual('-scheme');
-            expect(args[5]).toEqual('TestProjectName');
-            expect(args[6]).toEqual('-configuration');
-            expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-destination');
-            expect(args[9]).toEqual('generic/platform=iOS');
-            expect(args[10]).toEqual('-archivePath');
-            expect(args[11]).toEqual('TestProjectName.xcarchive');
-            expect(args[12]).toEqual('archive');
-            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
-            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
-            expect(args.length).toEqual(15);
+            expect(args).toEqual([
+                '-workspace',
+                'TestProjectName.xcworkspace',
+                '-scheme',
+                'TestProjectName',
+                '-configuration',
+                'TestConfiguration',
+                '-destination',
+                'generic/platform=iOS',
+                '-archivePath',
+                'TestProjectName.xcarchive',
+                'archive',
+                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
+            ]);
+            expect(args.length).toEqual(13);
             done();
         });
 
         it('should generate appropriate args if buildFlags are passed in', function (done) {
             var isDevice = true;
             var buildFlags = [
-                '-xcconfig TestXcconfigFlag',
                 '-workspace TestWorkspaceFlag',
                 '-scheme TestSchemeFlag',
                 '-configuration TestConfigurationFlag',
@@ -67,66 +66,66 @@ describe('build', function () {
             ];
 
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
-            expect(args[0]).toEqual('-xcconfig');
-            expect(args[1]).toEqual('TestXcconfigFlag');
-            expect(args[2]).toEqual('-workspace');
-            expect(args[3]).toEqual('TestWorkspaceFlag');
-            expect(args[4]).toEqual('-scheme');
-            expect(args[5]).toEqual('TestSchemeFlag');
-            expect(args[6]).toEqual('-configuration');
-            expect(args[7]).toEqual('TestConfigurationFlag');
-            expect(args[8]).toEqual('-destination');
-            expect(args[9]).toEqual('TestDestinationFlag');
-            expect(args[10]).toEqual('-archivePath');
-            expect(args[11]).toEqual('TestArchivePathFlag');
-            expect(args[12]).toEqual('archive');
-            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag');
-            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag');
-            expect(args.length).toEqual(15);
+            expect(args).toEqual([
+                '-workspace',
+                'TestWorkspaceFlag',
+                '-scheme',
+                'TestSchemeFlag',
+                '-configuration',
+                'TestConfigurationFlag',
+                '-destination',
+                'TestDestinationFlag',
+                '-archivePath',
+                'TestArchivePathFlag',
+                'archive',
+                'CONFIGURATION_BUILD_DIR=TestConfigBuildDirFlag',
+                'SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag'
+            ]);
+            expect(args.length).toEqual(13);
             done();
         });
 
         it('should generate appropriate args for device', function (done) {
             var isDevice = true;
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null);
-            expect(args[0]).toEqual('-xcconfig');
-            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
-            expect(args[2]).toEqual('-workspace');
-            expect(args[3]).toEqual('TestProjectName.xcworkspace');
-            expect(args[4]).toEqual('-scheme');
-            expect(args[5]).toEqual('TestProjectName');
-            expect(args[6]).toEqual('-configuration');
-            expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-destination');
-            expect(args[9]).toEqual('generic/platform=iOS');
-            expect(args[10]).toEqual('-archivePath');
-            expect(args[11]).toEqual('TestProjectName.xcarchive');
-            expect(args[12]).toEqual('archive');
-            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
-            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
-            expect(args.length).toEqual(15);
+            expect(args).toEqual([
+                '-workspace',
+                'TestProjectName.xcworkspace',
+                '-scheme',
+                'TestProjectName',
+                '-configuration',
+                'TestConfiguration',
+                '-destination',
+                'generic/platform=iOS',
+                '-archivePath',
+                'TestProjectName.xcarchive',
+                'archive',
+                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
+            ]);
+            expect(args.length).toEqual(13);
             done();
         });
 
         it('should generate appropriate args for simulator', function (done) {
             var isDevice = false;
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null, 'iPhone 5s');
-            expect(args[0]).toEqual('-xcconfig');
-            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
-            expect(args[2]).toEqual('-workspace');
-            expect(args[3]).toEqual('TestProjectName.xcworkspace');
-            expect(args[4]).toEqual('-scheme');
-            expect(args[5]).toEqual('TestProjectName');
-            expect(args[6]).toEqual('-configuration');
-            expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-sdk');
-            expect(args[9]).toEqual('iphonesimulator');
-            expect(args[10]).toEqual('-destination');
-            expect(args[11]).toEqual('platform=iOS Simulator,name=iPhone 5s');
-            expect(args[12]).toEqual('build');
-            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'));
-            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
-            expect(args.length).toEqual(15);
+            expect(args).toEqual([
+                '-workspace',
+                'TestProjectName.xcworkspace',
+                '-scheme',
+                'TestProjectName',
+                '-configuration',
+                'TestConfiguration',
+                '-sdk',
+                'iphonesimulator',
+                '-destination',
+                'platform=iOS Simulator,name=iPhone 5s',
+                'build',
+                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'),
+                'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
+            ]);
+            expect(args.length).toEqual(13);
             done();
         });
 
@@ -135,24 +134,24 @@ describe('build', function () {
             var buildFlags = '-sdk TestSdkFlag';
 
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags);
-            expect(args[0]).toEqual('-xcconfig');
-            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
-            expect(args[2]).toEqual('-workspace');
-            expect(args[3]).toEqual('TestProjectName.xcworkspace');
-            expect(args[4]).toEqual('-scheme');
-            expect(args[5]).toEqual('TestProjectName');
-            expect(args[6]).toEqual('-configuration');
-            expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-destination');
-            expect(args[9]).toEqual('generic/platform=iOS');
-            expect(args[10]).toEqual('-archivePath');
-            expect(args[11]).toEqual('TestProjectName.xcarchive');
-            expect(args[12]).toEqual('archive');
-            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
-            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
-            expect(args[15]).toEqual('-sdk');
-            expect(args[16]).toEqual('TestSdkFlag');
-            expect(args.length).toEqual(17);
+            expect(args).toEqual([
+                '-workspace',
+                'TestProjectName.xcworkspace',
+                '-scheme',
+                'TestProjectName',
+                '-configuration',
+                'TestConfiguration',
+                '-destination',
+                'generic/platform=iOS',
+                '-archivePath',
+                'TestProjectName.xcarchive',
+                'archive',
+                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'),
+                '-sdk',
+                'TestSdkFlag'
+            ]);
+            expect(args.length).toEqual(15);
             done();
         });
 
@@ -161,47 +160,47 @@ describe('build', function () {
             var buildFlags = '-archivePath TestArchivePathFlag';
 
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, buildFlags, 'iPhone 5s');
-            expect(args[0]).toEqual('-xcconfig');
-            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
-            expect(args[2]).toEqual('-workspace');
-            expect(args[3]).toEqual('TestProjectName.xcworkspace');
-            expect(args[4]).toEqual('-scheme');
-            expect(args[5]).toEqual('TestProjectName');
-            expect(args[6]).toEqual('-configuration');
-            expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-sdk');
-            expect(args[9]).toEqual('iphonesimulator');
-            expect(args[10]).toEqual('-destination');
-            expect(args[11]).toEqual('platform=iOS Simulator,name=iPhone 5s');
-            expect(args[12]).toEqual('build');
-            expect(args[13]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'));
-            expect(args[14]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
-            expect(args[15]).toEqual('-archivePath');
-            expect(args[16]).toEqual('TestArchivePathFlag');
-            expect(args.length).toEqual(17);
+            expect(args).toEqual([
+                '-workspace',
+                'TestProjectName.xcworkspace',
+                '-scheme',
+                'TestProjectName',
+                '-configuration',
+                'TestConfiguration',
+                '-sdk',
+                'iphonesimulator',
+                '-destination',
+                'platform=iOS Simulator,name=iPhone 5s',
+                'build',
+                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'),
+                'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'),
+                '-archivePath',
+                'TestArchivePathFlag'
+            ]);
+            expect(args.length).toEqual(15);
             done();
         });
 
         it('should generate appropriate args for automatic provisioning', function (done) {
             var isDevice = true;
             var args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null, null, true);
-            expect(args[0]).toEqual('-xcconfig');
-            expect(args[1]).toEqual(path.join('/test', 'build-testconfiguration.xcconfig'));
-            expect(args[2]).toEqual('-workspace');
-            expect(args[3]).toEqual('TestProjectName.xcworkspace');
-            expect(args[4]).toEqual('-scheme');
-            expect(args[5]).toEqual('TestProjectName');
-            expect(args[6]).toEqual('-configuration');
-            expect(args[7]).toEqual('TestConfiguration');
-            expect(args[8]).toEqual('-destination');
-            expect(args[9]).toEqual('generic/platform=iOS');
-            expect(args[10]).toEqual('-archivePath');
-            expect(args[11]).toEqual('TestProjectName.xcarchive');
-            expect(args[12]).toEqual('-allowProvisioningUpdates');
-            expect(args[13]).toEqual('archive');
-            expect(args[14]).toEqual('CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'));
-            expect(args[15]).toEqual('SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'));
-            expect(args.length).toEqual(16);
+            expect(args).toEqual([
+                '-workspace',
+                'TestProjectName.xcworkspace',
+                '-scheme',
+                'TestProjectName',
+                '-configuration',
+                'TestConfiguration',
+                '-destination',
+                'generic/platform=iOS',
+                '-archivePath',
+                'TestProjectName.xcarchive',
+                '-allowProvisioningUpdates',
+                'archive',
+                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
+            ]);
+            expect(args.length).toEqual(14);
             done();
         });
     });
@@ -242,14 +241,6 @@ describe('build', function () {
 
         var parseBuildFlag = build.__get__('parseBuildFlag');
 
-        it('should detect an xcconfig change', function (done) {
-            var buildFlag = '-xcconfig /path/to/config';
-            var args = { 'otherFlags': [] };
-            parseBuildFlag(buildFlag, args);
-            expect(args.xcconfig).toEqual('/path/to/config');
-            expect(args.otherFlags.length).toEqual(0);
-            done();
-        });
         it('should detect a workspace change', function (done) {
             var buildFlag = '-workspace MyTestWorkspace';
             var args = { 'otherFlags': [] };


### PR DESCRIPTION
### Platforms affected
ios

### What does this PR do?
- Remove xcconfig build flag for device and emulator.
- Remove custom argument override for xcconfig.
- Updated build test spec with removal of xcconfig with cleanup.

Since Cordova projects are using `xcworkspace` and the `content.xcworkspacedata` file declares our projects `xcodeproj`, the `xcconfig` file paths are declared in the `pbxproj`.

*contents.xcworkspacedata*
```
<FileRef location = "group:HelloCordova.xcodeproj"></FileRef>
```

Once a Pod project is added to the application, for example `cordova-plugin-firebase-messaging`,  the `contents.xcworkspacedata` file is updated to reflect the Pod project.

```
<FileRef location = "group:HelloCordova.xcodeproj"></FileRef>
<FileRef location = "group:Pods/Pods.xcodeproj"></FileRef>
```

If the xcconfig flag was set, in this scenario, pathing issues are introduced. For example header files will not be found and can not load. The xcconfig flag is applied to the entire workspace and will affect also the pod project’s xcconfig files.

*Example*
* In our application, the `SRCROOT` varaible is declared as `platforms/ios`.
* With the current implmetation (xcconfig flag deifned) the `SRCROOT` variable will be declared as `platforms/ios/Pods` for pod project.

In this case, in regards to the last item, the `PODS_ROOT = ${SRCROOT}/Pods` in `Pods-HelloCordova.debug.xcconfig` will be defined as `platforms/ios/Pods/Pods` which is incorrect.

Following this example:
```
$ cordova create podtest com.foobar.podtest
$ cd podtest
$ cordova platform add ios@4.5.4
$ cordova plugin add cordova-plugin-firebase-messaging
$ cordova prepare ios
$ cordova compile ios
```

You will notice in the build output the incorrect paths for example: `/cordova/podtest/platforms/ios/Pods/Pods/Headers/FirebaseCore -`

By removing the flag, the `SRCROOT` will not be affected for the pods project so that when `Pods-HelloCordova.debug.xcconfig` declares `PODS_ROOT`, the path will then be correct `platforms/ios/Pods`.

### What testing has been done on this change?
**General Tests**
- [x] `npm test`
- [x] `npm run eslint`

**Default Template**
- [x] `cordova build ios`
- [x] `cordova build ios --release --device`
- [x] `cordova build ios --debug --device`
- [x] `cordova run ios --emulator`
- [x] `cordova prepare ios`
- [x] `cordova compile ios`

**Default Template + CocoaPods Plugin**
- [x] `cordova build ios`
- [x] `cordova build ios --release --device`
- [x] `cordova build ios --debug --device`
- [x] `cordova run ios --emulator`
- [x] `cordova prepare ios`
- [x] `cordova compile ios`

*Pod test is using `cordova-support-google-services` and `cordova-plugin-firebase-messaging` plugin.*