### PR TITLE
Fixes $(PRODUCT_BUNDLE_IDENTIFIER) not being resolved for a product archive

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -183,7 +183,15 @@ module.exports.run = function (buildOpts) {
                 pbxproj: path.join(projectPath, projectName + '.xcodeproj', 'project.pbxproj')
             };
 
-            var bundleIdentifier = projectFile.parse(locations).getPackageName();
+            var project = projectFile.parse(locations);
+            var packageName = project.getPackageName();
+            var bundleIdentifier = packageName;
+
+            var variables = packageName.match(/\$\((\w+)\)/) // match $(VARIABLE), if any
+            if (variables && variables.length >=2) {
+                bundleIdentifier = project.xcode.getBuildProperty(variables[1]);
+            }
+
             var exportOptions = {'compileBitcode': false, 'method': 'development'};
 
             if (buildOpts.packageType) {


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?

Fixes #407 (not sure if it does it for everything yet)

### What testing has been done on this change?

Manual
