### PR TITLE
Use cross-spawn & shelljs instead of child-process

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -20,7 +20,7 @@
 var Q = require('q');
 var path = require('path');
 var shell = require('shelljs');
-var spawn = require('./spawn');
+var superspawn = require('cordova-common').superspawn;
 var fs = require('fs');
 var plist = require('plist');
 var util = require('util');
@@ -168,10 +168,10 @@ module.exports.run = function (buildOpts) {
             var buildOutputDir = path.join(projectPath, 'build', (buildOpts.device ? 'device' : 'emulator'));
 
             // remove the build/device folder before building
-            return spawn('rm', [ '-rf', buildOutputDir ], projectPath)
+            return superspawn.spawn('rm', [ '-rf', buildOutputDir ], { cwd: projectPath })
                 .then(function () {
                     var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget, buildOpts.automaticProvisioning);
-                    return spawn('xcodebuild', xcodebuildArgs, projectPath);
+                    return superspawn.spawn('xcodebuild', xcodebuildArgs, { cwd: projectPath });
                 });
 
         }).then(function () {
@@ -225,7 +225,7 @@ module.exports.run = function (buildOpts) {
 
             function packageArchive () {
                 var xcodearchiveArgs = getXcodeArchiveArgs(projectName, projectPath, buildOutputDir, exportOptionsPath, buildOpts.automaticProvisioning);
-                return spawn('xcodebuild', xcodearchiveArgs, projectPath);
+                return superspawn.spawn('xcodebuild', xcodearchiveArgs, { cwd: projectPath });
             }
 
             return Q.nfcall(fs.writeFile, exportOptionsPath, exportOptionsPlist, 'utf-8')

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -168,11 +168,10 @@ module.exports.run = function (buildOpts) {
             var buildOutputDir = path.join(projectPath, 'build', (buildOpts.device ? 'device' : 'emulator'));
 
             // remove the build/device folder before building
-            return superspawn.spawn('rm', [ '-rf', buildOutputDir ], { cwd: projectPath })
-                .then(function () {
-                    var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget, buildOpts.automaticProvisioning);
-                    return superspawn.spawn('xcodebuild', xcodebuildArgs, { cwd: projectPath });
-                });
+            shell.rm('-rf', buildOutputDir);
+
+            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget, buildOpts.automaticProvisioning);
+            return superspawn.spawn('xcodebuild', xcodebuildArgs, { cwd: projectPath });
 
         }).then(function () {
             if (!buildOpts.device || buildOpts.noSign) {

--- a/bin/templates/scripts/cordova/lib/clean.js
+++ b/bin/templates/scripts/cordova/lib/clean.js
@@ -20,7 +20,7 @@
 var Q = require('q');
 var path = require('path');
 var shell = require('shelljs');
-var spawn = require('./spawn');
+var superspawn = require('cordova-common').superspawn;
 
 var projectPath = path.join(__dirname, '..', '..');
 
@@ -33,9 +33,9 @@ module.exports.run = function () {
         return Q.reject('No Xcode project found in ' + projectPath);
     }
 
-    return spawn('xcodebuild', ['-project', projectName, '-configuration', 'Debug', '-alltargets', 'clean'], projectPath)
+    return superspawn.spawn('xcodebuild', ['-project', projectName, '-configuration', 'Debug', '-alltargets', 'clean'], { cwd: projectPath })
         .then(function () {
-            return spawn('xcodebuild', ['-project', projectName, '-configuration', 'Release', '-alltargets', 'clean'], projectPath);
+            return superspawn.spawn('xcodebuild', ['-project', projectName, '-configuration', 'Release', '-alltargets', 'clean'], { cwd: projectPath });
         }).then(function () {
             return shell.rm('-rf', path.join(projectPath, 'build'));
         });

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -21,7 +21,7 @@ var Q = require('q');
 var path = require('path');
 var cp = require('child_process');
 var build = require('./build');
-var spawn = require('./spawn');
+var superspawn = require('cordova-common').superspawn;
 var check_reqs = require('./check_reqs');
 
 var events = require('cordova-common').events;
@@ -78,7 +78,7 @@ module.exports.run = function (runOptions) {
                         var ipafile = path.join(buildOutputDir, projectName + '.ipa');
 
                         // unpack the existing platform/ios/build/device/appname.ipa (zipfile), will create a Payload folder
-                        return spawn('unzip', [ '-o', '-qq', ipafile ], buildOutputDir);
+                        return superspawn.spawn('unzip', [ '-o', '-qq', ipafile ], { cwd: buildOutputDir });
                     })
                     .then(function () {
                         // Uncompress IPA (zip file)
@@ -87,14 +87,14 @@ module.exports.run = function (runOptions) {
                         var payloadFolder = path.join(buildOutputDir, 'Payload');
 
                         // delete the existing platform/ios/build/device/appname.app
-                        return spawn('rm', [ '-rf', appFile ], buildOutputDir)
+                        return superspawn('rm', [ '-rf', appFile ], { cwd: buildOutputDir })
                             .then(function () {
                                 // move the platform/ios/build/device/Payload/appname.app to parent
-                                return spawn('mv', [ '-f', appFileInflated, buildOutputDir ], buildOutputDir);
+                                return superspawn('mv', [ '-f', appFileInflated, buildOutputDir ], { cwd: buildOutputDir });
                             })
                             .then(function () {
                                 // delete the platform/ios/build/device/Payload folder
-                                return spawn('rm', [ '-rf', payloadFolder ], buildOutputDir);
+                                return superspawn('rm', [ '-rf', payloadFolder ], { cwd: buildOutputDir });
                             });
                     })
                     .then(function () {
@@ -149,7 +149,7 @@ function filterSupportedArgs (args) {
  * @return {Promise} Fullfilled when any device is connected, rejected otherwise
  */
 function checkDeviceConnected () {
-    return spawn('ios-deploy', ['-c', '-t', '1']);
+    return superspawn.spawn('ios-deploy', ['-c', '-t', '1']);
 }
 
 /**
@@ -161,9 +161,9 @@ function checkDeviceConnected () {
 function deployToDevice (appPath, target, extraArgs) {
     // Deploying to device...
     if (target) {
-        return spawn('ios-deploy', ['--justlaunch', '-d', '-b', appPath, '-i', target].concat(extraArgs));
+        return superspawn.spawn('ios-deploy', ['--justlaunch', '-d', '-b', appPath, '-i', target].concat(extraArgs));
     } else {
-        return spawn('ios-deploy', ['--justlaunch', '--no-wifi', '-d', '-b', appPath].concat(extraArgs));
+        return superspawn.spawn('ios-deploy', ['--justlaunch', '--no-wifi', '-d', '-b', appPath].concat(extraArgs));
     }
 }
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -21,6 +21,7 @@ var Q = require('q');
 var path = require('path');
 var cp = require('child_process');
 var build = require('./build');
+var shell = require('shelljs');
 var superspawn = require('cordova-common').superspawn;
 var check_reqs = require('./check_reqs');
 
@@ -87,15 +88,13 @@ module.exports.run = function (runOptions) {
                         var payloadFolder = path.join(buildOutputDir, 'Payload');
 
                         // delete the existing platform/ios/build/device/appname.app
-                        return superspawn('rm', [ '-rf', appFile ], { cwd: buildOutputDir })
-                            .then(function () {
-                                // move the platform/ios/build/device/Payload/appname.app to parent
-                                return superspawn('mv', [ '-f', appFileInflated, buildOutputDir ], { cwd: buildOutputDir });
-                            })
-                            .then(function () {
-                                // delete the platform/ios/build/device/Payload folder
-                                return superspawn('rm', [ '-rf', payloadFolder ], { cwd: buildOutputDir });
-                            });
+                        shell.rm('-rf', appFile);
+                        // move the platform/ios/build/device/Payload/appname.app to parent
+                        shell.mv('-f', appFileInflated, buildOutputDir);
+                        // delete the platform/ios/build/device/Payload folder
+                        shell.rm('-rf', payloadFolder);
+
+                        return null;
                     })
                     .then(function () {
                         appPath = path.join(projectPath, 'build', 'device', projectName + '.app');

--- a/bin/templates/scripts/cordova/lib/spawn.js
+++ b/bin/templates/scripts/cordova/lib/spawn.js
@@ -27,6 +27,7 @@ var proc = require('child_process');
  * @param  {String} opt_cwd       Working directory for command
  * @param  {String} opt_verbosity Verbosity level for command stdout output, "verbose" by default
  * @return {Promise}              Promise either fullfilled or rejected with error code
+ * @deprecated Use `require('cordova-common').superspawn` instead.
  */
 module.exports = function (cmd, args, opt_cwd) {
     var d = Q.defer();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Applies `superspawn` and `shelljs` consistently. Both modules are used in other places in this module. The existing `spawn.js` in this project should be obsolete now. I preserved it just in case.

**Details by @brodybits:**

Change details:
* Use `cross-spawn` ("superspawn") instead of `child-process` spawn
* Use `shelljs` instead instead of `child-process` spawn in other places
* Add a comment that the `spawn` function provided by `spawn.js` is deprecated

Motivation: this change will allow us to spawn with `printCommand: true` option, to print the `xcodebuild` and other shell commands as proposed in #479.

### What testing has been done on this change?
~~Nothing at all.~~

- [x] Green Travis CI build