### PR TITLE
Fix issue after updating to macOS 10.14.2.

### DIFF
--- a/bin/templates/scripts/cordova/lib/list-emulator-build-targets
+++ b/bin/templates/scripts/cordova/lib/list-emulator-build-targets
@@ -50,7 +50,7 @@ function listEmulatorBuildTargets () {
             var availableDevices = Object.keys(devices).reduce(function (availAcc, deviceCategory) {
                 var availableDevicesInCategory = devices[deviceCategory];
                 availableDevicesInCategory.forEach(function (device) {
-                    if (device.name === deviceType.name.replace(/\-inch/g, ' inch')) {
+                    if (device.name === deviceType.name || device.name === deviceType.name.replace(/\-inch/g, ' inch')) {
                         // Check new flag isAvailable (XCode 10.1+) or legacy string availability (XCode 10 and lower)
                         if (device.isAvailable || (device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0)) {
                             availAcc.push(device);


### PR DESCRIPTION
After updating to macOS 10.14.2, running `cordova run ios` causes error `Cannot read property 'name' of undefined`. It turns out that the problem is due to `device.name` including the '-'. It seems this changed with the update to Xcode 10.1 which seems to have been bundled along with the 10.14.2 update.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
