### PR TITLE
(ios) Fix setting of target-device to handset in combination with plugins and resource files

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -22,7 +22,6 @@ var Q = require('q');
 var fs = require('fs');
 var path = require('path');
 var shell = require('shelljs');
-var xcode = require('xcode');
 var unorm = require('unorm');
 var plist = require('plist');
 var URL = require('url');
@@ -282,15 +281,15 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     var needUpdatedBuildSettingsForLaunchStoryboard = checkIfBuildSettingsNeedUpdatedForLaunchStoryboard(platformConfig, infoPlist);
     var swiftVersion = platformConfig.getPreference('SwiftVersion', 'ios');
 
-    var proj = new xcode.project(locations.pbxproj); /* eslint new-cap : 0 */
+    var project;
 
     try {
-        proj.parseSync();
+        project = projectFile.parse(locations);
     } catch (err) {
         return Q.reject(new CordovaError('Could not parse ' + locations.pbxproj + ': ' + err));
     }
 
-    var origPkg = proj.getBuildProperty('PRODUCT_BUNDLE_IDENTIFIER');
+    var origPkg = project.xcode.getBuildProperty('PRODUCT_BUNDLE_IDENTIFIER');
 
     // no build settings provided and we don't need to update build settings for launch storyboards,
     // then we don't need to parse and update .pbxproj file
@@ -300,27 +299,27 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
 
     if (origPkg !== pkg) {
         events.emit('verbose', 'Set PRODUCT_BUNDLE_IDENTIFIER to ' + pkg + '.');
-        proj.updateBuildProperty('PRODUCT_BUNDLE_IDENTIFIER', pkg);
+        project.xcode.updateBuildProperty('PRODUCT_BUNDLE_IDENTIFIER', pkg);
     }
 
     if (targetDevice) {
         events.emit('verbose', 'Set TARGETED_DEVICE_FAMILY to ' + targetDevice + '.');
-        proj.updateBuildProperty('TARGETED_DEVICE_FAMILY', targetDevice);
+        project.xcode.updateBuildProperty('TARGETED_DEVICE_FAMILY', targetDevice);
     }
 
     if (deploymentTarget) {
         events.emit('verbose', 'Set IPHONEOS_DEPLOYMENT_TARGET to "' + deploymentTarget + '".');
-        proj.updateBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', deploymentTarget);
+        project.xcode.updateBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', deploymentTarget);
     }
 
     if (swiftVersion) {
         events.emit('verbose', 'Set SwiftVersion to "' + swiftVersion + '".');
-        proj.updateBuildProperty('SWIFT_VERSION', swiftVersion);
+        project.xcode.updateBuildProperty('SWIFT_VERSION', swiftVersion);
     }
 
-    updateBuildSettingsForLaunchStoryboard(proj, platformConfig, infoPlist);
+    updateBuildSettingsForLaunchStoryboard(project.xcode, platformConfig, infoPlist);
 
-    fs.writeFileSync(locations.pbxproj, proj.writeSync(), 'utf-8');
+    project.write();
 
     return Q();
 }
@@ -962,7 +961,7 @@ function processAccessAndAllowNavigationEntries (config) {
     var allow_navigations = config.getAllowNavigations();
 
     return allow_navigations
-        // we concat allow_navigations and accesses, after processing accesses
+    // we concat allow_navigations and accesses, after processing accesses
         .concat(accesses.map(function (obj) {
             // map accesses to a common key interface using 'href', not origin
             obj.href = obj.origin;


### PR DESCRIPTION
### Platforms affected
IOs

### Motivation and Context
when:
- setting the target device `<preference name="target-device" value="handset" />`
- using (any) plugins
- Adding a resource file `<resource-file src="GoogleService-Info.plist" />`

then:
`TARGETED_DEVICE_FAMILY` is reset to the default value of "1,2" while adding the resource file after handling the target device.

### Description
Instead of creating a new instance of the xcode project via `new xcode.project([...])` use the wrapped xcode project via `projectFile.parse([...])`.
This will reuse the cached xcode project, which is created when adding the plugins, and therefore maintain the changes when setting the target device.
The cached xcode project will then also be used when adding the resource file.

### Testing
- add plugins
- set target-device to handheld
- add a resource file

verify, that `TARGETED_DEVICE_FAMILY = 1;` is written to the project.pbxproj file.

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~
