### PR TITLE
Update nyc to get rid of npm audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "~3.1.0",
-    "nyc": "^13.1.0",
+    "nyc": "^14.0.0",
     "rewire": "^4.0.1",
     "tmp": "0.0.33"
   },


### PR DESCRIPTION
Wanting to get this in before doing the 5.0.1 release.

### Platforms affected
None? This was a dev dependency only


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There was an npm audit warning from a subdependency of nyc


### Description
<!-- Describe your changes in detail -->
Update nyc


### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm run cover` finished successfully and output coverage info
