### PR TITLE
Revert "exec purgeProjectFileCache when pod install (#354)"

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -285,7 +285,6 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
             if (podfileFile.isDirty()) {
                 podfileFile.write();
                 events.emit('verbose', 'Running `pod install` (to install plugins)');
-                projectFile.purgeProjectFileCache(self.locations.root);
 
                 return podfileFile.install(check_reqs.check_cocoapods);
             } else {


### PR DESCRIPTION
This reverts commit 01742bf27d731c70eaec3270c405e09882a313f2.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
