### PR TITLE
GH-498: (ios) support old cordova-common in which no getPodSpecs function

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -267,7 +267,7 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
         })
         .then(function () {
             if (plugin != null) {
-                var podSpecs = plugin.getPodSpecs(self.platform);
+                var podSpecs = plugin.getPodSpecs ? plugin.getPodSpecs(self.platform) : [];
                 var frameworkTags = plugin.getFrameworks(self.platform);
                 var frameworkPods = frameworkTags.filter(function (obj) {
                     return (obj.type === 'podspec');
@@ -321,7 +321,7 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
         })
         .then(function () {
             if (plugin != null) {
-                var podSpecs = plugin.getPodSpecs(self.platform);
+                var podSpecs = plugin.getPodSpecs ? plugin.getPodSpecs(self.platform) : [];
                 var frameworkTags = plugin.getFrameworks(self.platform);
                 var frameworkPods = frameworkTags.filter(function (obj) {
                     return (obj.type === 'podspec');


### PR DESCRIPTION
### Platforms affected
Cordova-iOS

### What does this PR do?
Fix the issue #498 .
The old cordova-common (2.x.x) has no `getPodSpecs` function.
To support the old cordova-common, skipping call getPosSpecs function if it does not exist. 

### What testing has been done on this change?
creating project by cordova 8.1.2 (cordova-lib@8.1.1, cordova-common@2.2.5).
adding this cordova-ios platform.
checking there is no errors.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
