### PR TITLE
(#659) Remove CONFIGURATION_BUILD_DIR default string

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -348,7 +348,7 @@ function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, b
         ];
         buildActions = [ 'archive' ];
         settings = [
-            customArgs.configuration_build_dir || 'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'device'),
+            customArgs.configuration_build_dir || '',
             customArgs.shared_precomps_dir || 'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
         ];
         // Add other matched flags to otherFlags to let xcodebuild present an appropriate error.
@@ -370,7 +370,7 @@ function getXcodeBuildArgs (projectName, projectPath, configuration, isDevice, b
         ];
         buildActions = [ 'build' ];
         settings = [
-            customArgs.configuration_build_dir || 'CONFIGURATION_BUILD_DIR=' + path.join(projectPath, 'build', 'emulator'),
+            customArgs.configuration_build_dir || '',
             customArgs.shared_precomps_dir || 'SHARED_PRECOMPS_DIR=' + path.join(projectPath, 'build', 'sharedpch')
         ];
         // Add other matched flags to otherFlags to let xcodebuild present an appropriate error.

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -55,7 +55,7 @@ describe('build', function () {
                 '-archivePath',
                 'TestProjectName.xcarchive',
                 'archive',
-                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                '',
                 'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
             ]);
             expect(args.length).toEqual(13);
@@ -109,7 +109,7 @@ describe('build', function () {
                 '-archivePath',
                 'TestProjectName.xcarchive',
                 'archive',
-                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                '',
                 'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
             ]);
             expect(args.length).toEqual(13);
@@ -131,7 +131,7 @@ describe('build', function () {
                 '-destination',
                 'platform=iOS Simulator,name=iPhone 5s',
                 'build',
-                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'),
+                '',
                 'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
             ]);
             expect(args.length).toEqual(13);
@@ -155,7 +155,7 @@ describe('build', function () {
                 '-archivePath',
                 'TestProjectName.xcarchive',
                 'archive',
-                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                '',
                 'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'),
                 '-sdk',
                 'TestSdkFlag'
@@ -181,7 +181,7 @@ describe('build', function () {
                 '-destination',
                 'platform=iOS Simulator,name=iPhone 5s',
                 'build',
-                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'emulator'),
+                '',
                 'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch'),
                 '-archivePath',
                 'TestArchivePathFlag'
@@ -206,7 +206,7 @@ describe('build', function () {
                 'TestProjectName.xcarchive',
                 '-allowProvisioningUpdates',
                 'archive',
-                'CONFIGURATION_BUILD_DIR=' + path.join(testProjectPath, 'build', 'device'),
+                '',
                 'SHARED_PRECOMPS_DIR=' + path.join(testProjectPath, 'build', 'sharedpch')
             ]);
             expect(args.length).toEqual(14);


### PR DESCRIPTION
###Platforms affected
* all

### Motivation and Context
https://github.com/apache/cordova-ios/issues/659

### Description
Remove CONFIGURATION_BUILD_DIR default string. Use the user custom defined CONFIGURATION_BUILD_DIR as the default and if undefined, then the value is an empty string.

### Testing
Modified unittests to no longer have a default hard-coded `CONFIGURATION_BUILD_DIR` value.

### Checklist
- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
