### PR TITLE
Ensure test failure on unexpected promise resolution

### DIFF
--- a/tests/spec/component/versions.spec.js
+++ b/tests/spec/component/versions.spec.js
@@ -25,38 +25,40 @@ if (process.platform === 'darwin') {
     describe('versions', function () {
         describe('get_tool_version method', () => {
             it('should not have found tool by name.', (done) => {
-                versions.get_tool_version('unknown').catch((error) => {
-                    expect(error).toContain('is not valid tool name');
-                    done();
-                });
+                versions.get_tool_version('unknown')
+                    .then(() => done.fail('expected promise rejection'))
+                    .catch((error) => {
+                        expect(error).toContain('is not valid tool name');
+                        done();
+                    });
             });
 
             it('should find xcodebuild version.', (done) => {
                 versions.get_tool_version('xcodebuild').then((version) => {
                     expect(version).not.toBe(undefined);
                     done();
-                });
+                }).catch(() => done.fail('expected promise resolution'));
             });
 
             it('should find ios-sim version.', (done) => {
                 versions.get_tool_version('ios-sim').then((version) => {
                     expect(version).not.toBe(undefined);
                     done();
-                });
+                }).catch(() => done.fail('expected promise resolution'));
             });
 
             it('should find ios-deploy version.', (done) => {
                 versions.get_tool_version('ios-deploy').then((version) => {
                     expect(version).not.toBe(undefined);
                     done();
-                });
+                }).catch(() => done.fail('expected promise resolution'));
             });
 
             it('should find pod version.', (done) => {
                 versions.get_tool_version('pod').then((version) => {
                     expect(version).not.toBe(undefined);
                     done();
-                });
+                }).catch(() => done.fail('expected promise resolution'));
             });
         });
     });


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
It makes sure that the tests are failed correctly if the result is not as expected. Previously, these tests would simply time out after the Jasmine default timeout period. Now the tests will fail right away and give a better indication towards the reason.

### What testing has been done on this change?
I've ran the tests.

```shell
Started
....F

Failures:
1) versions get_tool_version method should find pod version.
  Message:
    Failed: expected promise resolution
  Stack:
    Error: expected promise resolution
        at versions.get_tool_version.then.catch (/Users/oliver/cordova-ios/tests/spec/component/versions.spec.js:61:37)
```