### PR TITLE
More logging for simulator selection and deployment

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -160,7 +160,7 @@ module.exports.run = function (buildOpts) {
                     if (!theTarget) {
                         return getDefaultSimulatorTarget().then(function (defaultTarget) {
                             emulatorTarget = defaultTarget.name;
-                            events.emit('log', 'Building for "' + emulatorTarget + '" Simulator (' + theTarget.identifier + ', ' + theTarget.simIdentifier + ')');
+                            events.emit('log', 'Building for "' + emulatorTarget + '" Simulator (' + defaultTarget.identifier + ', ' + defaultTarget.simIdentifier + ')');
                             return emulatorTarget;
                         });
                     } else {

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -160,12 +160,13 @@ module.exports.run = function (buildOpts) {
                     if (!theTarget) {
                         return getDefaultSimulatorTarget().then(function (defaultTarget) {
                             emulatorTarget = defaultTarget.name;
-                            events.emit('log', 'Building for "' + emulatorTarget + '" Simulator (' + defaultTarget.identifier + ', ' + defaultTarget.simIdentifier + ')');
+                            events.emit('warn', `No simulator found for "${newTarget}. Falling back to the default target.`);
+                            events.emit('log', `Building for "${emulatorTarget}" Simulator (${defaultTarget.identifier}, ${defaultTarget.simIdentifier}).`);
                             return emulatorTarget;
                         });
                     } else {
                         emulatorTarget = theTarget.name;
-                        events.emit('log', 'Building for "' + emulatorTarget + '" Simulator (' + theTarget.identifier + ', ' + theTarget.simIdentifier + ')');
+                        events.emit('log', `Building for "${emulatorTarget}" Simulator (${theTarget.identifier}, ${theTarget.simIdentifier}).`);
                         return emulatorTarget;
                     }
                 });

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -160,12 +160,12 @@ module.exports.run = function (buildOpts) {
                     if (!theTarget) {
                         return getDefaultSimulatorTarget().then(function (defaultTarget) {
                             emulatorTarget = defaultTarget.name;
-                            events.emit('log', 'Building for ' + emulatorTarget + ' Simulator');
+                            events.emit('log', 'Building for "' + emulatorTarget + '" Simulator (' + theTarget.identifier + ', ' + theTarget.simIdentifier + ')');
                             return emulatorTarget;
                         });
                     } else {
                         emulatorTarget = theTarget.name;
-                        events.emit('log', 'Building for ' + emulatorTarget + ' Simulator');
+                        events.emit('log', 'Building for "' + emulatorTarget + '" Simulator (' + theTarget.identifier + ', ' + theTarget.simIdentifier + ')');
                         return emulatorTarget;
                     }
                 });
