### PR TITLE
Update Xcode versions used in CI to latest minor release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ sudo: false
 
 matrix:
   include:
-    # Run one test with Xcode 9.x, the rest with 10.1
-    - osx_image: xcode9.3
+    # Run one test with Xcode 9.x, the rest with 10.x
+    - osx_image: xcode9.4
       env: TRAVIS_NODE_VERSION=10
-    - osx_image: xcode10.1
+    - osx_image: xcode10.3
       env: TRAVIS_NODE_VERSION=6
-    - osx_image: xcode10.1
+    - osx_image: xcode10.3
       env: TRAVIS_NODE_VERSION=8
-    - osx_image: xcode10.1
+    - osx_image: xcode10.3
       env: TRAVIS_NODE_VERSION=10
-    - osx_image: xcode10.1
+    - osx_image: xcode10.3
       env: TRAVIS_NODE_VERSION=12
 
 before_install:


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Lately the ObjC tests that were using Xcode 10.1 on CI have been very unstable. It was not uncommon that two out of four CI runs failed. [The Error](https://travis-ci.org/apache/cordova-ios/jobs/604550483#L2258-L2260) is always the same and seems to be caused by a [known defect](https://github.com/microsoft/azure-pipelines-tasks/issues/8840) in Xcode 10.1. The only known fix seems to be not to use 10.1. So that's what we will do.


### Description
<!-- Describe your changes in detail -->
I've updated our Travis CI config to use Xcode 9.4 and 10.3 respectively. The update of Xcode 9 is not necessary, but since it's the current default for Travis CI ObjC images I thought it wouldn't hurt.


### Testing
I've let the five CI jobs run four times each on my fork's CI with these changes and there were no errors.