### PR TITLE
iOS: Fix running cordova build ios for emulators with Xcode 10.1 RELEASE

### DIFF
--- a/bin/templates/scripts/cordova/lib/list-emulator-build-targets
+++ b/bin/templates/scripts/cordova/lib/list-emulator-build-targets
@@ -51,11 +51,10 @@ function listEmulatorBuildTargets () {
                 var availableDevicesInCategory = devices[deviceCategory];
                 availableDevicesInCategory.forEach(function (device) {
                     if (device.name === deviceType.name.replace(/\-inch/g, ' inch')) {
-                        if ((device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0)
-                            || device.isAvailable == 'YES') {
-                                // XCode 10 and lower
-                                availAcc.push(device);
-                            }
+                        // Check new flag isAvailable (XCode 10.1+) or legacy string availability (XCode 10 and lower)
+                        if (device.isAvailable || (device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0)) {
+                            availAcc.push(device);
+                        }
                     } 
                 });
                 return availAcc;

--- a/bin/templates/scripts/cordova/lib/list-emulator-build-targets
+++ b/bin/templates/scripts/cordova/lib/list-emulator-build-targets
@@ -50,10 +50,13 @@ function listEmulatorBuildTargets () {
             var availableDevices = Object.keys(devices).reduce(function (availAcc, deviceCategory) {
                 var availableDevicesInCategory = devices[deviceCategory];
                 availableDevicesInCategory.forEach(function (device) {
-                    if (device.name === deviceType.name.replace(/\-inch/g, ' inch') && 
-                        device.availability.toLowerCase().indexOf('unavailable') < 0) {
-                            availAcc.push(device);
-                        }
+                    if (device.name === deviceType.name.replace(/\-inch/g, ' inch')) {
+                        if ((device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0)
+                            || device.isAvailable == 'YES') {
+                                // XCode 10 and lower
+                                availAcc.push(device);
+                            }
+                    } 
                 });
                 return availAcc;
             }, []);


### PR DESCRIPTION
Successor of https://github.com/apache/cordova-ios/pull/428, ready for XCode 10.1 release.

### Platforms affected
iOS

### What does this PR do?
Fix scanning for available emulators to build / run against.

### What testing has been done on this change?
Tests have been run on a Mac mini with Mac OS X Mojave 10.14 and Xcode 10.1.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
