### PR TITLE
iOS: Fix running cordova build ios for emulators with Xcode 10.1 (ß)

### DIFF
--- a/bin/templates/scripts/cordova/lib/list-emulator-build-targets
+++ b/bin/templates/scripts/cordova/lib/list-emulator-build-targets
@@ -51,8 +51,8 @@ function listEmulatorBuildTargets () {
                 var availableDevicesInCategory = devices[deviceCategory];
                 availableDevicesInCategory.forEach(function (device) {
                     if (device.name === deviceType.name.replace(/\-inch/g, ' inch')) {
-                        if ((device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0)
-                            || device.isAvailable == 'YES') {
+                        if (device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0
+                            || device.isAvailable && device.isAvailable.toLowerCase() == 'yes') {
                                 // XCode 10 and lower
                                 availAcc.push(device);
                             }

--- a/bin/templates/scripts/cordova/lib/list-emulator-build-targets
+++ b/bin/templates/scripts/cordova/lib/list-emulator-build-targets
@@ -50,10 +50,13 @@ function listEmulatorBuildTargets () {
             var availableDevices = Object.keys(devices).reduce(function (availAcc, deviceCategory) {
                 var availableDevicesInCategory = devices[deviceCategory];
                 availableDevicesInCategory.forEach(function (device) {
-                    if (device.name === deviceType.name.replace(/\-inch/g, ' inch') && 
-                        device.availability.toLowerCase().indexOf('unavailable') < 0) {
-                            availAcc.push(device);
-                        }
+                    if (device.name === deviceType.name.replace(/\-inch/g, ' inch')) {
+                        if ((device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0)
+                            || device.isAvailable == 'YES') {
+                                // XCode 10 and lower
+                                availAcc.push(device);
+                            }
+                    } 
                 });
                 return availAcc;
             }, []);


### PR DESCRIPTION
Xcode's simctl json format has changed with Xcode 10.1, so without this fix "cordova build ios" will fail when built on a mac without a physical device attached to.

New Format running xcrun simctl list --json: 

```
{
        "state" : "Shutdown",
        "isAvailable" : "YES",
        "name" : "iPad Air",
        "udid" : "6A467ED2-BE11-4C79-9B51-39557672C181",
        "availabilityError" : ""
      },
```


### Platforms affected

Mac OS X, iOS

### What does this PR do?

Fix scanning for available emulators to build / run against. 

### What testing has been done on this change?

Tests have been run on a Mac mini with Mac OS X 10.3 and Xcode 10 + Xcode 10.1 ß installed. 

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
Not possible, because I am unable to create a new issue there. Apache Cordova is not shown in the List of available projects though I am able to search and find for issues on it.

- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
See above.
- [ ] Added automated test coverage as appropriate for this change.