### PR TITLE
cordova run --list --device fails for Virtualhere devices (fixes #458)

### DIFF
--- a/bin/templates/scripts/cordova/lib/list-devices
+++ b/bin/templates/scripts/cordova/lib/list-devices
@@ -29,9 +29,9 @@ var Q = require('q'),
  */
 function listDevices() {
     var commands = [
-        Q.nfcall(exec, 'system_profiler SPUSBDataType | sed -n -e \'/iPad/,/Serial/p\' | grep "Serial Number:" | awk -F ": " \'{print $2 " iPad"}\''),
-        Q.nfcall(exec, 'system_profiler SPUSBDataType | sed -n -e \'/iPhone/,/Serial/p\' | grep "Serial Number:" | awk -F ": " \'{print $2 " iPhone"}\''),
-        Q.nfcall(exec, 'system_profiler SPUSBDataType | sed -n -e \'/iPod/,/Serial/p\' | grep "Serial Number:" | awk -F ": " \'{print $2 " iPod"}\'')
+        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPad/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPad\"}'"),
+        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPhone/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPhone\"}'"),
+        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPod/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPod\"}'"),
     ];
 
     // wrap al lexec calls into promises and wait until they're fullfilled

--- a/tests/spec/unit/lib/list-devices.spec.js
+++ b/tests/spec/unit/lib/list-devices.spec.js
@@ -28,9 +28,9 @@ describe('cordova/lib/list-devices', function () {
         });
         it('should invoke proper system calls to retrieve connected devices', function () {
             list_devices.run();
-            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/system_profiler.*iPad/g));
-            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/system_profiler.*iPod/g));
-            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/system_profiler.*iPhone/g));
+            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPad/g));
+            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPod/g));
+            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPhone/g));
         });
         it('should trim and split standard output and return as array', function (done) {
             Q.all.and.returnValue(Q.resolve([['   this is\nmy sweet\nstdout\n    ']]));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
I'm using Virtualhere (https://www.virtualhere.com/home) for developing remotely.
While Safari and Xcode do see the device after connecting via Virtualhere, cordova does not.
The attached patch remedies the issue in cordova-ios@4.5.5

### What testing has been done on this change?
Manual testing with virtualhere devices as well as regular USB devices

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

closes #458
