### PR TITLE
Bump ios-sim to v8 to fix simulator listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "engineStrict": true,
   "dependencies": {
     "cordova-common": "^3.1.0",
-    "ios-sim": "^7.0.0",
+    "ios-sim": "^8.0.0",
     "nopt": "^4.0.1",
     "plist": "^3.0.1",
     "q": "^1.5.1",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves https://github.com/apache/cordova-ios/issues/547.


### Description
<!-- Describe your changes in detail -->
Updates `ios-sim` to version 8.


### Testing
<!-- Please describe in detail how you tested your changes. -->
All unit tests pass. Running the scripts to list emulators presented a list of emulator devices and iOS versions.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
