### PR TITLE
Don't write spec to podfile when it's an empty string

### DIFF
--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -313,7 +313,7 @@ Podfile.prototype.write = function () {
             }
         } else {
             var list = ['\'' + name + '\''];
-            if ('spec' in json) {
+            if ('spec' in json  && json.spec.length) {
                 list.push('\'' + json.spec + '\'');
             }
 

--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -313,7 +313,7 @@ Podfile.prototype.write = function () {
             }
         } else {
             var list = ['\'' + name + '\''];
-            if ('spec' in json  && json.spec.length) {
+            if ('spec' in json && json.spec.length) {
                 list.push('\'' + json.spec + '\'');
             }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When plugin framework tag contains an empty spec value (`spec=""`), Podfile becomes malformed and `pod install` command fails with
```
ArgumentError - Illformed requirement `""`
```

Example:
```xml
    <framework src="Fabric" type="podspec" spec="~> 1.7.6"/>
    <framework src="Crashlytics" type="podspec" spec="~> 3.10.1"/>
    <framework src="Firebase/Core" type="podspec" spec=""/>
```

Creates
```
	pod 'Fabric', '~> 1.7.6'
	pod 'Crashlytics', '~> 3.10.1'
	pod 'Firebase/Core', ''
```

Proposed change checks for an empty spec value and doesn't write version number:

```
	pod 'Fabric', '~> 1.7.6'
	pod 'Crashlytics', '~> 3.10.1'
	pod 'Firebase/Core'
```

### Description
<!-- Describe your changes in detail -->

I'm not sure if it's a bug in cordova-ios or specific plugin ([cordova-plugin-firebase-crashlytics](https://github.com/ReallySmallSoftware/cordova-plugin-firebase-crashlytics)).
However cordova documentation for the [framework tag](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#framework) doesn't specify if the spec attribute can be omitted so it seems valid to me to use empty value.



### Testing
<!-- Please describe in detail how you tested your changes. -->
- Install cordova-plugin-firebase-crashlytics plugin in verbose mode:
  `cordova plugin add cordova-plugin-firebase-crashlytics --verbose`
- Installation doesn't fail


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