@@ -217,6 +217,7 @@ module.exports.run = function (buildOpts) {
             events.emit('log', 'Building project: ' + path.join(projectPath, projectName + '.xcworkspace'));
             events.emit('log', '\tConfiguration: ' + configuration);
             events.emit('log', '\tPlatform: ' + (buildOpts.device ? 'device' : 'emulator'));
+            events.emit('log', '\tTarget: ' + emulatorTarget);
 
             var buildOutputDir = path.join(projectPath, 'build', (buildOpts.device ? 'device' : 'emulator'));
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -19,7 +19,6 @@
 
 var Q = require('q');
 var path = require('path');
-var cp = require('child_process');
 var build = require('./build');
 var shell = require('shelljs');
 var superspawn = require('cordova-common').superspawn;
@@ -208,15 +207,15 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
 
     return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true, stdio: 'pipe' })
         .progress(function (stdio) {
-            if (stdio.stderr) { 
-                console.error(stdio.stderr); 
+            if (stdio.stderr) {
+                console.error(stdio.stderr);
             }
             if (stdio.stdout) {
-                console.log('ios-sim log: ' + data.toString());
+                console.log('ios-sim log: ' + stdio.stdout);
             }
         })
-        .then(function(result){
-            console.log('Simulator successfully started via `ios-sim`.');
+        .then(function (result) {
+            console.log('Simulator successfully started via `ios-sim`.', result);
         });
 }
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -174,7 +174,6 @@ function deployToDevice (appPath, target, extraArgs) {
  * @return {Promise}        Resolves when deploy succeeds otherwise rejects
  */
 function deployToSim (appPath, target) {
-    // Select target device for emulator. Default is 'iPhone-6'
     if (!target) {
         return require('./list-emulator-images').run()
             .then(function (emulators) {

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -177,6 +177,7 @@ function deployToDevice (appPath, target, extraArgs) {
 function deployToSim (appPath, target) {
     events.emit('log', 'Deploying to simulator');
     if (!target) {
+        // Select target device for emulator
         return require('./list-emulator-images').run()
             .then(function (emulators) {
                 if (emulators.length > 0) {

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -202,9 +202,13 @@ function startSim (appPath, target) {
     return iossimLaunch(appPath, 'com.apple.CoreSimulator.SimDeviceType.' + target, logPath, '--exit');
 }
 
-function iossimLaunch (app_path, devicetypeid, log, exit) {
+function iossimLaunch (appPath, devicetypeid, log, exit) {
     var f = path.resolve(path.dirname(require.resolve('ios-sim')), 'bin', 'ios-sim');
-    var proc = cp.spawn(f, ['launch', app_path, '--devicetypeid', devicetypeid, '--log', log, exit]);
+    
+    var params = ['launch', appPath, '--devicetypeid', devicetypeid, '--log', log, exit];
+    console.log("$ " + f + params.join(' '));
+    var proc = cp.spawn(f, params);
+    
     proc.stdout.on('data', (data) => {
         console.log(data.toString());
     });

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -159,6 +159,7 @@ function checkDeviceConnected () {
  * @return {Promise}        Resolves when deploy succeeds otherwise rejects
  */
 function deployToDevice (appPath, target, extraArgs) {
+    events.emit('log', 'Deploying to device');
     // Deploying to device...
     if (target) {
         return superspawn.spawn('ios-deploy', ['--justlaunch', '-d', '-b', appPath, '-i', target].concat(extraArgs), { printCommand: true, stdio: 'inherit' });
@@ -174,6 +175,7 @@ function deployToDevice (appPath, target, extraArgs) {
  * @return {Promise}        Resolves when deploy succeeds otherwise rejects
  */
 function deployToSim (appPath, target) {
+    events.emit('log', 'Deploying to simulator');
     if (!target) {
         return require('./list-emulator-images').run()
             .then(function (emulators) {

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -210,7 +210,7 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
     var proc = cp.spawn(f, params);
     
     proc.stdout.on('data', (data) => {
-        console.log("Data from simulator: " + data.toString());
+        console.log("ios-sim log: " + data.toString());
     });
 }
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -205,17 +205,17 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
     var f = path.resolve(path.dirname(require.resolve('ios-sim')), 'bin', 'ios-sim');
     var params = ['launch', appPath, '--devicetypeid', devicetypeid, '--log', log, exit];
 
-    return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true, stdio: 'pipe' })
+    return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true })
         .progress(function (stdio) {
             if (stdio.stderr) {
-                console.error(stdio.stderr);
+                console.error('ios-sim: ' + stdio.stderr);
             }
             if (stdio.stdout) {
-                console.log('ios-sim log: ' + stdio.stdout);
+                events.emit('log', 'ios-sim: ' + stdio.stdout.trim());
             }
         })
         .then(function (result) {
-            console.log('Simulator successfully started via `ios-sim`.', result);
+            events.emit('log', 'Simulator successfully started via `ios-sim`.');
         });
 }
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -210,7 +210,7 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
     var proc = cp.spawn(f, params);
     
     proc.stdout.on('data', (data) => {
-        console.log(data.toString());
+        console.log("Data from simulator: " + data.toString());
     });
 }
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -187,7 +187,7 @@ function deployToSim (appPath, target) {
                         target = emulator;
                     }
                 });
-                events.emit('log', 'No target specified for emulator. Deploying to "' + target + '" simulator');
+                events.emit('log', `No target specified for emulator. Deploying to "${target}" simulator.`);
                 return startSim(appPath, target);
             });
     } else {
@@ -208,10 +208,10 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
     return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true })
         .progress(function (stdio) {
             if (stdio.stderr) {
-                console.error('ios-sim: ' + stdio.stderr);
+                events.emit('error', `[ios-sim] ${stdio.stderr}`);
             }
             if (stdio.stdout) {
-                events.emit('log', 'ios-sim: ' + stdio.stdout.trim());
+                events.emit('log', `[ios-sim] ${stdio.stdout.trim()}`);
             }
         })
         .then(function (result) {

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -188,7 +188,7 @@ function deployToSim (appPath, target) {
                         target = emulator;
                     }
                 });
-                events.emit('log', 'No target specified for emulator. Deploying to ' + target + ' simulator');
+                events.emit('log', 'No target specified for emulator. Deploying to "' + target + '" simulator');
                 return startSim(appPath, target);
             });
     } else {

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -207,11 +207,19 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
 
     var params = ['launch', appPath, '--devicetypeid', devicetypeid, '--log', log, exit];
     console.log('$ ' + f + ' ' + params.join(' '));
-    var proc = cp.spawn(f, params);
 
-    proc.stdout.on('data', (data) => {
-        console.log('ios-sim log: ' + data.toString());
-    });
+    return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true, stdio: 'inherit' })
+        .progress(function (stdio) {
+            if (stdio.stderr) { 
+                console.error(stdio.stderr); 
+            }
+            if (stdio.stdout) {
+                console.log('ios-sim log: ' + data.toString());
+            }
+        })
+        .then(function(result){
+            console.log('Simulator successfully started via `ios-sim`.');
+        });
 }
 
 function listDevices () {

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -204,13 +204,13 @@ function startSim (appPath, target) {
 
 function iossimLaunch (appPath, devicetypeid, log, exit) {
     var f = path.resolve(path.dirname(require.resolve('ios-sim')), 'bin', 'ios-sim');
-    
+
     var params = ['launch', appPath, '--devicetypeid', devicetypeid, '--log', log, exit];
-    console.log("$ " + f + ' ' + params.join(' '));
+    console.log('$ ' + f + ' ' + params.join(' '));
     var proc = cp.spawn(f, params);
-    
+
     proc.stdout.on('data', (data) => {
-        console.log("ios-sim log: " + data.toString());
+        console.log('ios-sim log: ' + data.toString());
     });
 }
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -206,7 +206,7 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
     var f = path.resolve(path.dirname(require.resolve('ios-sim')), 'bin', 'ios-sim');
     
     var params = ['launch', appPath, '--devicetypeid', devicetypeid, '--log', log, exit];
-    console.log("$ " + f + params.join(' '));
+    console.log("$ " + f + ' ' + params.join(' '));
     var proc = cp.spawn(f, params);
     
     proc.stdout.on('data', (data) => {

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -204,11 +204,9 @@ function startSim (appPath, target) {
 
 function iossimLaunch (appPath, devicetypeid, log, exit) {
     var f = path.resolve(path.dirname(require.resolve('ios-sim')), 'bin', 'ios-sim');
-
     var params = ['launch', appPath, '--devicetypeid', devicetypeid, '--log', log, exit];
-    console.log('$ ' + f + ' ' + params.join(' '));
 
-    return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true, stdio: 'inherit' })
+    return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true, stdio: 'pipe' })
         .progress(function (stdio) {
             if (stdio.stderr) { 
                 console.error(stdio.stderr); 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "cordova-common": "^3.1.0",
-    "ios-sim": "github:janpio/ios-sim#802",
+    "ios-sim": "^8.0.1",
     "nopt": "^4.0.1",
     "plist": "^3.0.1",
     "q": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "cordova-common": "^3.1.0",
-    "ios-sim": "^8.0.1",
+    "ios-sim": "github:janpio/ios-sim#patch-1",
     "nopt": "^4.0.1",
     "plist": "^3.0.1",
     "q": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "cordova-common": "^3.1.0",
-    "ios-sim": "github:janpio/ios-sim#patch-1",
+    "ios-sim": "janpio/ios-sim#patch-1",
     "nopt": "^4.0.1",
     "plist": "^3.0.1",
     "q": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "cordova-common": "^3.1.0",
-    "ios-sim": "janpio/ios-sim#patch-1",
+    "ios-sim": "github:janpio/ios-sim#802",
     "nopt": "^4.0.1",
     "plist": "^3.0.1",
     "q": "^1.5.1",


### PR DESCRIPTION
### Motivation and Context

Currently the simulator selection and app deployment on the selected simulator is a bit of a black box, the logging is insufficient to properly understand and retrace what is happening.

### Description

- When building for simulator
  - display more information about the simulator being built for (simulator ID, simulator identifier string):  
    ```
    $ cordova run ios --no-telemetry --no-update-notifier --target iPhone-XR --emulator
    Building for "iPhone X" Simulator (com.apple.CoreSimulator.SimDeviceType.iPhone-X, iPhone-X)
    ```
  - before executing `xcodebuild` command, output the `emulatorTarget` that will be used as part of `-destination` option:  
    ```
    Building project: /private/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/tmp-2604oc4wBu2VePt9/platforms/ios/HelloCordova.xcworkspace
	Configuration: Debug
	Platform: emulator
	Target: iPhone X
    ```
- When deploying
  - log when deploy (both device and simulator) starts:  
    `Deploying to simulator`
  - to simulator
    - use superspawn to trigger `ios-sim`
	    - output the command used to start simulator:  
          `Running command: /private/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/tmp-2604oc4wBu2VePt9/node_modules/ios-sim/bin/ios-sim launch /private/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/tmp-2604oc4wBu2VePt9/platforms/ios/build/emulator/HelloCordova.app --devicetypeid com.apple.CoreSimulator.SimDeviceType.iPhone-XR --log /private/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/tmp-2604oc4wBu2VePt9/platforms/ios/cordova/console.log --exit`
	    - prefix logging coming from `ios-sim` with `ios-sim log: ` for context:
          ```
          ios-sim log: device.name: iPhone X
          ios-sim log: device.runtime: iOS 11.0
          device.id: 5F22BAE5-1DB2-43CC-8983-5C4EE1BA37E7
		  ```
		- output any errors returned from `ios-sim` and fail (instead of hanging):  
          ```
           No available runtimes could be found for "iphone xʀ".
          /private/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/tmp-2604oc4wBu2VePt9/node_modules/ios-sim/bin/ios-sim: Command failed with exit code 1 Error output:
            No available runtimes could be found for "iphone xʀ".
           ```

(Related: The output this creates would benefit from changes to `ios-sim`: https://github.com/ios-control/ios-sim/pull/255 + https://github.com/ios-control/ios-sim/pull/256 (8.x))

### Testing

This has been used in `cordova-paramedic` to better understand cordova-ios behaviour and uncover a few problems around simulator selection and deployment.

### Checklist

- [x] I've run the tests to see all new and existing tests pass