### PR TITLE
fix: make prepare wait for add to finish

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -37,34 +37,31 @@ function copyJsAndCordovaLib (projectPath, projectName, use_shared, config) {
     shell.cp('-f', path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'www'));
     shell.cp('-rf', path.join(ROOT, 'cordova-js-src'), path.join(projectPath, 'platform_www'));
     shell.cp('-f', path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'platform_www'));
-
-    fs.lstat(path.join(projectPath, 'CordovaLib'), function (err, stats) {
-        if (!err) {
-            if (stats.isSymbolicLink()) {
-                fs.unlinkSync(path.join(projectPath, 'CordovaLib'));
-            } else {
-                shell.rm('-rf', path.join(projectPath, 'CordovaLib'));
-            }
-        }
-
-        if (use_shared) {
-            update_cordova_subproject([path.join(projectPath, projectName + '.xcodeproj', 'project.pbxproj'), config]);
-            // Symlink not used in project file, but is currently required for plugman because
-            // it reads the VERSION file from it (instead of using the cordova/version script
-            // like it should).
-            fs.symlinkSync(path.join(ROOT, 'CordovaLib'), path.join(projectPath, 'CordovaLib'));
+    try {
+        const stats = fs.lstatSync(path.join(projectPath, 'CordovaLib'));
+        if (stats.isSymbolicLink()) {
+            fs.unlinkSync(path.join(projectPath, 'CordovaLib'));
         } else {
-            var r = path.join(projectPath, projectName);
-            shell.mkdir('-p', path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj'));
-            shell.cp('-f', path.join(r, '.gitignore'), projectPath);
-            shell.cp('-rf', path.join(ROOT, 'CordovaLib', 'Classes'), path.join(projectPath, 'CordovaLib'));
-            shell.cp('-f', path.join(ROOT, 'CordovaLib', 'VERSION'), path.join(projectPath, 'CordovaLib'));
-            shell.cp('-f', path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'CordovaLib'));
-            shell.cp('-f', path.join(ROOT, 'CordovaLib', 'CordovaLib_Prefix.pch'), path.join(projectPath, 'CordovaLib'));
-            shell.cp('-f', path.join(ROOT, 'CordovaLib', 'CordovaLib.xcodeproj', 'project.pbxproj'), path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj'));
-            update_cordova_subproject([path.join(r + '.xcodeproj', 'project.pbxproj'), path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj', 'project.pbxproj'), config]);
+            shell.rm('-rf', path.join(projectPath, 'CordovaLib'));
         }
-    });
+    } catch (e) { }
+    if (use_shared) {
+        update_cordova_subproject([path.join(projectPath, projectName + '.xcodeproj', 'project.pbxproj'), config]);
+        // Symlink not used in project file, but is currently required for plugman because
+        // it reads the VERSION file from it (instead of using the cordova/version script
+        // like it should).
+        fs.symlinkSync(path.join(ROOT, 'CordovaLib'), path.join(projectPath, 'CordovaLib'));
+    } else {
+        var r = path.join(projectPath, projectName);
+        shell.mkdir('-p', path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj'));
+        shell.cp('-f', path.join(r, '.gitignore'), projectPath);
+        shell.cp('-rf', path.join(ROOT, 'CordovaLib', 'Classes'), path.join(projectPath, 'CordovaLib'));
+        shell.cp('-f', path.join(ROOT, 'CordovaLib', 'VERSION'), path.join(projectPath, 'CordovaLib'));
+        shell.cp('-f', path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'CordovaLib'));
+        shell.cp('-f', path.join(ROOT, 'CordovaLib', 'CordovaLib_Prefix.pch'), path.join(projectPath, 'CordovaLib'));
+        shell.cp('-f', path.join(ROOT, 'CordovaLib', 'CordovaLib.xcodeproj', 'project.pbxproj'), path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj'));
+        update_cordova_subproject([path.join(r + '.xcodeproj', 'project.pbxproj'), path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj', 'project.pbxproj'), config]);
+    }
 }
 
 function copyScripts (projectPath, projectName) {


### PR DESCRIPTION
prepare is being run before add command finish because `fs.lstat` is async and the `createProject` is resolving before `fs.lstat` finishes.

This PR changes `fs.lstat` to `fs.lstatSync` to make the directory check sync and avoid to resolve before all create work is done.

Closes #725 