### PR TITLE
fix(build.json): spacing in error message and missing path in log

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -120,9 +120,9 @@ module.exports.run = function (buildOpts) {
 
     if (buildOpts.buildConfig) {
         if (!fs.existsSync(buildOpts.buildConfig)) {
-            return Q.reject('Build config file does not exist:' + buildOpts.buildConfig);
+            return Q.reject('Build config file does not exist: ' + buildOpts.buildConfig);
         }
-        events.emit('log', 'Reading build config file:', path.resolve(buildOpts.buildConfig));
+        events.emit('log', 'Reading build config file: ' + path.resolve(buildOpts.buildConfig));
         var contents = fs.readFileSync(buildOpts.buildConfig, 'utf-8');
         var buildConfig = JSON.parse(contents.replace(/^\ufeff/, '')); // Remove BOM
         if (buildConfig.ios) {


### PR DESCRIPTION
### Motivation and Context

An error message is missing a space in the error message, and the log is missing the path completely because it doesn't concat the string

closes #648

### Description

Fix both issues.



### Testing
none



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
