### PR TITLE
Add check for newer versions of cocoapods to avoid locking adding platforms on non synced pods repo

### DIFF
--- a/bin/templates/scripts/cordova/lib/check_reqs.js
+++ b/bin/templates/scripts/cordova/lib/check_reqs.js
@@ -23,7 +23,6 @@ const Q = require('q');
 const shell = require('shelljs');
 const util = require('util');
 const versions = require('./versions');
-const semver = require('semver');
 
 const SUPPORTED_OS_PLATFORMS = [ 'darwin' ];
 
@@ -124,14 +123,11 @@ module.exports.check_cocoapods = function (toolChecker) {
         .then(function (toolOptions) {
             if (toolOptions.ignore) return toolOptions;
 
-            let podVersion = shell.exec('pod --version', { silent: true });
-            if (podVersion && podVersion.output) {
-                const version = podVersion.output.trim();
-                // starting with 1.8.0 cocoapods now use cdn and we dont need to sync first
-                if ((semver.valid(version) && semver.gte(version, '1.8.0'))) {
-                    return toolOptions;
-                }
+            // starting with 1.8.0 cocoapods now use cdn and we dont need to sync first
+            if (versions.compareVersions(toolOptions.version, '1.8.0') >= 0) {
+                return toolOptions;
             }
+
             let code = shell.exec('pod repo | grep -e "^0 repos"', { silent: true }).code;
             let repoIsSynced = (code !== 0);
 

--- a/bin/templates/scripts/cordova/lib/check_reqs.js
+++ b/bin/templates/scripts/cordova/lib/check_reqs.js
@@ -122,18 +122,20 @@ module.exports.check_cocoapods = function (toolChecker) {
         // check whether the cocoapods repo has been synced through `pod repo` command
         // a value of '0 repos' means it hasn't been synced
         .then(function (toolOptions) {
+            if (toolOptions.ignore) return toolOptions;
+
             let podVersion = shell.exec('pod --version', { silent: true });
             if (podVersion && podVersion.output) {
                 const version = podVersion.output.trim();
                 // starting with 1.8.0 cocoapods now use cdn and we dont need to sync first
-                if ((semver.valid(version) && semver.gte(version, '1.8.0')) || toolOptions.ignore) {
+                if ((semver.valid(version) && semver.gte(version, '1.8.0'))) {
                     return toolOptions;
                 }
             }
             let code = shell.exec('pod repo | grep -e "^0 repos"', { silent: true }).code;
             let repoIsSynced = (code !== 0);
 
-            if (toolOptions.ignore || repoIsSynced) {
+            if (repoIsSynced) {
                 // return check_cocoapods_repo_size();
                 // we could check the repo size above, but it takes too long.
                 return toolOptions;

--- a/tests/spec/unit/lib/check_reqs.spec.js
+++ b/tests/spec/unit/lib/check_reqs.spec.js
@@ -71,7 +71,7 @@ describe('check_reqs', function () {
         let toolsChecker;
         beforeEach(() => {
             toolsChecker = jasmine.createSpy('toolsChecker')
-                .and.returnValue(Promise.resolve({}));
+                .and.returnValue(Promise.resolve({ version: '1.2.3' }));
         });
 
         it('should resolve when on an unsupported platform', () => {


### PR DESCRIPTION
Starting on 1.8.0, cocoapods now use CDN to avoid having to sync the master repo, so we don't need to check anymore if the repo is populated.

Even more, the "pod setup" command now doesn't do anything, and newer versions of cocoapods are actually incompatible with cordova-ios, as the repository filled check will kick in and make it impossible to use it.

Error example with meteor and cocoapods 1.8.4:

✗ CocoaPods: The CocoaPods repo has not been synced yet, this will take a long
  time (approximately 500MB as of Sept 2016). Please run `pod setup` first to
  sync the repo.

This also solves issue #700 

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
