### PR TITLE
Add warning that function in spawn.js is deprecated

### DIFF
--- a/bin/templates/scripts/cordova/lib/spawn.js
+++ b/bin/templates/scripts/cordova/lib/spawn.js
@@ -30,6 +30,9 @@ var proc = require('child_process');
  * @deprecated Use `require('cordova-common').superspawn` instead.
  */
 module.exports = function (cmd, args, opt_cwd) {
+    console.warn(
+        'This function is deprecated, may be removed from a future release. ' +
+        "Use `require('cordova-common').superspawn` instead.");
     var d = Q.defer();
     try {
         var child = proc.spawn(cmd, args, {cwd: opt_cwd, stdio: 'inherit'});


### PR DESCRIPTION
followup to PR #478, now that cordova-ios does not internally use the function any more

/cc @oliversalzburg