### PR TITLE
GH-523 : ignore swift version settings of cocoapods libraries on windows

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -445,7 +445,7 @@ Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods) {
 
             return podfileFile.install(check_reqs.check_cocoapods)
                 .then(function () {
-                    self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile);
+                    return self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile);
                 });
         } else {
             events.emit('verbose', 'Podfile unchanged, skipping `pod install`');
@@ -564,7 +564,7 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
 
             return podfileFile.install(check_reqs.check_cocoapods)
                 .then(function () {
-                    self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile);
+                    return self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile);
                 });
         } else {
             events.emit('verbose', 'Podfile unchanged, skipping `pod install`');
@@ -582,41 +582,47 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
 Api.prototype.setSwiftVersionForCocoaPodsLibraries = function (podsjsonFile) {
     var self = this;
     var __dirty = false;
-    var podPbxPath = path.join(self.root, 'Pods', 'Pods.xcodeproj', 'project.pbxproj');
-    var podXcodeproj = xcode.project(podPbxPath);
-    podXcodeproj.parseSync();
-    var podTargets = podXcodeproj.pbxNativeTargetSection();
-    var podConfigurationList = podXcodeproj.pbxXCConfigurationList();
-    var podConfigs = podXcodeproj.pbxXCBuildConfigurationSection();
+    return check_reqs.check_cocoapods().then(function (toolOptions) {
+        if (toolOptions.ignore) {
+            events.emit('verbose', '=== skip Swift Version Settings For Cocoapods Libraries');
+        } else {
+            var podPbxPath = path.join(self.root, 'Pods', 'Pods.xcodeproj', 'project.pbxproj');
+            var podXcodeproj = xcode.project(podPbxPath);
+            podXcodeproj.parseSync();
+            var podTargets = podXcodeproj.pbxNativeTargetSection();
+            var podConfigurationList = podXcodeproj.pbxXCConfigurationList();
+            var podConfigs = podXcodeproj.pbxXCBuildConfigurationSection();
 
-    var libraries = podsjsonFile.getLibraries();
-    Object.keys(libraries).forEach(function (key) {
-        var podJson = libraries[key];
-        var name = podJson.name;
-        var swiftVersion = podJson['swift-version'];
-        if (swiftVersion) {
-            __dirty = true;
-            Object.keys(podTargets).filter(function (targetKey) {
-                return podTargets[targetKey].productName === name;
-            }).map(function (targetKey) {
-                return podTargets[targetKey].buildConfigurationList;
-            }).map(function (buildConfigurationListId) {
-                return podConfigurationList[buildConfigurationListId];
-            }).map(function (buildConfigurationList) {
-                return buildConfigurationList.buildConfigurations;
-            }).reduce(function (acc, buildConfigurations) {
-                return acc.concat(buildConfigurations);
-            }, []).map(function (buildConfiguration) {
-                return buildConfiguration.value;
-            }).forEach(function (buildId) {
-                __dirty = true;
-                podConfigs[buildId].buildSettings['SWIFT_VERSION'] = swiftVersion;
+            var libraries = podsjsonFile.getLibraries();
+            Object.keys(libraries).forEach(function (key) {
+                var podJson = libraries[key];
+                var name = podJson.name;
+                var swiftVersion = podJson['swift-version'];
+                if (swiftVersion) {
+                    __dirty = true;
+                    Object.keys(podTargets).filter(function (targetKey) {
+                        return podTargets[targetKey].productName === name;
+                    }).map(function (targetKey) {
+                        return podTargets[targetKey].buildConfigurationList;
+                    }).map(function (buildConfigurationListId) {
+                        return podConfigurationList[buildConfigurationListId];
+                    }).map(function (buildConfigurationList) {
+                        return buildConfigurationList.buildConfigurations;
+                    }).reduce(function (acc, buildConfigurations) {
+                        return acc.concat(buildConfigurations);
+                    }, []).map(function (buildConfiguration) {
+                        return buildConfiguration.value;
+                    }).forEach(function (buildId) {
+                        __dirty = true;
+                        podConfigs[buildId].buildSettings['SWIFT_VERSION'] = swiftVersion;
+                    });
+                }
             });
+            if (__dirty) {
+                fs.writeFileSync(podPbxPath, podXcodeproj.writeSync(), 'utf-8');
+            }
         }
     });
-    if (__dirty) {
-        fs.writeFileSync(podPbxPath, podXcodeproj.writeSync(), 'utf-8');
-    }
 };
 
 /**


### PR DESCRIPTION
### Platforms affected
cordova-ios

### Motivation and Context
Fixing the issue #523 

### Description
To avoid error on windows, adding checks cocoapods is available or not before changing swift version of cocoapods libraries.

### Testing
In my local Mac,
create project and adding phonegap-plugin-push.
Checking build.
Checking the application can receive push notifications.
(by using cordova@nightly)

In my local Windows 10,
create project and adding phonegap-plugin-push.
Checking to skip the cocoapods specific process.
(by using cordova@8.1.0)

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `ios` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
