### PR TITLE
[WIP] Update Xcode version supported (9.x/10.x/...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Cordova iOS is an iOS application library that allows for Cordova-based projects
 
 Requires:
 
-* Xcode 8.x or greater. Download it at [http://developer.apple.com/downloads](http://developer.apple.com/downloads) or the [Mac App Store](http://itunes.apple.com/us/app/xcode/id497799835?mt=12).
+* Xcode 9.x (deprecated), 10, or greater. Download it at [http://developer.apple.com/downloads](http://developer.apple.com/downloads) or the [Mac App Store](http://itunes.apple.com/us/app/xcode/id497799835?mt=12).
 * [node.js](https://nodejs.org)
 
 Create a Cordova project


### PR DESCRIPTION
Continuation from PR #386: show minimum Xcode version as 9.x (deprecated) or 10.

This is assuming that the issues with Xcode 10 discussed in #407 are resolved by the time we make the new release of cordova-ios.

~~P.S. Linking to apache/cordova-docs#863: Minimum Xcode version in cordova-docs & cordova-ios not consistent~~ (sorry apache/cordova-docs#863 was an old issue, will raise a new issue to track this one)