### PR TITLE
GH-407: remove removing certificates functions in xcode post scripts

### DIFF
--- a/bin/templates/scripts/cordova/lib/copy-www-build-step.js
+++ b/bin/templates/scripts/cordova/lib/copy-www-build-step.js
@@ -51,9 +51,9 @@ try {
 // Code signing files must be removed or else there are
 // resource signing errors.
 shell.rm('-rf', dstWwwDir);
-shell.rm('-rf', path.join(dstDir, '_CodeSignature'));
-shell.rm('-rf', path.join(dstDir, 'PkgInfo'));
-shell.rm('-rf', path.join(dstDir, 'embedded.mobileprovision'));
+// shell.rm('-rf', path.join(dstDir, '_CodeSignature'));
+// shell.rm('-rf', path.join(dstDir, 'PkgInfo'));
+// shell.rm('-rf', path.join(dstDir, 'embedded.mobileprovision'));
 
 // Copy www dir recursively
 var code;

--- a/bin/templates/scripts/cordova/lib/copy-www-build-step.js
+++ b/bin/templates/scripts/cordova/lib/copy-www-build-step.js
@@ -48,12 +48,7 @@ try {
     process.exit(2);
 }
 
-// Code signing files must be removed or else there are
-// resource signing errors.
 shell.rm('-rf', dstWwwDir);
-// shell.rm('-rf', path.join(dstDir, '_CodeSignature'));
-// shell.rm('-rf', path.join(dstDir, 'PkgInfo'));
-// shell.rm('-rf', path.join(dstDir, 'embedded.mobileprovision'));
 
 // Copy www dir recursively
 var code;


### PR DESCRIPTION
### Platforms affected
ios

### What does this PR do?
To fix #407 with automatic provioning.
This PR fixs the issue that `ios-deploy` (`cordova run --device`) can not work with automatic provisoning. 

This PR simply remove following lines 

```
shell.rm('-rf', path.join(dstDir, '_CodeSignature'));
shell.rm('-rf', path.join(dstDir, 'PkgInfo'));
shell.rm('-rf', path.join(dstDir, 'embedded.mobileprovision'));
```

in cordova/lib/copy-www-build-step.js.

I am not sure why that codes are here.
But I image that the old version of the cordova use `xcrun` for the certification after building process. In such situation, the above codes are necessary.

However I found that these codes lead strange behavior with automatic provisioning in ios-deploy (in `cordova run --device`) as reported in #407 .

### What testing has been done on this change?

I test as following on my local mac (mojave).

1. `cordova run --device` with automatic provisioning using Xcode 10.1.
2. `cordova run --device` with manual provioning using Xcode 10.1.
3. `cordova run --device` with automatic provisioning using Xcode 9.4.1.
4. `cordova run --device` with manual provioning using Xcode 9.4.1.

All they works well.

```
npx cordova@nightly 
### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
