### PR TITLE
Only copy platform node_modules when create by bin

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -64,6 +64,7 @@ var options = {
     cli: argv.cli,
     link: argv.link || argv.shared,
     customTemplate: argv.argv.remain[3],
+    copyPlatformNodeModules: true
 };
 
 require('./templates/scripts/cordova/loggingHelper').adjustLoggerLevel(argv);

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -66,7 +66,7 @@ function copyJsAndCordovaLib (projectPath, projectName, use_shared) {
     });
 }
 
-function copyScripts (projectPath, projectName) {
+function copyScripts (projectPath, projectName, options) {
     var srcScriptsDir = path.join(ROOT, 'bin', 'templates', 'scripts', 'cordova');
     var destScriptsDir = path.join(projectPath, 'cordova');
 
@@ -76,7 +76,7 @@ function copyScripts (projectPath, projectName) {
     // Copy in the new ones.
     var binDir = path.join(ROOT, 'bin');
     shell.cp('-r', srcScriptsDir, projectPath);
-    shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
+    if (options.copyPlatformNodeModules) shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
 
     // Copy the check_reqs script
     shell.cp(path.join(binDir, 'check_reqs*'), destScriptsDir);
@@ -232,7 +232,7 @@ exports.createProject = function (project_path, package_name, project_name, opts
 
     // CordovaLib stuff
     copyJsAndCordovaLib(project_path, project_name, use_shared);
-    copyScripts(project_path, project_name);
+    copyScripts(project_path, project_name, opts);
 
     events.emit('log', generateDoneMessage('create', use_shared));
     return Q.resolve();


### PR DESCRIPTION
### Platforms affected
ios

### What does this PR do?
When platform is installed though CLI, `cordova platform add android`, the copy node_modules step is no longer valid as dependencies are now at the project level.

The step is required only when the create binary from the platform repo is called.

https://github.com/apache/cordova/issues/32

### What testing has been done on this change?
- npm t
- https://ci.appveyor.com/project/erisu/cordova-ios/builds/20107772
- https://travis-ci.org/erisu/cordova-ios