### PR TITLE
Fix issue #486. Distinguish xcodebuild `build` command and `archive` command.

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -170,7 +170,7 @@ module.exports.run = function (buildOpts) {
             // remove the build/device folder before building
             shell.rm('-rf', buildOutputDir);
 
-            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget, buildOpts.automaticProvisioning);
+            var xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget, buildOpts.automaticProvisioning, buildOpts.buildAction);
             return superspawn.spawn('xcodebuild', xcodebuildArgs, { cwd: projectPath, printCommand: true, stdio: 'inherit' });
 
         }).then(function () {
@@ -269,7 +269,7 @@ module.exports.findXCodeProjectIn = findXCodeProjectIn;
  * @param  {Boolean} autoProvisioning   Whether to allow Xcode to automatically update provisioning
  * @return {Array}                  Array of arguments that could be passed directly to spawn method
  */
-function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, buildFlags, emulatorTarget, autoProvisioning) {
+function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, buildFlags, emulatorTarget, autoProvisioning, buildAction) {
     var xcodebuildArgs;
     var options;
     var buildActions;
@@ -295,7 +295,7 @@ function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, b
             '-destination', customArgs.destination || 'generic/platform=iOS',
             '-archivePath', customArgs.archivePath || projectName + '.xcarchive'
         ];
-        buildActions = [ 'archive' ];
+        buildActions = buildAction ? [ buildAction ] : [ 'archive' ];
         settings = [
             customArgs.configuration_build_dir || 'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'device'),
             customArgs.shared_precomps_dir || 'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')


### PR DESCRIPTION
distinguish `xcodebuild build` and `xcodebuild archive` according to `cordova build` and `cordova run`

### Platforms affected
cordova-ios 

### What does this PR do?
Resolve this the #486

1. removing `shelljs` in cordova/lib/run.js.  This is because `shelljs.rm` can not remove symbolic link.
2. using `xcodebuild build` at `cordova run --device`. Because `ios-deploy` can not work normally with `.app` pacakge obtained by`xcodebuild archive` and `xcodebuild -exportArchive` command.  
3. new option `--nobuild-device` is added. This is force skip build process evenwhen `cordova run --device`.

In this PR, `build.js` is called from `run.js` with the build-action `build`. This is because we should use internal `xcodebuild build` command to get the `.app` package instead of `xcodebuild archive` command with Xcode 10. 

Before this PR,
`cordova run --device` runs as follows.

1. `cordova-lib` calls `build.js` 
2. `cordova-lib` calls `run.js` with `--nobuild` option.  => But `ios-deploy` does not work normally.

After this PR,
`cordova run --device` runs as follows.

1. `cordova-lib` calls `build.js` (This build process is unnecessary. Because the `ios-deploy` does not work normally with the obtained .app package ) 
2. `cordova-lib` calls `run.js` with `--nobuild` option. => `run.js` calls `build.js` with option `buildFlag: CONFIGURATION_BUILD_DIR=[projectPath]/build/device-run` and `buildAction: build`.
 
Although this PR works with the latest cordova-lib, there is one unnecessary build process.
To remove unnecessary build process, we should update `cordova-lib`. I will send new PR for cordova-lib.

### What testing has been done on this change?
I checked as follows with both Xcode9 and Xcode10 envrionment.

```
$ npx cordova@nightly create xcode10Test com.foo.bar
$ cd xcode10Test
$ vi build.json
(set the certificate and provisioning file, development for debug build and ad-hoc for release build)
$ npx cordova@nightly platform add github:knight9999/cordova-ios#fix_cordova_run
$ npx cordova@nightly run --emulator --debug 
(In some environment, you should specify the target like
`--target="iPhone-8, 11.3"`.  The available targets are shown by `npx cordova@nightly run --list` This is because the selecting default simulator logic is different between build.js and run.js. This is another issue we should solve. but is out of this PR.) 
(confirm the app on emulator)
$ npx cordova@nightly run --device --debug
(confirm the app on device)
$ npx cordova@nightly run --device --release
(confirm the app on device)
$ npx cordova@nightly run --device --release --nobuild --nobuild-device
(This skip build processes. confirm the app on device)
$ npx cordova@nightly build --device
(install .ipa file and confirm the app on device)
$ npx cordova@nightly build --release
(install .ipa file and confirm the app on device)
```

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
