### PR TITLE
fix: iOS device list is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "engineStrict": true,
   "dependencies": {
     "cordova-common": "^3.1.0",
-    "ios-sim": "^8.0.0",
+    "ios-sim": "^8.0.1",
     "nopt": "^4.0.1",
     "plist": "^3.0.1",
     "q": "^1.5.1",


### PR DESCRIPTION
This closes #586

I tested it by installing `ios-sim@8.0.1` locally in a cordova project. Before the update, there are no virtual devices listed. After the update, there are virtual devices listed.