### PR TITLE
Update jasmine & fix broken tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "jasmine": "~3.1.0",
+    "jasmine": "^3.4.0",
     "nyc": "^14.0.0",
     "rewire": "^4.0.1",
     "tmp": "0.0.33"

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -169,7 +169,7 @@ describe('Platform Api', function () {
         describe('addPlugin', function () {
             var my_plugin = {
                 getHeaderFiles: function () { return []; },
-                getFrameworks: function () {},
+                getFrameworks: function () { return []; },
                 getPodSpecs: function () { return []; }
             };
             beforeEach(function () {
@@ -182,8 +182,8 @@ describe('Platform Api', function () {
             });
             it('should assign a package name to plugin variables if one is not explicitly provided via options', function () {
                 var opts = {};
-                api.addPlugin('my cool plugin', opts);
-                expect(opts.variables.PACKAGE_NAME).toEqual('ios.cordova.io');
+                return api.addPlugin(my_plugin, opts)
+                    .then(() => expect(opts.variables.PACKAGE_NAME).toEqual('ios.cordova.io'));
             });
             describe('with header-file of `BridgingHeader` type', function () {
                 var bridgingHeader_mock;

--- a/tests/spec/unit/lib/list-devices.spec.js
+++ b/tests/spec/unit/lib/list-devices.spec.js
@@ -23,26 +23,25 @@ var Q = require('q');
 describe('cordova/lib/list-devices', function () {
     describe('run method', function () {
         beforeEach(function () {
-            spyOn(Q, 'all').and.returnValue(Q.resolve());
+            spyOn(Q, 'all').and.returnValue(Q.resolve([]));
             spyOn(Q, 'nfcall');
         });
         it('should invoke proper system calls to retrieve connected devices', function () {
-            list_devices.run();
-            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPad/g));
-            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPod/g));
-            expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPhone/g));
+            return list_devices.run()
+                .then(() => {
+                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPad/g));
+                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPod/g));
+                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPhone/g));
+                });
         });
-        it('should trim and split standard output and return as array', function (done) {
+        it('should trim and split standard output and return as array', function () {
             Q.all.and.returnValue(Q.resolve([['   this is\nmy sweet\nstdout\n    ']]));
-            list_devices.run()
+            return list_devices.run()
                 .then(function (results) {
                     expect(results).toContain('this is');
                     expect(results).toContain('my sweet');
                     expect(results).toContain('stdout');
-                }).fail(function (err) {
-                    fail('list-devices fail handler unexpectedly invoked');
-                    console.error(err);
-                }).done(done);
+                });
         });
     });
 });


### PR DESCRIPTION
Fixes #393.

The tests that failed after the jasmine update both did not handle their promises properly. They also were broken beyond that, which seemed to have been nicely covered up by the old version of jasmine.

I could only run the unit tests on Linux. Let's see if anything else is broken...