### PR TITLE
Dependency bump cordova-common@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "engineStrict": true,
   "dependencies": {
-    "cordova-common": "2.1.0",
+    "cordova-common": "^3.0.0",
     "ios-sim": "^6.1.2",
     "nopt": "^3.0.6",
     "plist": "^1.2.0",


### PR DESCRIPTION
### Platforms affected
ios

### What does this PR do?
Updates the cordova-common dependency to ^3.0.0.

### What testing has been done on this change?
- npm t
- Travis CI Testing: https://travis-ci.org/erisu/cordova-ios/builds/452163362
- Appveyor Testing: https://ci.appveyor.com/project/erisu/cordova-ios/builds/20134164

Will require https://github.com/apache/cordova-ios/pull/448  after merge for fixing unit tests.