### PR TITLE
UIWebView call loadRequest multiple times lead to deadlock in iOS12 (fixes #447)

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
@@ -329,9 +329,14 @@ static NSString *stripFragment(NSString* url)
             break;
 
         case STATE_WAITING_FOR_LOAD_FINISH:
-            if (_loadCount == 1) {
+            // fix call loadRequest multiple times just callback webViewDidFinishLoad once time in iOS 12
+            if (@available(iOS 12.0, *)) {
                 fireCallback = YES;
-                _state = STATE_IDLE;
+            } else {
+                if (_loadCount == 1) {
+                    fireCallback = YES;
+                    _state = STATE_IDLE;
+                }
             }
             _loadCount -= 1;
             break;


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fix issue 447 UIWebView call loadRequest multiple times lead to deadlock in iOS12.
The number of callback of `webViewDidStartLoad`  and `webViewDidFinishLoad`  is not equal.`_loadCount` will never equals 1, delegate's `webViewDidFinishLoad` and `[CDVUserAgentUtil releaseLock:vc.userAgentLockToken];` will never call.Then new CDVViewcontroller  won't load page.

### What testing has been done on this change?


### Checklist

