### PR TITLE
(iOS) Allowed extra variation in version comparison

### DIFF
--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -179,8 +179,8 @@ exports.compareVersions = function (version1, version2) {
             return parsed;
         });
     }
-    var parsedVer1 = parseVer(version1);
-    var parsedVer2 = parseVer(version2);
+    var parsedVer1 = parseVer(version1.replace(/-[a-zA-Z]{1,}(\d*)/, '$1'));
+    var parsedVer2 = parseVer(version2.replace(/-[a-zA-Z]{1,}(\d*)/, '$1'));
 
     // Compare corresponding segments of each version
     for (var i = 0; i < Math.max(parsedVer1.length, parsedVer2.length); i++) {

--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -179,8 +179,8 @@ exports.compareVersions = function (version1, version2) {
             return parsed;
         });
     }
-    var parsedVer1 = parseVer(version1.replace(/-[a-zA-Z]{1,}(\d*)/, '$1'));
-    var parsedVer2 = parseVer(version2.replace(/-[a-zA-Z]{1,}(\d*)/, '$1'));
+    var parsedVer1 = parseVer(version1.replace(/-[a-zA-Z.]{1,}(\d*)/, '$1'));
+    var parsedVer2 = parseVer(version2.replace(/-[a-zA-Z.]{1,}(\d*)/, '$1'));
 
     // Compare corresponding segments of each version
     for (var i = 0; i < Math.max(parsedVer1.length, parsedVer2.length); i++) {


### PR DESCRIPTION
This should allow more varients on the semver spec to pass.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

fixes https://github.com/apache/cordova/issues/165

### Description
<!-- Describe your changes in detail -->

Allows more of the semver spec to work with the version comparison function. Previously only X.X.X version would be allowed, however now variants like X.X.X-alphaX or X.X.X-betaX will be allowed.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran across multiple variants of versions which match the above, is backwards compatible with the original method as if the regex isn't triggered then the system runs as previous. 

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [N/A] I've updated the documentation if necessary
