### PR TITLE
Reuse common xcodebuild arguments in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "cover": "nyc jasmine --config=tests/spec/coverage.json",
     "e2e-tests": "jasmine tests/spec/create.spec.js",
     "objc-tests": "npm run objc-tests-lib && npm run objc-tests-framework",
-    "objc-tests-lib": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -scheme CordovaLibTests -destination \"platform=iOS Simulator,name=iPhone 8\" CONFIGURATION_BUILD_DIR=\"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
-    "objc-tests-framework": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -scheme CordovaFrameworkApp -destination \"platform=iOS Simulator,name=iPhone 8\" CONFIGURATION_BUILD_DIR=\"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
+    "objc-tests-lib": "npm run xcodebuild -- -scheme CordovaLibTests",
+    "objc-tests-framework": "npm run xcodebuild -- -scheme CordovaFrameworkApp",
+    "xcodebuild": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -destination \"platform=iOS Simulator,name=iPhone 8\" CONFIGURATION_BUILD_DIR=\"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
     "preobjc-tests": "tests/scripts/killsim.js",
     "unit-tests": "jasmine --config=tests/spec/unit.json",
     "eslint": "eslint bin tests"


### PR DESCRIPTION
Moves all common `xcodebuild` arguments used in npm scripts to a new script called `xcodebuild`. 