### PR TITLE
Don't use whitespace as an indent indicator

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -223,7 +223,7 @@ function updateProject (platformConfig, locations) {
 
     /* eslint-disable no-tabs */
     // Write out the plist file with the same formatting as Xcode does
-    var info_contents = plist.build(infoPlist, { indent: '	', offset: -1 });
+    var info_contents = plist.build(infoPlist, { indent: '\t', offset: -1 });
     /* eslint-enable no-tabs */
 
     info_contents = info_contents.replace(/<string>[\s\r\n]*<\/string>/g, '<string></string>');


### PR DESCRIPTION
This is extremely confusing if your editor is not configured to clearly distinguish different sorts of whitespce

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is just clean code style IMHO

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
