### PR TITLE
Fix unit tests against cordova-common@3

### DIFF
--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -18,7 +18,7 @@
  */
 
 'use strict';
-var fs = require('fs');
+var fs = require('fs-extra');
 var os = require('os');
 var path = require('path');
 var shell = require('shelljs');


### PR DESCRIPTION
**Note:** This can't be merged until we do a release of cordova-common next major and update the dependency in cordova-ios package.json. But I'm opening this now so it's ready to go whenever that process happens.

### Platforms affected
iOS, but it's unit testing so technically none

### What does this PR do?
Fixes the unit tests when run against cordova-common master (which uses `fs-extra`)

### What testing has been done on this change?
Unit tests now pass.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
