### PR TITLE
Replace ios-deploy with node-ios-device

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
 
 install:
   - npm install
-  - npm install ios-deploy
   - npm install -g codecov
 
 script:

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -110,9 +110,8 @@ module.exports.run = function (buildOpts) {
                 // we also explicitly set device flag in options as we pass
                 // those parameters to other api (build as an example)
                 buildOpts.device = true;
-                return check_reqs.check_ios_deploy();
             }
-        }).then(function () {
+
             // CB-12287: Determine the device we should target when building for a simulator
             if (!buildOpts.device) {
                 var newTarget = buildOpts.target || '';

--- a/bin/templates/scripts/cordova/lib/check_reqs.js
+++ b/bin/templates/scripts/cordova/lib/check_reqs.js
@@ -30,11 +30,6 @@ const XCODEBUILD_MIN_VERSION = '9.0.0';
 const XCODEBUILD_NOT_FOUND_MESSAGE =
     'Please install version ' + XCODEBUILD_MIN_VERSION + ' or greater from App Store';
 
-const IOS_DEPLOY_MIN_VERSION = '1.9.2';
-const IOS_DEPLOY_NOT_FOUND_MESSAGE =
-    'Please download, build and install version ' + IOS_DEPLOY_MIN_VERSION + ' or greater' +
-    ' from https://github.com/phonegap/ios-deploy into your path, or do \'npm install -g ios-deploy\'';
-
 const COCOAPODS_MIN_VERSION = '1.0.1';
 const COCOAPODS_NOT_FOUND_MESSAGE =
     'Please install version ' + COCOAPODS_MIN_VERSION + ' or greater from https://cocoapods.org/';
@@ -51,14 +46,6 @@ const COCOAPODS_REPO_NOT_FOUND_MESSAGE = 'The CocoaPods repo at ~/.cocoapods was
  */
 module.exports.run = module.exports.check_xcodebuild = function () {
     return checkTool('xcodebuild', XCODEBUILD_MIN_VERSION, XCODEBUILD_NOT_FOUND_MESSAGE);
-};
-
-/**
- * Checks if ios-deploy util is available
- * @return {Promise} Returns a promise either resolved with ios-deploy version or rejected
- */
-module.exports.check_ios_deploy = function () {
-    return checkTool('ios-deploy', IOS_DEPLOY_MIN_VERSION, IOS_DEPLOY_NOT_FOUND_MESSAGE);
 };
 
 module.exports.check_os = function () {
@@ -136,7 +123,7 @@ module.exports.check_cocoapods = function (toolChecker) {
 
 /**
  * Checks if specific tool is available.
- * @param  {String} tool       Tool name to check. Known tools are 'xcodebuild' and 'ios-deploy'
+ * @param  {String} tool       Tool name to check. Known tools are 'xcodebuild'
  * @param  {Number} minVersion Min allowed tool version.
  * @param  {String} message    Message that will be used to reject promise.
  * @param  {String} toolFriendlyName  Friendly name of the tool, to report to the user. Optional.
@@ -187,7 +174,6 @@ module.exports.check_all = function () {
     const requirements = [
         new Requirement('os', 'Apple macOS', true),
         new Requirement('xcode', 'Xcode'),
-        new Requirement('ios-deploy', 'ios-deploy'),
         new Requirement('CocoaPods', 'CocoaPods')
     ];
 
@@ -197,7 +183,6 @@ module.exports.check_all = function () {
     let checkFns = [
         module.exports.check_os,
         module.exports.check_xcodebuild,
-        module.exports.check_ios_deploy,
         module.exports.check_cocoapods
     ];
 

--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -92,23 +92,6 @@ exports.get_apple_xcode_version = function () {
 };
 
 /**
- * Gets ios-deploy util version
- * @return {Promise} Promise that either resolved with ios-deploy version
- *                           or rejected in case of error
- */
-exports.get_ios_deploy_version = function () {
-    var d = Q.defer();
-    child_process.exec('ios-deploy --version', function (error, stdout, stderr) {
-        if (error) {
-            d.reject(stderr);
-        } else {
-            d.resolve(stdout);
-        }
-    });
-    return d.promise;
-};
-
-/**
  * Gets pod (CocoaPods) util version
  * @return {Promise} Promise that either resolved with pod version
  *                           or rejected in case of error
@@ -144,7 +127,7 @@ exports.get_ios_sim_version = function () {
 
 /**
  * Gets specific tool version
- * @param  {String} toolName Tool name to check. Known tools are 'xcodebuild', 'ios-sim' and 'ios-deploy'
+ * @param  {String} toolName Tool name to check. Known tools are 'xcodebuild' and 'ios-sim'
  * @return {Promise}         Promise that either resolved with tool version
  *                                   or rejected in case of error
  */
@@ -152,9 +135,8 @@ exports.get_tool_version = function (toolName) {
     switch (toolName) {
     case 'xcodebuild': return exports.get_apple_xcode_version();
     case 'ios-sim': return exports.get_ios_sim_version();
-    case 'ios-deploy': return exports.get_ios_deploy_version();
     case 'pod': return exports.get_cocoapods_version();
-    default: return Q.reject(toolName + ' is not valid tool name. Valid names are: \'xcodebuild\', \'ios-sim\', \'ios-deploy\', and \'pod\'');
+    default: return Q.reject(toolName + ' is not valid tool name. Valid names are: \'xcodebuild\', \'ios-sim\', and \'pod\'');
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "cordova-common": "^3.0.0",
     "ios-sim": "^6.1.2",
+    "node-ios-device": "^1.6.3",
     "nopt": "^3.0.6",
     "plist": "^1.2.0",
     "q": "^1.4.1",

--- a/tests/spec/component/versions.spec.js
+++ b/tests/spec/component/versions.spec.js
@@ -47,13 +47,6 @@ if (process.platform === 'darwin') {
                 }).catch(() => done.fail('expected promise resolution'));
             });
 
-            it('should find ios-deploy version.', (done) => {
-                versions.get_tool_version('ios-deploy').then((version) => {
-                    expect(version).not.toBe(undefined);
-                    done();
-                }).catch(() => done.fail('expected promise resolution'));
-            });
-
             it('should find pod version.', (done) => {
                 versions.get_tool_version('pod').then((version) => {
                     expect(version).not.toBe(undefined);


### PR DESCRIPTION
Closes #419, #420
Fixes #429 

### What does this PR do?
Replaces `ios-deploy` with `node-ios-device`.
Removes a global dependency.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.