### PR TITLE
Silence logging output during test runs

### DIFF
--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -22,7 +22,16 @@ var rewire = require('rewire');
 var build = rewire('../../../bin/templates/scripts/cordova/lib/build');
 
 describe('build', function () {
+    let emitSpy;
     var testProjectPath = path.join('/test', 'project', 'path');
+
+    beforeEach(function () {
+        // Events spy
+        emitSpy = jasmine.createSpy('emitSpy');
+        build.__set__('events', {
+            emit: emitSpy
+        });
+    });
 
     describe('getXcodeBuildArgs method', function () {
 
@@ -436,7 +445,6 @@ describe('build', function () {
         let shellLsSpy;
         let rejectSpy;
         let resolveSpy;
-        let emitSpy;
         const fakePath = '/path/foobar';
 
         beforeEach(() => {
@@ -454,12 +462,6 @@ describe('build', function () {
             build.__set__('Q', {
                 reject: rejectSpy,
                 resolve: resolveSpy
-            });
-
-            // Events spy
-            emitSpy = jasmine.createSpy('emitSpy');
-            build.__set__('events', {
-                emit: emitSpy
             });
         });
 

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -25,8 +25,6 @@ var shell = require('shelljs');
 var plist = require('plist');
 var xcode = require('xcode');
 var rewire = require('rewire');
-var EventEmitter = require('events').EventEmitter;
-var Api = require('../../../bin/templates/scripts/cordova/Api');
 var prepare = rewire('../../../bin/templates/scripts/cordova/lib/prepare');
 var projectFile = require('../../../bin/templates/scripts/cordova/lib/projectFile');
 var FileUpdater = require('cordova-common').FileUpdater;
@@ -61,15 +59,21 @@ function wrapperError (p, done, post) {
 }
 
 describe('prepare', function () {
-    var p;
+    var p, Api;
     beforeEach(function () {
+        Api = rewire('../../../bin/templates/scripts/cordova/Api');
+
+        // Prevent logging to avoid polluting the test reports
+        Api.__set__('events.emit', jasmine.createSpy());
+
         shell.mkdir('-p', iosPlatform);
         shell.cp('-rf', iosProjectFixture + '/*', iosPlatform);
-        p = new Api('ios', iosPlatform, new EventEmitter());
+        p = new Api('ios', iosPlatform);
     });
 
     afterEach(function () {
         shell.rm('-rf', path.join(__dirname, 'some'));
+        process.removeAllListeners();
     });
 
     describe('launch storyboard feature (CB-9762)', function () {


### PR DESCRIPTION
Ensures logging events aren't printed to the screen during jasmine test runs.