### PR TITLE
Backport xcode 11 emulator support to 4.5.x

### DIFF
--- a/bin/templates/scripts/cordova/lib/list-emulator-build-targets
+++ b/bin/templates/scripts/cordova/lib/list-emulator-build-targets
@@ -34,48 +34,52 @@ var Q = require('q'),
  *     ]
  * 
  */
-function listEmulatorBuildTargets () {
+function listEmulatorBuildTargets() {
     return Q.nfcall(exec, 'xcrun simctl list --json')
-    .then(function(stdio) {
-        return JSON.parse(stdio[0]);
-    })
-    .then(function(simInfo) {
-        var devices = simInfo.devices;
-        var deviceTypes = simInfo.devicetypes;
-        return deviceTypes.reduce(function (typeAcc, deviceType) {
-            if (!deviceType.name.match(/^[iPad|iPhone]/)) {
-                // ignore targets we don't support (like Apple Watch or Apple TV)
-                return typeAcc;
-            }
-            var availableDevices = Object.keys(devices).reduce(function (availAcc, deviceCategory) {
-                var availableDevicesInCategory = devices[deviceCategory];
-                availableDevicesInCategory.forEach(function (device) {
-                    if (device.name === deviceType.name.replace(/\-inch/g, ' inch') && 
-                        device.availability.toLowerCase().indexOf('unavailable') < 0) {
-                            availAcc.push(device);
+        .then(function (stdio) {
+            return JSON.parse(stdio[0]);
+        })
+        .then(function (simInfo) {
+            var devices = simInfo.devices;
+            var deviceTypes = simInfo.devicetypes;
+            return deviceTypes.reduce(function (typeAcc, deviceType) {
+                if (!deviceType.name.match(/^[iPad|iPhone]/)) {
+                    // ignore targets we don't support (like Apple Watch or Apple TV)
+                    return typeAcc;
+                }
+                var availableDevices = Object.keys(devices).reduce(function (availAcc, deviceCategory) {
+                    var availableDevicesInCategory = devices[deviceCategory];
+                    availableDevicesInCategory.forEach(function (device) {
+                        if (device.name === deviceType.name.replace(/\-inch/g, ' inch')) {
+                            // xcode <= 10
+                            if ("availability" in device && device.availability.toLowerCase().indexOf('unavailable') < 0) {
+                                if (!("availabilityError" in device)) {  // xcode 11
+                                    availAcc.push(device);
+                                }
+                            }
                         }
-                });
-                return availAcc;
+                    });
+                    return availAcc;
+                }, []);
+                // we only want device types that have at least one available device
+                // (regardless of OS); this filters things out like iPhone 4s, which
+                // is present in deviceTypes, but probably not available on the user's
+                // system.
+                if (availableDevices.length > 0) {
+                    typeAcc.push(deviceType);
+                }
+                return typeAcc;
             }, []);
-            // we only want device types that have at least one available device
-            // (regardless of OS); this filters things out like iPhone 4s, which
-            // is present in deviceTypes, but probably not available on the user's
-            // system.
-            if (availableDevices.length > 0) {
-                typeAcc.push(deviceType);
-            }
-            return typeAcc;
-        }, []);
-    })
-    .then(function(filteredTargets) {
-        // the simIdentifier, or cordova emulate target name, is the very last part
-        // of identifier.
-        return filteredTargets.map(function (target) {
-            var identifierPieces = target.identifier.split(".");
-            target.simIdentifier = identifierPieces[identifierPieces.length-1];
-            return target;
+        })
+        .then(function (filteredTargets) {
+            // the simIdentifier, or cordova emulate target name, is the very last part
+            // of identifier.
+            return filteredTargets.map(function (target) {
+                var identifierPieces = target.identifier.split(".");
+                target.simIdentifier = identifierPieces[identifierPieces.length - 1];
+                return target;
+            });
         });
-    });
 }
 
 exports.run = listEmulatorBuildTargets;
@@ -86,16 +90,16 @@ exports.run = listEmulatorBuildTargets;
  * @param {string} simIdentifier       a target, like "iPhone-SE"
  * @return {Object}                    the matching target, or undefined if no match
  */
-exports.targetForSimIdentifier = function(simIdentifier) {
+exports.targetForSimIdentifier = function (simIdentifier) {
     return listEmulatorBuildTargets()
-    .then(function(targets) {
-        return targets.reduce(function(acc, target) {
-            if (!acc && target.simIdentifier.toLowerCase() === simIdentifier.toLowerCase()) {
-                acc = target;
-            }
-            return acc;
-        }, undefined);
-    });
+        .then(function (targets) {
+            return targets.reduce(function (acc, target) {
+                if (!acc && target.simIdentifier.toLowerCase() === simIdentifier.toLowerCase()) {
+                    acc = target;
+                }
+                return acc;
+            }, undefined);
+        });
 }
 
 // Check if module is started as separate script.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
macOS w/ xcode 11


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
People may be stuck on older cordova versions


### Description
<!-- Describe your changes in detail -->
Fixes simulator listing for xcode 11


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x ] I've run the tests to see all new and existing tests pass
- [ x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ x] I've updated the documentation if necessary
