### PR TITLE
Override id with ios-CFBundleIdentifier

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -131,7 +131,7 @@ Api.createPlatform = function (destination, config, options, events) {
     var result;
     try {
         result = require('../../../lib/create')
-            .createProject(destination, config.packageName(), name, options)
+            .createProject(destination, config.getAttribute('ios-CFBundleIdentifier') || config.packageName(), name, options)
             .then(function () {
                 // after platform is created we return Api instance based on new Api.js location
                 // This is required to correctly resolve paths in the future api calls


### PR DESCRIPTION
Override id with  ios-CFBundleIdentifier  when both id and ios-CFBundleIdentifier are defined in config.xml

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When both id and ios-CFBundleIdentifier are defined in config.xml, Xcode project should be created with  ios-CFBundleIdentifier as the bundle identifier. Else, bundle identifier should be the id.
https://github.com/apache/cordova-ios/issues/565

### Description
<!-- Describe your changes in detail -->
Check both packageName(i.e. id) and ios-CFBundleIdentifier when creating the platform (Xcode project)


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested these scenarios,
1. config.xml with both id and ios-CFBundleIdentifier
2. config.xml with id only
3. config.xml with ios-CFBundleIdentifier only

### Checklist

- [X ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
