### PR TITLE
chore: bump node requirement (>=10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ matrix:
     - osx_image: xcode9.4
       env: TRAVIS_NODE_VERSION=10
     - osx_image: xcode10.3
-      env: TRAVIS_NODE_VERSION=6
-    - osx_image: xcode10.3
-      env: TRAVIS_NODE_VERSION=8
-    - osx_image: xcode10.3
       env: TRAVIS_NODE_VERSION=10
     - osx_image: xcode10.3
       env: TRAVIS_NODE_VERSION=12

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: 6
-  - nodejs_version: 8
   - nodejs_version: 10
   - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tmp": "^0.1.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "dependencies": {
     "cordova-common": "^3.1.0",


### PR DESCRIPTION
### Motivation and Context

* Follow inline with Node Support
* Prepare for next major
* https://github.com/apache/cordova/issues/79

### Description

* Bump `engines.node` to `>=10` in `package.json`
* Drop node 6 and 8 from CI services.

### Testing

- `npm t`
- CI services continue to pass

### Checklist

- [x] I've run the tests to see all new and existing tests pass
