### PR TITLE
refactor: use arrow functions

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -103,7 +103,7 @@ function copyScripts (projectPath, projectName) {
     shell.sed('-i', /__PROJECT_NAME__/g, project_name_esc, path.join(destScriptsDir, 'build-release.xcconfig'));
 
     // Make sure they are executable (sometimes zipping them can remove executable bit)
-    shell.find(destScriptsDir).forEach(function (entry) {
+    shell.find(destScriptsDir).forEach(entry => {
         shell.chmod(755, entry);
     });
 }
@@ -195,7 +195,7 @@ function relpath (_path, start) {
  * - <project_template_dir>: Path to a project template (override)
  *
  */
-exports.createProject = function (project_path, package_name, project_name, opts, config) {
+exports.createProject = (project_path, package_name, project_name, opts, config) => {
     package_name = package_name || 'my.cordova.project';
     project_name = project_name || 'CordovaExample';
     const use_shared = !!opts.link;
@@ -238,7 +238,7 @@ exports.createProject = function (project_path, package_name, project_name, opts
     return Q.resolve();
 };
 
-exports.updateProject = function (projectPath, opts) {
+exports.updateProject = (projectPath, opts) => {
     const errorString =
     'An in-place platform update is not supported. \n' +
     'The `platforms` folder is always treated as a build artifact.\n' +

--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -66,7 +66,7 @@ function Api (platform, platformRootDir, events) {
     let xcodeCordovaProj;
 
     try {
-        const xcodeProjDir_array = fs.readdirSync(this.root).filter(function (e) { return e.match(/\.xcodeproj$/i); });
+        const xcodeProjDir_array = fs.readdirSync(this.root).filter(e => e.match(/\.xcodeproj$/i));
         if (xcodeProjDir_array.length > 1) {
             for (let x = 0; x < xcodeProjDir_array.length; x++) {
                 if (xcodeProjDir_array[x].substring(0, 2) === '._') {
@@ -116,7 +116,7 @@ function Api (platform, platformRootDir, events) {
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.createPlatform = function (destination, config, options, events) {
+Api.createPlatform = (destination, config, options, events) => {
     setupEvents(events);
 
     // CB-6992 it is necessary to normalize characters
@@ -127,7 +127,7 @@ Api.createPlatform = function (destination, config, options, events) {
     try {
         result = require('../../../lib/create')
             .createProject(destination, config.getAttribute('ios-CFBundleIdentifier') || config.packageName(), name, options, config)
-            .then(function () {
+            .then(() => {
                 // after platform is created we return Api instance based on new Api.js location
                 // This is required to correctly resolve paths in the future api calls
                 const PlatformApi = require(path.resolve(destination, 'cordova/Api'));
@@ -156,14 +156,14 @@ Api.createPlatform = function (destination, config, options, events) {
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.updatePlatform = function (destination, options, events) {
+Api.updatePlatform = (destination, options, events) => {
     setupEvents(events);
 
     let result;
     try {
         result = require('../../../lib/create')
             .updateProject(destination, options)
-            .then(function () {
+            .then(() => {
                 const PlatformApi = require(path.resolve(destination, 'cordova/Api'));
                 return new PlatformApi('ios', destination, events);
             });
@@ -241,19 +241,17 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
 
     return PluginManager.get(self.platform, self.locations, xcodeproj)
         .addPlugin(plugin, installOptions)
-        .then(function () {
+        .then(() => {
             if (plugin != null) {
                 const headerTags = plugin.getHeaderFiles(self.platform);
-                const bridgingHeaders = headerTags.filter(function (obj) {
-                    return (obj.type === 'BridgingHeader');
-                });
+                const bridgingHeaders = headerTags.filter(obj => obj.type === 'BridgingHeader');
                 if (bridgingHeaders.length > 0) {
                     const project_dir = self.locations.root;
                     const project_name = self.locations.xcodeCordovaProj.split('/').pop();
                     const BridgingHeader = require('./lib/BridgingHeader').BridgingHeader;
                     const bridgingHeaderFile = new BridgingHeader(path.join(project_dir, project_name, 'Bridging-Header.h'));
                     events.emit('verbose', 'Adding Bridging-Headers since the plugin contained <header-file> with type="BridgingHeader"');
-                    bridgingHeaders.forEach(function (obj) {
+                    bridgingHeaders.forEach(obj => {
                         const bridgingHeaderPath = path.basename(obj.src);
                         bridgingHeaderFile.addHeader(plugin.id, bridgingHeaderPath);
                     });
@@ -261,13 +259,11 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
                 }
             }
         })
-        .then(function () {
+        .then(() => {
             if (plugin != null) {
                 const podSpecs = plugin.getPodSpecs ? plugin.getPodSpecs(self.platform) : [];
                 const frameworkTags = plugin.getFrameworks(self.platform);
-                const frameworkPods = frameworkTags.filter(function (obj) {
-                    return (obj.type === 'podspec');
-                });
+                const frameworkPods = frameworkTags.filter(obj => obj.type === 'podspec');
                 return self.addPodSpecs(plugin, podSpecs, frameworkPods);
             }
         })
@@ -295,19 +291,17 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
 
     return PluginManager.get(self.platform, self.locations, xcodeproj)
         .removePlugin(plugin, uninstallOptions)
-        .then(function () {
+        .then(() => {
             if (plugin != null) {
                 const headerTags = plugin.getHeaderFiles(self.platform);
-                const bridgingHeaders = headerTags.filter(function (obj) {
-                    return (obj.type === 'BridgingHeader');
-                });
+                const bridgingHeaders = headerTags.filter(obj => obj.type === 'BridgingHeader');
                 if (bridgingHeaders.length > 0) {
                     const project_dir = self.locations.root;
                     const project_name = self.locations.xcodeCordovaProj.split('/').pop();
                     const BridgingHeader = require('./lib/BridgingHeader').BridgingHeader;
                     const bridgingHeaderFile = new BridgingHeader(path.join(project_dir, project_name, 'Bridging-Header.h'));
                     events.emit('verbose', 'Removing Bridging-Headers since the plugin contained <header-file> with type="BridgingHeader"');
-                    bridgingHeaders.forEach(function (obj) {
+                    bridgingHeaders.forEach(obj => {
                         const bridgingHeaderPath = path.basename(obj.src);
                         bridgingHeaderFile.removeHeader(plugin.id, bridgingHeaderPath);
                     });
@@ -315,13 +309,11 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
                 }
             }
         })
-        .then(function () {
+        .then(() => {
             if (plugin != null) {
                 const podSpecs = plugin.getPodSpecs ? plugin.getPodSpecs(self.platform) : [];
                 const frameworkTags = plugin.getFrameworks(self.platform);
-                const frameworkPods = frameworkTags.filter(function (obj) {
-                    return (obj.type === 'podspec');
-                });
+                const frameworkPods = frameworkTags.filter(obj => obj.type === 'podspec');
                 return self.removePodSpecs(plugin, podSpecs, frameworkPods);
             }
         })
@@ -354,9 +346,9 @@ Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods) {
 
     if (podSpecs.length) {
         events.emit('verbose', 'Adding pods since the plugin contained <podspecs>');
-        podSpecs.forEach(function (obj) {
+        podSpecs.forEach(obj => {
             // declarations
-            Object.keys(obj.declarations).forEach(function (key) {
+            Object.keys(obj.declarations).forEach(key => {
                 if (obj.declarations[key] === 'true') {
                     const declaration = Podfile.proofDeclaration(key);
                     const podJson = {
@@ -373,7 +365,7 @@ Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods) {
                 }
             });
             // sources
-            Object.keys(obj.sources).forEach(function (key) {
+            Object.keys(obj.sources).forEach(key => {
                 const podJson = {
                     source: obj.sources[key].source
                 };
@@ -387,7 +379,7 @@ Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods) {
                 }
             });
             // libraries
-            Object.keys(obj.libraries).forEach(function (key) {
+            Object.keys(obj.libraries).forEach(key => {
                 const podJson = Object.assign({}, obj.libraries[key]);
                 const val = podsjsonFile.getLibrary(key);
                 if (val) {
@@ -405,7 +397,7 @@ Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods) {
     if (frameworkPods.length) {
         events.emit('warn', '"framework" tag with type "podspec" is deprecated and will be removed. Please use the "podspec" tag.');
         events.emit('verbose', 'Adding pods since the plugin contained <framework>(s) with type="podspec"');
-        frameworkPods.forEach(function (obj) {
+        frameworkPods.forEach(obj => {
             const podJson = {
                 name: obj.src,
                 type: obj.type,
@@ -439,9 +431,7 @@ Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods) {
             projectFile.purgeProjectFileCache(self.locations.root);
 
             return podfileFile.install(check_reqs.check_cocoapods)
-                .then(function () {
-                    return self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile);
-                });
+                .then(() => self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile));
         } else {
             events.emit('verbose', 'Podfile unchanged, skipping `pod install`');
         }
@@ -472,9 +462,9 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
 
     if (podSpecs.length) {
         events.emit('verbose', 'Adding pods since the plugin contained <podspecs>');
-        podSpecs.forEach(function (obj) {
+        podSpecs.forEach(obj => {
             // declarations
-            Object.keys(obj.declarations).forEach(function (key) {
+            Object.keys(obj.declarations).forEach(key => {
                 if (obj.declarations[key] === 'true') {
                     const declaration = Podfile.proofDeclaration(key);
                     const podJson = {
@@ -493,7 +483,7 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
                 }
             });
             // sources
-            Object.keys(obj.sources).forEach(function (key) {
+            Object.keys(obj.sources).forEach(key => {
                 const podJson = {
                     source: obj.sources[key].source
                 };
@@ -509,7 +499,7 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
                 }
             });
             // libraries
-            Object.keys(obj.libraries).forEach(function (key) {
+            Object.keys(obj.libraries).forEach(key => {
                 const podJson = Object.assign({}, obj.libraries[key]);
                 const val = podsjsonFile.getLibrary(key);
                 if (val) {
@@ -528,7 +518,7 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
     if (frameworkPods.length) {
         events.emit('warn', '"framework" tag with type "podspec" is deprecated and will be removed. Please use the "podspec" tag.');
         events.emit('verbose', 'Adding pods since the plugin contained <framework>(s) with type=\"podspec\"'); /* eslint no-useless-escape : 0 */
-        frameworkPods.forEach(function (obj) {
+        frameworkPods.forEach(obj => {
             const podJson = {
                 name: obj.src,
                 type: obj.type,
@@ -557,9 +547,7 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
             events.emit('verbose', 'Running `pod install` (to uninstall pods)');
 
             return podfileFile.install(check_reqs.check_cocoapods)
-                .then(function () {
-                    return self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile);
-                });
+                .then(() => self.setSwiftVersionForCocoaPodsLibraries(podsjsonFile));
         } else {
             events.emit('verbose', 'Podfile unchanged, skipping `pod install`');
         }
@@ -576,7 +564,7 @@ Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods) {
 Api.prototype.setSwiftVersionForCocoaPodsLibraries = function (podsjsonFile) {
     const self = this;
     let __dirty = false;
-    return check_reqs.check_cocoapods().then(function (toolOptions) {
+    return check_reqs.check_cocoapods().then(toolOptions => {
         if (toolOptions.ignore) {
             events.emit('verbose', '=== skip Swift Version Settings For Cocoapods Libraries');
         } else {
@@ -588,28 +576,23 @@ Api.prototype.setSwiftVersionForCocoaPodsLibraries = function (podsjsonFile) {
             const podConfigs = podXcodeproj.pbxXCBuildConfigurationSection();
 
             const libraries = podsjsonFile.getLibraries();
-            Object.keys(libraries).forEach(function (key) {
+            Object.keys(libraries).forEach(key => {
                 const podJson = libraries[key];
                 const name = podJson.name;
                 const swiftVersion = podJson['swift-version'];
                 if (swiftVersion) {
                     __dirty = true;
-                    Object.keys(podTargets).filter(function (targetKey) {
-                        return podTargets[targetKey].productName === name;
-                    }).map(function (targetKey) {
-                        return podTargets[targetKey].buildConfigurationList;
-                    }).map(function (buildConfigurationListId) {
-                        return podConfigurationList[buildConfigurationListId];
-                    }).map(function (buildConfigurationList) {
-                        return buildConfigurationList.buildConfigurations;
-                    }).reduce(function (acc, buildConfigurations) {
-                        return acc.concat(buildConfigurations);
-                    }, []).map(function (buildConfiguration) {
-                        return buildConfiguration.value;
-                    }).forEach(function (buildId) {
-                        __dirty = true;
-                        podConfigs[buildId].buildSettings['SWIFT_VERSION'] = swiftVersion;
-                    });
+                    Object.keys(podTargets)
+                        .filter(targetKey => podTargets[targetKey].productName === name)
+                        .map(targetKey => podTargets[targetKey].buildConfigurationList)
+                        .map(buildConfigurationListId => podConfigurationList[buildConfigurationListId])
+                        .map(buildConfigurationList => buildConfigurationList.buildConfigurations)
+                        .reduce((acc, buildConfigurations) => acc.concat(buildConfigurations), [])
+                        .map(buildConfiguration => buildConfiguration.value)
+                        .forEach(buildId => {
+                            __dirty = true;
+                            podConfigs[buildId].buildSettings['SWIFT_VERSION'] = swiftVersion;
+                        });
                 }
             });
             if (__dirty) {
@@ -654,9 +637,7 @@ Api.prototype.setSwiftVersionForCocoaPodsLibraries = function (podsjsonFile) {
 Api.prototype.build = function (buildOptions) {
     const self = this;
     return check_reqs.run()
-        .then(function () {
-            return require('./lib/build').run.call(self, buildOptions);
-        });
+        .then(() => require('./lib/build').run.call(self, buildOptions));
 };
 
 /**
@@ -674,9 +655,7 @@ Api.prototype.build = function (buildOptions) {
 Api.prototype.run = function (runOptions) {
     const self = this;
     return check_reqs.run()
-        .then(function () {
-            return require('./lib/run').run.call(self, runOptions);
-        });
+        .then(() => require('./lib/run').run.call(self, runOptions));
 };
 
 /**
@@ -688,12 +667,8 @@ Api.prototype.run = function (runOptions) {
 Api.prototype.clean = function (cleanOptions) {
     const self = this;
     return check_reqs.run()
-        .then(function () {
-            return require('./lib/clean').run.call(self, cleanOptions);
-        })
-        .then(function () {
-            return require('./lib/prepare').clean.call(self, cleanOptions);
-        });
+        .then(() => require('./lib/clean').run.call(self, cleanOptions))
+        .then(() => require('./lib/prepare').clean.call(self, cleanOptions));
 };
 
 /**
@@ -704,8 +679,6 @@ Api.prototype.clean = function (cleanOptions) {
  * @return  {Promise<Requirement[]>}  Promise, resolved with set of Requirement
  *   objects for current platform.
  */
-Api.prototype.requirements = function () {
-    return check_reqs.check_all();
-};
+Api.prototype.requirements = () => check_reqs.check_all();
 
 module.exports = Api;

--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -116,7 +116,7 @@ function Api (platform, platformRootDir, events) {
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.createPlatform = (destination, config, options, events) => {
+Api.createPlatform = function (destination, config, options, events) {
     setupEvents(events);
 
     // CB-6992 it is necessary to normalize characters
@@ -156,7 +156,7 @@ Api.createPlatform = (destination, config, options, events) => {
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.updatePlatform = (destination, options, events) => {
+Api.updatePlatform = function (destination, options, events) {
     setupEvents(events);
 
     let result;
@@ -679,6 +679,8 @@ Api.prototype.clean = function (cleanOptions) {
  * @return  {Promise<Requirement[]>}  Promise, resolved with set of Requirement
  *   objects for current platform.
  */
-Api.prototype.requirements = () => check_reqs.check_all();
+Api.prototype.requirements = function () {
+    return check_reqs.check_all();
+};
 
 module.exports = Api;

--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -268,7 +268,7 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
                 const podSpecs = plugin.getPodSpecs ? plugin.getPodSpecs(self.platform) : [];
                 const frameworkTags = plugin.getFrameworks(self.platform);
                 const frameworkPods = frameworkTags.filter(obj => obj.type === 'podspec');
-                return self.addPodSpecs(plugin, podSpecs, frameworkPods, );
+                return self.addPodSpecs(plugin, podSpecs, frameworkPods, installOptions);
             }
         })
         // CB-11022 return non-falsy value to indicate

--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -116,7 +116,7 @@ function Api (platform, platformRootDir, events) {
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.createPlatform = function (destination, config, options, events) {
+Api.createPlatform = (destination, config, options, events) => {
     setupEvents(events);
 
     // CB-6992 it is necessary to normalize characters
@@ -156,7 +156,7 @@ Api.createPlatform = function (destination, config, options, events) {
  * @return {Promise<PlatformApi>} Promise either fulfilled with PlatformApi
  *   instance or rejected with CordovaError.
  */
-Api.updatePlatform = function (destination, options, events) {
+Api.updatePlatform = (destination, options, events) => {
     setupEvents(events);
 
     let result;

--- a/bin/templates/scripts/cordova/lib/BridgingHeader.js
+++ b/bin/templates/scripts/cordova/lib/BridgingHeader.js
@@ -55,9 +55,11 @@ BridgingHeader.prototype.write = function () {
     fs.writeFileSync(this.path, text, 'utf8');
 };
 
-BridgingHeader.prototype.__stringifyForBridgingHeader = bridgingHeaders => bridgingHeaders.map(obj => obj.code).join('');
+BridgingHeader.prototype.__stringifyForBridgingHeader = function (bridgingHeaders) {
+    return bridgingHeaders.map(obj => obj.code).join('');
+};
 
-BridgingHeader.prototype.__parseForBridgingHeader = text => {
+BridgingHeader.prototype.__parseForBridgingHeader = function (text) {
     let i = 0;
     const list = [];
     let type = 'code';

--- a/bin/templates/scripts/cordova/lib/BridgingHeader.js
+++ b/bin/templates/scripts/cordova/lib/BridgingHeader.js
@@ -55,13 +55,9 @@ BridgingHeader.prototype.write = function () {
     fs.writeFileSync(this.path, text, 'utf8');
 };
 
-BridgingHeader.prototype.__stringifyForBridgingHeader = function (bridgingHeaders) {
-    return bridgingHeaders.map(function (obj) {
-        return obj.code;
-    }).join('');
-};
+BridgingHeader.prototype.__stringifyForBridgingHeader = bridgingHeaders => bridgingHeaders.map(obj => obj.code).join('');
 
-BridgingHeader.prototype.__parseForBridgingHeader = function (text) {
+BridgingHeader.prototype.__parseForBridgingHeader = text => {
     let i = 0;
     const list = [];
     let type = 'code';

--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -260,7 +260,7 @@ Podfile.prototype.removeDeclaration = function (declaration) {
     events.emit('verbose', util.format('Removed source line for `%s`', declaration));
 };
 
-Podfile.proofDeclaration = function (declaration) {
+Podfile.proofDeclaration = declaration => {
     const list = Object.keys(Podfile.declarationRegexpMap).filter(key => {
         const regexp = new RegExp(Podfile.declarationRegexpMap[key]);
         return regexp.test(declaration);

--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -71,7 +71,7 @@ function Podfile (podFilePath, projectName, minDeploymentTarget) {
     }
 }
 
-Podfile.prototype.__parseForDeclarations = text => {
+Podfile.prototype.__parseForDeclarations = function (text) {
     // split by \n
     const arr = text.split('\n');
 
@@ -108,7 +108,7 @@ Podfile.prototype.__parseForDeclarations = text => {
         }, {});
 };
 
-Podfile.prototype.__parseForSources = text => {
+Podfile.prototype.__parseForSources = function (text) {
     // split by \n
     const arr = text.split('\n');
 
@@ -128,7 +128,7 @@ Podfile.prototype.__parseForSources = text => {
         }, {});
 };
 
-Podfile.prototype.__parseForPods = text => {
+Podfile.prototype.__parseForPods = function (text) {
     // split by \n
     const arr = text.split('\n');
 
@@ -165,7 +165,9 @@ Podfile.prototype.__parseForPods = text => {
         }, {});
 };
 
-Podfile.prototype.escapeSingleQuotes = string => string.replace(/'/g, '\\\'');
+Podfile.prototype.escapeSingleQuotes = function (string) {
+    return string.replace(/'/g, '\\\'');
+};
 
 Podfile.prototype.getTemplate = function () {
     // Escaping possible ' in the project name
@@ -258,7 +260,7 @@ Podfile.prototype.removeDeclaration = function (declaration) {
     events.emit('verbose', util.format('Removed source line for `%s`', declaration));
 };
 
-Podfile.proofDeclaration = declaration => {
+Podfile.proofDeclaration = function (declaration) {
     const list = Object.keys(Podfile.declarationRegexpMap).filter(key => {
         const regexp = new RegExp(Podfile.declarationRegexpMap[key]);
         return regexp.test(declaration);

--- a/bin/templates/scripts/cordova/lib/check_reqs.js
+++ b/bin/templates/scripts/cordova/lib/check_reqs.js
@@ -61,8 +61,8 @@ module.exports.check_ios_deploy = () => {
     return checkTool('ios-deploy', IOS_DEPLOY_MIN_VERSION, IOS_DEPLOY_NOT_FOUND_MESSAGE);
 };
 
-// Build iOS apps available for OSX platform only, so we reject on others platforms
 module.exports.check_os = () => {
+    // Build iOS apps available for OSX platform only, so we reject on others platforms
     return os_platform_is_supported()
         ? Q.resolve(process.platform)
         : Q.reject('Cordova tooling for iOS requires Apple macOS');

--- a/bin/templates/scripts/cordova/lib/check_reqs.js
+++ b/bin/templates/scripts/cordova/lib/check_reqs.js
@@ -49,18 +49,24 @@ const COCOAPODS_REPO_NOT_FOUND_MESSAGE = 'The CocoaPods repo at ~/.cocoapods was
  * Checks if xcode util is available
  * @return {Promise} Returns a promise either resolved with xcode version or rejected
  */
-module.exports.run = module.exports.check_xcodebuild = () => checkTool('xcodebuild', XCODEBUILD_MIN_VERSION, XCODEBUILD_NOT_FOUND_MESSAGE);
+module.exports.run = module.exports.check_xcodebuild = () => {
+    return checkTool('xcodebuild', XCODEBUILD_MIN_VERSION, XCODEBUILD_NOT_FOUND_MESSAGE);
+};
 
 /**
  * Checks if ios-deploy util is available
  * @return {Promise} Returns a promise either resolved with ios-deploy version or rejected
  */
-module.exports.check_ios_deploy = () => checkTool('ios-deploy', IOS_DEPLOY_MIN_VERSION, IOS_DEPLOY_NOT_FOUND_MESSAGE);
+module.exports.check_ios_deploy = () => {
+    return checkTool('ios-deploy', IOS_DEPLOY_MIN_VERSION, IOS_DEPLOY_NOT_FOUND_MESSAGE);
+};
 
 // Build iOS apps available for OSX platform only, so we reject on others platforms
-module.exports.check_os = () => os_platform_is_supported()
-    ? Q.resolve(process.platform)
-    : Q.reject('Cordova tooling for iOS requires Apple macOS');
+module.exports.check_os = () => {
+    return os_platform_is_supported()
+        ? Q.resolve(process.platform)
+        : Q.reject('Cordova tooling for iOS requires Apple macOS');
+};
 
 function os_platform_is_supported () {
     return (SUPPORTED_OS_PLATFORMS.indexOf(process.platform) !== -1);

--- a/bin/templates/scripts/cordova/lib/clean.js
+++ b/bin/templates/scripts/cordova/lib/clean.js
@@ -24,19 +24,26 @@ const superspawn = require('cordova-common').superspawn;
 
 const projectPath = path.join(__dirname, '..', '..');
 
-module.exports.run = function () {
-    const projectName = shell.ls(projectPath).filter(function (name) {
-        return path.extname(name) === '.xcodeproj';
-    })[0];
+module.exports.run = () => {
+    const projectName = shell.ls(projectPath).filter(name => path.extname(name) === '.xcodeproj')[0];
 
     if (!projectName) {
         return Q.reject('No Xcode project found in ' + projectPath);
     }
 
-    return superspawn.spawn('xcodebuild', ['-project', projectName, '-configuration', 'Debug', '-alltargets', 'clean'], { cwd: projectPath, printCommand: true, stdio: 'inherit' })
-        .then(function () {
-            return superspawn.spawn('xcodebuild', ['-project', projectName, '-configuration', 'Release', '-alltargets', 'clean'], { cwd: projectPath, printCommand: true, stdio: 'inherit' });
-        }).then(function () {
-            return shell.rm('-rf', path.join(projectPath, 'build'));
-        });
+    return superspawn.spawn(
+        'xcodebuild',
+        ['-project', projectName, '-configuration', 'Debug', '-alltargets', 'clean'],
+        { cwd: projectPath, printCommand: true, stdio: 'inherit' }
+    )
+        .then(
+            () => superspawn.spawn(
+                'xcodebuild',
+                ['-project', projectName, '-configuration', 'Release', '-alltargets', 'clean'],
+                { cwd: projectPath, printCommand: true, stdio: 'inherit' }
+            )
+        )
+        .then(
+            () => shell.rm('-rf', path.join(projectPath, 'build'))
+        );
 };

--- a/bin/templates/scripts/cordova/lib/clean.js
+++ b/bin/templates/scripts/cordova/lib/clean.js
@@ -31,19 +31,15 @@ module.exports.run = () => {
         return Q.reject('No Xcode project found in ' + projectPath);
     }
 
-    return superspawn.spawn(
-        'xcodebuild',
-        ['-project', projectName, '-configuration', 'Debug', '-alltargets', 'clean'],
-        { cwd: projectPath, printCommand: true, stdio: 'inherit' }
-    )
-        .then(
-            () => superspawn.spawn(
-                'xcodebuild',
-                ['-project', projectName, '-configuration', 'Release', '-alltargets', 'clean'],
-                { cwd: projectPath, printCommand: true, stdio: 'inherit' }
-            )
-        )
-        .then(
-            () => shell.rm('-rf', path.join(projectPath, 'build'))
+    const xcodebuildClean = configName => {
+        return superspawn.spawn(
+            'xcodebuild',
+            ['-project', projectName, '-configuration', configName, '-alltargets', 'clean'],
+            { cwd: projectPath, printCommand: true, stdio: 'inherit' }
         );
+    };
+
+    return xcodebuildClean('Debug')
+        .then(() => xcodebuildClean('Release'))
+        .then(() => shell.rm('-rf', path.join(projectPath, 'build')));
 };

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -217,7 +217,7 @@ const handlers = {
     }
 };
 
-module.exports.getInstaller = function (type) {
+module.exports.getInstaller = type => {
     if (handlers[type] && handlers[type].install) {
         return handlers[type].install;
     }
@@ -225,7 +225,7 @@ module.exports.getInstaller = function (type) {
     events.emit('warn', '<' + type + '> is not supported for iOS plugins');
 };
 
-module.exports.getUninstaller = function (type) {
+module.exports.getUninstaller = type => {
     if (handlers[type] && handlers[type].uninstall) {
         return handlers[type].uninstall;
     }
@@ -346,7 +346,7 @@ function linkFileOrDirTree (src, dest) {
 
     if (fs.statSync(src).isDirectory()) {
         shell.mkdir('-p', dest);
-        fs.readdirSync(src).forEach(function (entry) {
+        fs.readdirSync(src).forEach(entry => {
             linkFileOrDirTree(path.join(src, entry), path.join(dest, entry));
         });
     } else {

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -630,7 +630,10 @@ function mapLaunchStoryboardContents (splashScreens, launchStoryboardImagesDir) 
                      *         return item.src.indexOf(searchPattern) >= 0;
                      *     });
                      */
-                    const launchStoryboardImage = splashScreens.reduce((p, c) => (c.src.indexOf(searchPattern) >= 0) ? c : p, undefined);
+                    const launchStoryboardImage = splashScreens.reduce(
+                        (p, c) => (c.src.indexOf(searchPattern) >= 0) ? c : p
+                        , undefined
+                    );
 
                     if (launchStoryboardImage) {
                         item.filename = 'Default' + searchPattern + '.png';

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -54,17 +54,15 @@ module.exports.prepare = function (cordovaProject, options) {
 
     // Update own www dir with project's www assets and plugins' assets and js-files
     return Q.when(updateWww(cordovaProject, this.locations))
-        .then(function () {
-            // update project according to config.xml changes.
-            return updateProject(self._config, self.locations);
-        })
-        .then(function () {
+        // update project according to config.xml changes.
+        .then(() => updateProject(self._config, self.locations))
+        .then(() => {
             updateIcons(cordovaProject, self.locations);
             updateSplashScreens(cordovaProject, self.locations);
             updateLaunchStoryboardImages(cordovaProject, self.locations);
             updateFileResources(cordovaProject, self.locations);
         })
-        .then(function () {
+        .then(() => {
             events.emit('verbose', 'Prepared iOS project successfully');
         });
 };
@@ -84,7 +82,7 @@ module.exports.clean = function (options) {
     const projectConfig = new ConfigParser(this.locations.configXml);
 
     const self = this;
-    return Q().then(function () {
+    return Q().then(() => {
         cleanWww(projectRoot, self.locations);
         cleanIcons(projectRoot, projectConfig, self.locations);
         cleanSplashScreens(projectRoot, projectConfig, self.locations);
@@ -230,7 +228,7 @@ function updateProject (platformConfig, locations) {
     fs.writeFileSync(plistFile, info_contents, 'utf-8');
     events.emit('verbose', 'Wrote out iOS Bundle Version "' + version + '" to ' + plistFile);
 
-    return handleBuildSettings(platformConfig, locations, infoPlist).then(function () {
+    return handleBuildSettings(platformConfig, locations, infoPlist).then(() => {
         if (name === originalName) {
             events.emit('verbose', 'iOS Product Name has not changed (still "' + originalName + '")');
             return Q();
@@ -371,7 +369,7 @@ function mapIconResources (icons, iconsDir) {
     ];
 
     const pathMap = {};
-    platformIcons.forEach(function (item) {
+    platformIcons.forEach(item => {
         const icon = icons.getBySize(item.width, item.height) || icons.getDefault();
         if (icon) {
             const target = path.join(iconsDir, item.dest);
@@ -416,7 +414,7 @@ function cleanIcons (projectRoot, projectConfig, locations) {
         const platformProjDir = path.relative(projectRoot, locations.xcodeCordovaProj);
         const iconsDir = getIconsDir(projectRoot, platformProjDir);
         const resourceMap = mapIconResources(icons, iconsDir);
-        Object.keys(resourceMap).forEach(function (targetIconPath) {
+        Object.keys(resourceMap).forEach(targetIconPath => {
             resourceMap[targetIconPath] = null;
         });
         events.emit('verbose', 'Cleaning icons at ' + iconsDir);
@@ -444,7 +442,7 @@ function mapSplashScreenResources (splashScreens, splashScreensDir) {
     ];
 
     const pathMap = {};
-    platformSplashScreens.forEach(function (item) {
+    platformSplashScreens.forEach(item => {
         const splash = splashScreens.getBySize(item.width, item.height);
         if (splash) {
             const target = path.join(splashScreensDir, item.dest);
@@ -489,7 +487,7 @@ function cleanSplashScreens (projectRoot, projectConfig, locations) {
         const platformProjDir = path.relative(projectRoot, locations.xcodeCordovaProj);
         const splashScreensDir = getSplashScreensDir(projectRoot, platformProjDir);
         const resourceMap = mapIconResources(splashScreens, splashScreensDir);
-        Object.keys(resourceMap).forEach(function (targetSplashPath) {
+        Object.keys(resourceMap).forEach(targetSplashPath => {
             resourceMap[targetSplashPath] = null;
         });
         events.emit('verbose', 'Cleaning splash screens at ' + splashScreensDir);
@@ -513,7 +511,7 @@ function updateFileResources (cordovaProject, locations) {
     }
 
     const resourceMap = {};
-    files.forEach(function (res) {
+    files.forEach(res => {
         const src = res.src;
         let target = res.target;
 
@@ -549,7 +547,7 @@ function cleanFileResources (projectRoot, projectConfig, locations) {
         const project = projectFile.parse(locations);
 
         const resourceMap = {};
-        files.forEach(function (res) {
+        files.forEach(res => {
             const src = res.src;
             let target = res.target;
 
@@ -607,10 +605,10 @@ function mapLaunchStoryboardContents (splashScreens, launchStoryboardImagesDir) 
     };
     const sizes = ['com', 'any'];
 
-    idioms.forEach(function (idiom) {
-        scalesForIdiom[idiom].forEach(function (scale) {
-            sizes.forEach(function (width) {
-                sizes.forEach(function (height) {
+    idioms.forEach(idiom => {
+        scalesForIdiom[idiom].forEach(scale => {
+            sizes.forEach(width => {
+                sizes.forEach(height => {
                     const item = {
                         idiom: idiom,
                         scale: scale,
@@ -632,9 +630,7 @@ function mapLaunchStoryboardContents (splashScreens, launchStoryboardImagesDir) 
                      *         return item.src.indexOf(searchPattern) >= 0;
                      *     });
                      */
-                    const launchStoryboardImage = splashScreens.reduce(function (p, c) {
-                        return (c.src.indexOf(searchPattern) >= 0) ? c : p;
-                    }, undefined);
+                    const launchStoryboardImage = splashScreens.reduce((p, c) => (c.src.indexOf(searchPattern) >= 0) ? c : p, undefined);
 
                     if (launchStoryboardImage) {
                         item.filename = 'Default' + searchPattern + '.png';
@@ -668,7 +664,7 @@ function mapLaunchStoryboardContents (splashScreens, launchStoryboardImagesDir) 
 function mapLaunchStoryboardResources (splashScreens, launchStoryboardImagesDir) {
     const platformLaunchStoryboardImages = mapLaunchStoryboardContents(splashScreens, launchStoryboardImagesDir);
     const pathMap = {};
-    platformLaunchStoryboardImages.forEach(function (item) {
+    platformLaunchStoryboardImages.forEach(item => {
         if (item.target) {
             pathMap[item.target] = item.src;
         }
@@ -712,7 +708,7 @@ function getLaunchStoryboardContentsJSON (splashScreens, launchStoryboardImagesD
             version: 1
         }
     };
-    contentsJSON.images = platformLaunchStoryboardImages.map(function (item) {
+    contentsJSON.images = platformLaunchStoryboardImages.map(item => {
         const newItem = {
             idiom: item.idiom,
             scale: item.scale
@@ -785,9 +781,7 @@ function splashScreensHaveLaunchStoryboardImages (contentsJSON) {
      *        return item.filename !== undefined;
      *     });
      */
-    return !!contentsJSON.images.reduce(function (p, c) {
-        return (c.filename !== undefined) ? c : p;
-    }, undefined);
+    return !!contentsJSON.images.reduce((p, c) => (c.filename !== undefined) ? c : p, undefined);
 }
 
 function platformHasLaunchStoryboardImages (platformConfig) {
@@ -798,9 +792,7 @@ function platformHasLaunchStoryboardImages (platformConfig) {
 
 function platformHasLegacyLaunchImages (platformConfig) {
     const splashScreens = platformConfig.getSplashScreens('ios');
-    return !!splashScreens.reduce(function (p, c) {
-        return (c.width !== undefined || c.height !== undefined) ? c : p;
-    }, undefined);
+    return !!splashScreens.reduce((p, c) => (c.width !== undefined || c.height !== undefined) ? c : p, undefined);
 }
 
 /**
@@ -899,7 +891,7 @@ function cleanLaunchStoryboardImages (projectRoot, projectConfig, locations) {
         const resourceMap = mapLaunchStoryboardResources(splashScreens, launchStoryboardImagesDir);
         const contentsJSON = getLaunchStoryboardContentsJSON(splashScreens, launchStoryboardImagesDir);
 
-        Object.keys(resourceMap).forEach(function (targetPath) {
+        Object.keys(resourceMap).forEach(targetPath => {
             resourceMap[targetPath] = null;
         });
         events.emit('verbose', 'Cleaning storyboard image set at ' + launchStoryboardImagesDir);
@@ -909,7 +901,7 @@ function cleanLaunchStoryboardImages (projectRoot, projectConfig, locations) {
             resourceMap, { rootDir: projectRoot, all: true }, logFileOp);
 
         // delete filename from contents.json
-        contentsJSON.images.forEach(function (image) {
+        contentsJSON.images.forEach(image => {
             image.filename = undefined;
         });
 
@@ -975,14 +967,14 @@ function processAccessAndAllowNavigationEntries (config) {
 
     return allow_navigations
     // we concat allow_navigations and accesses, after processing accesses
-        .concat(accesses.map(function (obj) {
+        .concat(accesses.map(obj => {
             // map accesses to a common key interface using 'href', not origin
             obj.href = obj.origin;
             delete obj.origin;
             return obj;
         }))
         // we reduce the array to an object with all the entries processed (key is Hostname)
-        .reduce(function (previousReturn, currentElement) {
+        .reduce((previousReturn, currentElement) => {
             const options = {
                 minimum_tls_version: currentElement.minimum_tls_version,
                 requires_forward_secrecy: currentElement.requires_forward_secrecy,

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -631,8 +631,8 @@ function mapLaunchStoryboardContents (splashScreens, launchStoryboardImagesDir) 
                      *     });
                      */
                     const launchStoryboardImage = splashScreens.reduce(
-                        (p, c) => (c.src.indexOf(searchPattern) >= 0) ? c : p
-                        , undefined
+                        (p, c) => (c.src.indexOf(searchPattern) >= 0) ? c : p,
+                        undefined
                     );
 
                     if (launchStoryboardImage) {

--- a/bin/templates/scripts/cordova/lib/projectFile.js
+++ b/bin/templates/scripts/cordova/lib/projectFile.js
@@ -41,7 +41,7 @@ function parseProjectFile (locations) {
     xcodeproj.parseSync();
 
     const xcBuildConfiguration = xcodeproj.pbxXCBuildConfigurationSection();
-    const plist_file_entry = _.find(xcBuildConfiguration, function (entry) { return entry.buildSettings && entry.buildSettings.INFOPLIST_FILE; });
+    const plist_file_entry = _.find(xcBuildConfiguration, entry => entry.buildSettings && entry.buildSettings.INFOPLIST_FILE);
     const plist_file = path.join(project_dir, plist_file_entry.buildSettings.INFOPLIST_FILE.replace(/^"(.*)"$/g, '$1').replace(/\\&/g, '&'));
     const config_file = path.join(path.dirname(plist_file), 'config.xml');
 
@@ -113,9 +113,7 @@ xcode.project.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
 xcode.project.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
     const sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
     if (sources) {
-        sources.files = _.reject(sources.files, function (file) {
-            return file.comment === longComment(file);
-        });
+        sources.files = _.reject(sources.files, file => file.comment === longComment(file));
     }
 };
 

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -30,7 +30,7 @@ const events = require('cordova-common').events;
 const cordovaPath = path.join(__dirname, '..');
 const projectPath = path.join(__dirname, '..', '..');
 
-module.exports.run = function (runOptions) {
+module.exports.run = runOptions => {
     // Validate args
     if (runOptions.device && runOptions.emulator) {
         return Q.reject('Only one of "device"/"emulator" options should be specified');
@@ -41,15 +41,13 @@ module.exports.run = function (runOptions) {
         if (runOptions.device) return module.exports.listDevices();
         if (runOptions.emulator) return module.exports.listEmulators();
         // if no --device or --emulator flag is specified, list both devices and emulators
-        return module.exports.listDevices().then(function () {
-            return module.exports.listEmulators();
-        });
+        return module.exports.listDevices().then(() => module.exports.listEmulators());
     }
 
     let useDevice = !!runOptions.device;
 
     return require('./list-devices').run()
-        .then(function (devices) {
+        .then(devices => {
             if (devices.length > 0 && !(runOptions.emulator)) {
                 useDevice = true;
                 // we also explicitly set device flag in options as we pass
@@ -57,15 +55,14 @@ module.exports.run = function (runOptions) {
                 runOptions.device = true;
                 return check_reqs.check_ios_deploy();
             }
-        }).then(function () {
+        }).then(() => {
             if (!runOptions.nobuild) {
                 return build.run(runOptions);
             } else {
                 return Q.resolve();
             }
-        }).then(function () {
-            return build.findXCodeProjectIn(projectPath);
-        }).then(function (projectName) {
+        }).then(() => build.findXCodeProjectIn(projectPath))
+        .then(projectName => {
             let appPath = path.join(projectPath, 'build', 'emulator', projectName + '.app');
             const buildOutputDir = path.join(projectPath, 'build', 'device');
 
@@ -73,14 +70,14 @@ module.exports.run = function (runOptions) {
             // we're running on device/emulator
             if (useDevice) {
                 return module.exports.checkDeviceConnected()
-                    .then(function () {
+                    .then(() => {
                         // Unpack IPA
                         const ipafile = path.join(buildOutputDir, projectName + '.ipa');
 
                         // unpack the existing platform/ios/build/device/appname.ipa (zipfile), will create a Payload folder
                         return superspawn.spawn('unzip', ['-o', '-qq', ipafile], { cwd: buildOutputDir, printCommand: true, stdio: 'inherit' });
                     })
-                    .then(function () {
+                    .then(() => {
                         // Uncompress IPA (zip file)
                         const appFileInflated = path.join(buildOutputDir, 'Payload', projectName + '.app');
                         const appFile = path.join(buildOutputDir, projectName + '.app');
@@ -95,18 +92,19 @@ module.exports.run = function (runOptions) {
 
                         return null;
                     })
-                    .then(function () {
-                        appPath = path.join(projectPath, 'build', 'device', projectName + '.app');
-                        let extraArgs = [];
-                        if (runOptions.argv) {
-                            // argv.slice(2) removes node and run.js, filterSupportedArgs removes the run.js args
-                            extraArgs = module.exports.filterSupportedArgs(runOptions.argv.slice(2));
-                        }
-                        return module.exports.deployToDevice(appPath, runOptions.target, extraArgs);
-                    }, function () {
+                    .then(
+                        () => {
+                            appPath = path.join(projectPath, 'build', 'device', projectName + '.app');
+                            let extraArgs = [];
+                            if (runOptions.argv) {
+                                // argv.slice(2) removes node and run.js, filterSupportedArgs removes the run.js args
+                                extraArgs = module.exports.filterSupportedArgs(runOptions.argv.slice(2));
+                            }
+                            return module.exports.deployToDevice(appPath, runOptions.target, extraArgs);
+                        },
                         // if device connection check failed use emulator then
-                        return module.exports.deployToSim(appPath, runOptions.target);
-                    });
+                        () => module.exports.deployToSim(appPath, runOptions.target)
+                    );
             } else {
                 return module.exports.deployToSim(appPath, runOptions.target);
             }
@@ -131,7 +129,7 @@ function filterSupportedArgs (args) {
     const sargs = ['--device', '--emulator', '--nobuild', '--list', '--target', '--debug', '--release'];
     const re = new RegExp(sargs.join('|'));
 
-    args.forEach(function (element) {
+    args.forEach(element => {
         // supported args not found, we add
         // we do a regex search because --target can be "--target=XXX"
         if (element.search(re) === -1) {
@@ -177,11 +175,11 @@ function deployToSim (appPath, target) {
     if (!target) {
         // Select target device for emulator
         return require('./list-emulator-images').run()
-            .then(function (emulators) {
+            .then(emulators => {
                 if (emulators.length > 0) {
                     target = emulators[0];
                 }
-                emulators.forEach(function (emulator) {
+                emulators.forEach(emulator => {
                     if (emulator.indexOf('iPhone') === 0) {
                         target = emulator;
                     }
@@ -205,7 +203,7 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
     const params = ['launch', appPath, '--devicetypeid', devicetypeid, '--log', log, exit];
 
     return superspawn.spawn(f, params, { cwd: projectPath, printCommand: true })
-        .progress(function (stdio) {
+        .progress(stdio => {
             if (stdio.stderr) {
                 events.emit('error', `[ios-sim] ${stdio.stderr}`);
             }
@@ -213,16 +211,16 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
                 events.emit('log', `[ios-sim] ${stdio.stdout.trim()}`);
             }
         })
-        .then(function (result) {
+        .then(result => {
             events.emit('log', 'Simulator successfully started via `ios-sim`.');
         });
 }
 
 function listDevices () {
     return require('./list-devices').run()
-        .then(function (devices) {
+        .then(devices => {
             events.emit('log', 'Available iOS Devices:');
-            devices.forEach(function (device) {
+            devices.forEach(device => {
                 events.emit('log', '\t' + device);
             });
         });
@@ -230,15 +228,15 @@ function listDevices () {
 
 function listEmulators () {
     return require('./list-emulator-images').run()
-        .then(function (emulators) {
+        .then(emulators => {
             events.emit('log', 'Available iOS Simulators:');
-            emulators.forEach(function (emulator) {
+            emulators.forEach(emulator => {
                 events.emit('log', '\t' + emulator);
             });
         });
 }
 
-module.exports.help = function () {
+module.exports.help = () => {
     console.log('\nUsage: run [ --device | [ --emulator [ --target=<id> ] ] ] [ --debug | --release | --nobuild ]');
     // TODO: add support for building different archs
     // console.log("           [ --archs=\"<list of target architectures>\" ] ");

--- a/bin/templates/scripts/cordova/lib/spawn.js
+++ b/bin/templates/scripts/cordova/lib/spawn.js
@@ -29,7 +29,7 @@ const proc = require('child_process');
  * @return {Promise}              Promise either fullfilled or rejected with error code
  * @deprecated Use `require('cordova-common').superspawn` instead.
  */
-module.exports = function (cmd, args, opt_cwd) {
+module.exports = (cmd, args, opt_cwd) => {
     console.warn(
         'This function is deprecated, may be removed from a future release. ' +
         "Use `require('cordova-common').superspawn` instead.");
@@ -37,7 +37,7 @@ module.exports = function (cmd, args, opt_cwd) {
     try {
         const child = proc.spawn(cmd, args, { cwd: opt_cwd, stdio: 'inherit' });
 
-        child.on('exit', function (code) {
+        child.on('exit', code => {
             if (code) {
                 d.reject('Error code ' + code + ' for command: ' + cmd + ' with args: ' + args);
             } else {

--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -23,9 +23,9 @@ const child_process = require('child_process');
 const Q = require('q');
 const semver = require('semver');
 
-exports.get_apple_ios_version = function () {
+exports.get_apple_ios_version = () => {
     const d = Q.defer();
-    child_process.exec('xcodebuild -showsdks', function (error, stdout, stderr) {
+    child_process.exec('xcodebuild -showsdks', (error, stdout, stderr) => {
         if (error) {
             d.reject(stderr);
         } else {
@@ -33,7 +33,7 @@ exports.get_apple_ios_version = function () {
         }
     });
 
-    return d.promise.then(function (output) {
+    return d.promise.then(output => {
         const regex = /[0-9]*\.[0-9]*/;
         const versions = [];
         const regexIOS = /^iOS \d+/;
@@ -46,14 +46,12 @@ exports.get_apple_ios_version = function () {
         versions.sort();
         console.log(versions[0]);
         return Q();
-    }, function (stderr) {
-        return Q.reject(stderr);
-    });
+    }, stderr => Q.reject(stderr));
 };
 
-exports.get_apple_osx_version = function () {
+exports.get_apple_osx_version = () => {
     const d = Q.defer();
-    child_process.exec('xcodebuild -showsdks', function (error, stdout, stderr) {
+    child_process.exec('xcodebuild -showsdks', (error, stdout, stderr) => {
         if (error) {
             d.reject(stderr);
         } else {
@@ -61,7 +59,7 @@ exports.get_apple_osx_version = function () {
         }
     });
 
-    return d.promise.then(function (output) {
+    return d.promise.then(output => {
         const regex = /[0-9]*\.[0-9]*/;
         const versions = [];
         const regexOSX = /^macOS \d+/;
@@ -74,14 +72,12 @@ exports.get_apple_osx_version = function () {
         versions.sort();
         console.log(versions[0]);
         return Q();
-    }, function (stderr) {
-        return Q.reject(stderr);
-    });
+    }, stderr => Q.reject(stderr));
 };
 
-exports.get_apple_xcode_version = function () {
+exports.get_apple_xcode_version = () => {
     const d = Q.defer();
-    child_process.exec('xcodebuild -version', function (error, stdout, stderr) {
+    child_process.exec('xcodebuild -version', (error, stdout, stderr) => {
         const versionMatch = /Xcode (.*)/.exec(stdout);
         if (error || !versionMatch) {
             d.reject(stderr);
@@ -97,9 +93,9 @@ exports.get_apple_xcode_version = function () {
  * @return {Promise} Promise that either resolved with ios-deploy version
  *                           or rejected in case of error
  */
-exports.get_ios_deploy_version = function () {
+exports.get_ios_deploy_version = () => {
     const d = Q.defer();
-    child_process.exec('ios-deploy --version', function (error, stdout, stderr) {
+    child_process.exec('ios-deploy --version', (error, stdout, stderr) => {
         if (error) {
             d.reject(stderr);
         } else {
@@ -114,9 +110,9 @@ exports.get_ios_deploy_version = function () {
  * @return {Promise} Promise that either resolved with pod version
  *                           or rejected in case of error
  */
-exports.get_cocoapods_version = function () {
+exports.get_cocoapods_version = () => {
     const d = Q.defer();
-    child_process.exec('pod --version', function (error, stdout, stderr) {
+    child_process.exec('pod --version', (error, stdout, stderr) => {
         if (error) {
             d.reject(stderr);
         } else {
@@ -131,9 +127,9 @@ exports.get_cocoapods_version = function () {
  * @return {Promise} Promise that either resolved with ios-sim version
  *                           or rejected in case of error
  */
-exports.get_ios_sim_version = function () {
+exports.get_ios_sim_version = () => {
     const d = Q.defer();
-    child_process.exec('ios-sim --version', function (error, stdout, stderr) {
+    child_process.exec('ios-sim --version', (error, stdout, stderr) => {
         if (error) {
             d.reject(stderr);
         } else {
@@ -149,7 +145,7 @@ exports.get_ios_sim_version = function () {
  * @return {Promise}         Promise that either resolved with tool version
  *                                   or rejected in case of error
  */
-exports.get_tool_version = function (toolName) {
+exports.get_tool_version = toolName => {
     switch (toolName) {
     case 'xcodebuild': return exports.get_apple_xcode_version();
     case 'ios-sim': return exports.get_ios_sim_version();

--- a/tests/spec/component/versions.spec.js
+++ b/tests/spec/component/versions.spec.js
@@ -22,38 +22,28 @@ const versions = rewire('../../../bin/templates/scripts/cordova/lib/versions');
 
 // These tests can not run on windows.
 if (process.platform === 'darwin') {
-    describe('versions', function () {
+    describe('versions', () => {
         describe('get_tool_version method', () => {
-            it('should not have found tool by name.', () => {
-                return versions.get_tool_version('unknown').then(
-                    () => fail('expected promise rejection'),
-                    error => expect(error).toContain('is not valid tool name')
-                );
-            });
+            it('should not have found tool by name.', () => versions.get_tool_version('unknown').then(
+                () => fail('expected promise rejection'),
+                error => expect(error).toContain('is not valid tool name')
+            ));
 
-            it('should find xcodebuild version.', () => {
-                return versions.get_tool_version('xcodebuild').then((version) => {
-                    expect(version).not.toBe(undefined);
-                });
-            });
+            it('should find xcodebuild version.', () => versions.get_tool_version('xcodebuild').then((version) => {
+                expect(version).not.toBe(undefined);
+            }));
 
-            it('should find ios-sim version.', () => {
-                return versions.get_tool_version('ios-sim').then((version) => {
-                    expect(version).not.toBe(undefined);
-                });
-            });
+            it('should find ios-sim version.', () => versions.get_tool_version('ios-sim').then((version) => {
+                expect(version).not.toBe(undefined);
+            }));
 
-            it('should find ios-deploy version.', () => {
-                return versions.get_tool_version('ios-deploy').then((version) => {
-                    expect(version).not.toBe(undefined);
-                });
-            });
+            it('should find ios-deploy version.', () => versions.get_tool_version('ios-deploy').then((version) => {
+                expect(version).not.toBe(undefined);
+            }));
 
-            it('should find pod version.', () => {
-                return versions.get_tool_version('pod').then((version) => {
-                    expect(version).not.toBe(undefined);
-                });
-            });
+            it('should find pod version.', () => versions.get_tool_version('pod').then((version) => {
+                expect(version).not.toBe(undefined);
+            }));
         });
     });
 }

--- a/tests/spec/component/versions.spec.js
+++ b/tests/spec/component/versions.spec.js
@@ -24,26 +24,36 @@ const versions = rewire('../../../bin/templates/scripts/cordova/lib/versions');
 if (process.platform === 'darwin') {
     describe('versions', () => {
         describe('get_tool_version method', () => {
-            it('should not have found tool by name.', () => versions.get_tool_version('unknown').then(
-                () => fail('expected promise rejection'),
-                error => expect(error).toContain('is not valid tool name')
-            ));
+            it('should not have found tool by name.', () => {
+                return versions.get_tool_version('unknown').then(
+                    () => fail('expected promise rejection'),
+                    error => expect(error).toContain('is not valid tool name')
+                );
+            });
 
-            it('should find xcodebuild version.', () => versions.get_tool_version('xcodebuild').then((version) => {
-                expect(version).not.toBe(undefined);
-            }));
+            it('should find xcodebuild version.', () => {
+                return versions.get_tool_version('xcodebuild').then((version) => {
+                    expect(version).not.toBe(undefined);
+                });
+            });
 
-            it('should find ios-sim version.', () => versions.get_tool_version('ios-sim').then((version) => {
-                expect(version).not.toBe(undefined);
-            }));
+            it('should find ios-sim version.', () => {
+                return versions.get_tool_version('ios-sim').then((version) => {
+                    expect(version).not.toBe(undefined);
+                });
+            });
 
-            it('should find ios-deploy version.', () => versions.get_tool_version('ios-deploy').then((version) => {
-                expect(version).not.toBe(undefined);
-            }));
+            it('should find ios-deploy version.', () => {
+                return versions.get_tool_version('ios-deploy').then((version) => {
+                    expect(version).not.toBe(undefined);
+                });
+            });
 
-            it('should find pod version.', () => versions.get_tool_version('pod').then((version) => {
-                expect(version).not.toBe(undefined);
-            }));
+            it('should find pod version.', () => {
+                return versions.get_tool_version('pod').then((version) => {
+                    expect(version).not.toBe(undefined);
+                });
+            });
         });
     });
 }

--- a/tests/spec/create.spec.js
+++ b/tests/spec/create.spec.js
@@ -50,57 +50,57 @@ function createAndBuild (projectname, projectid) {
     shell.rm('-rf', command);
 }
 
-describe('create', function () {
-    it('Test#001 : create project with ascii name, no spaces', function () {
+describe('create', () => {
+    it('Test#001 : create project with ascii name, no spaces', () => {
         const projectname = 'testcreate';
         const projectid = 'com.test.app1';
 
         createAndBuild(projectname, projectid);
     });
 
-    it('Test#002 : create project with ascii name, and spaces', function () {
+    it('Test#002 : create project with ascii name, and spaces', () => {
         const projectname = 'test create';
         const projectid = 'com.test.app2';
 
         createAndBuild(projectname, projectid);
     });
 
-    it('Test#003 : create project with unicode name, no spaces', function () {
+    it('Test#003 : create project with unicode name, no spaces', () => {
         const projectname = '応応応応用用用用';
         const projectid = 'com.test.app3';
 
         createAndBuild(projectname, projectid);
     });
 
-    it('Test#004 : create project with unicode name 2, no spaces', function () {
+    it('Test#004 : create project with unicode name 2, no spaces', () => {
         const projectname = 'إثرا';
         const projectid = 'com.test.app3.2';
 
         createAndBuild(projectname, projectid);
     });
 
-    it('Test#005 : create project with unicode name, and spaces', function () {
+    it('Test#005 : create project with unicode name, and spaces', () => {
         const projectname = '応応応応 用用用用';
         const projectid = 'com.test.app4';
 
         createAndBuild(projectname, projectid);
     });
 
-    it('Test#006 : create project with ascii+unicode name, no spaces', function () {
+    it('Test#006 : create project with ascii+unicode name, no spaces', () => {
         const projectname = '応応応応hello用用用用';
         const projectid = 'com.test.app5';
 
         createAndBuild(projectname, projectid);
     });
 
-    it('Test#007 : create project with ascii+unicode name, and spaces', function () {
+    it('Test#007 : create project with ascii+unicode name, and spaces', () => {
         const projectname = '応応応応 hello 用用用用';
         const projectid = 'com.test.app6';
 
         createAndBuild(projectname, projectid);
     });
 
-    it('Test#008 : create project with ascii name, and spaces, ampersand(&)', function () {
+    it('Test#008 : create project with ascii name, and spaces, ampersand(&)', () => {
         const projectname = 'hello & world';
         const projectid = 'com.test.app7';
 

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -125,11 +125,13 @@ describe('Platform Api', () => {
                     spyOn(my_plugin, 'getHeaderFiles').and.returnValue([my_bridgingHeader_json]);
                     BridgingHeader_mod.BridgingHeader.and.callFake(() => bridgingHeader_mock);
                 });
-                it('should add BridgingHeader', () => api.addPlugin(my_plugin)
-                    .then(() => {
-                        expect(bridgingHeader_mock.addHeader).toHaveBeenCalledWith(my_plugin.id, 'bridgingHeaderSource!');
-                        expect(bridgingHeader_mock.write).toHaveBeenCalled();
-                    }));
+                it('should add BridgingHeader', () => {
+                    return api.addPlugin(my_plugin)
+                        .then(() => {
+                            expect(bridgingHeader_mock.addHeader).toHaveBeenCalledWith(my_plugin.id, 'bridgingHeaderSource!');
+                            expect(bridgingHeader_mock.write).toHaveBeenCalled();
+                        });
+                });
             });
             describe('adding pods since the plugin contained <podspecs>', () => {
                 let podsjson_mock;
@@ -170,16 +172,18 @@ describe('Platform Api', () => {
                     PodsJson_mod.PodsJson.and.callFake(() => podsjson_mock);
                     Podfile_mod.Podfile.and.callFake(() => podfile_mock);
                 });
-                it('on a new declaration, it should add a new json to declarations', () => api.addPlugin(my_plugin)
-                    .then(() => {
-                        expect(podsjson_mock.getDeclaration.calls.count()).toEqual(2);
-                        compareListWithoutOrder(podsjson_mock.getDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
-                        expect(podsjson_mock.setJsonDeclaration.calls.count()).toEqual(2);
-                        compareListWithoutOrder(podsjson_mock.setJsonDeclaration.calls.allArgs(),
-                            [['use_frameworks!', { declaration: 'use_frameworks!', count: 1 }], ['inhibit_all_warnings!', { declaration: 'inhibit_all_warnings!', count: 1 }]]);
-                        expect(podfile_mock.addDeclaration.calls.count()).toEqual(2);
-                        compareListWithoutOrder(podfile_mock.addDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
-                    }));
+                it('on a new declaration, it should add a new json to declarations', () => {
+                    return api.addPlugin(my_plugin)
+                        .then(() => {
+                            expect(podsjson_mock.getDeclaration.calls.count()).toEqual(2);
+                            compareListWithoutOrder(podsjson_mock.getDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
+                            expect(podsjson_mock.setJsonDeclaration.calls.count()).toEqual(2);
+                            compareListWithoutOrder(podsjson_mock.setJsonDeclaration.calls.allArgs(),
+                                [['use_frameworks!', { declaration: 'use_frameworks!', count: 1 }], ['inhibit_all_warnings!', { declaration: 'inhibit_all_warnings!', count: 1 }]]);
+                            expect(podfile_mock.addDeclaration.calls.count()).toEqual(2);
+                            compareListWithoutOrder(podfile_mock.addDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
+                        });
+                });
                 it('should increment count in declarations if already exists', () => {
                     podsjson_mock.getDeclaration.and.callFake(declaration => {
                         if (declaration === 'use_frameworks!') {
@@ -198,18 +202,20 @@ describe('Platform Api', () => {
                             compareListWithoutOrder(podfile_mock.addDeclaration.calls.allArgs(), [['inhibit_all_warnings!']]);
                         });
                 });
-                it('on a new source, it should add a new json to sources', () => api.addPlugin(my_plugin)
-                    .then(() => {
-                        expect(podsjson_mock.getSource.calls.count()).toEqual(2);
-                        compareListWithoutOrder(podsjson_mock.getSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
-                        expect(podsjson_mock.setJsonSource.calls.count()).toEqual(2);
-                        compareListWithoutOrder(podsjson_mock.setJsonSource.calls.allArgs(), [
-                            ['https://github.com/sample/SampleSpecs.git', { source: 'https://github.com/sample/SampleSpecs.git', count: 1 }],
-                            ['https://github.com/CocoaPods/Specs.git', { source: 'https://github.com/CocoaPods/Specs.git', count: 1 }]
-                        ]);
-                        expect(podfile_mock.addSource.calls.count()).toEqual(2);
-                        compareListWithoutOrder(podfile_mock.addSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
-                    }));
+                it('on a new source, it should add a new json to sources', () => {
+                    return api.addPlugin(my_plugin)
+                        .then(() => {
+                            expect(podsjson_mock.getSource.calls.count()).toEqual(2);
+                            compareListWithoutOrder(podsjson_mock.getSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
+                            expect(podsjson_mock.setJsonSource.calls.count()).toEqual(2);
+                            compareListWithoutOrder(podsjson_mock.setJsonSource.calls.allArgs(), [
+                                ['https://github.com/sample/SampleSpecs.git', { source: 'https://github.com/sample/SampleSpecs.git', count: 1 }],
+                                ['https://github.com/CocoaPods/Specs.git', { source: 'https://github.com/CocoaPods/Specs.git', count: 1 }]
+                            ]);
+                            expect(podfile_mock.addSource.calls.count()).toEqual(2);
+                            compareListWithoutOrder(podfile_mock.addSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
+                        });
+                });
                 it('should increment count in sources if already exists', () => {
                     podsjson_mock.getSource.and.callFake(source => {
                         if (source === 'https://github.com/CocoaPods/Specs.git') {
@@ -228,27 +234,29 @@ describe('Platform Api', () => {
                             compareListWithoutOrder(podfile_mock.addSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git']]);
                         });
                 });
-                it('on a new library, it should add a new json to library', () => api.addPlugin(my_plugin)
-                    .then(() => {
-                        expect(podsjson_mock.getLibrary.calls.count()).toEqual(3);
-                        compareListWithoutOrder(podsjson_mock.getLibrary.calls.allArgs(), [
-                            ['AFNetworking'],
-                            ['Eureka'],
-                            ['HogeLib']
-                        ]);
-                        expect(podsjson_mock.setJsonLibrary.calls.count()).toEqual(3);
-                        compareListWithoutOrder(podsjson_mock.setJsonLibrary.calls.allArgs(), [
-                            ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
-                            ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
-                            ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
-                        ]);
-                        expect(podfile_mock.addSpec.calls.count()).toEqual(3);
-                        compareListWithoutOrder(podfile_mock.addSpec.calls.allArgs(), [
-                            ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
-                            ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
-                            ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
-                        ]);
-                    }));
+                it('on a new library, it should add a new json to library', () => {
+                    return api.addPlugin(my_plugin)
+                        .then(() => {
+                            expect(podsjson_mock.getLibrary.calls.count()).toEqual(3);
+                            compareListWithoutOrder(podsjson_mock.getLibrary.calls.allArgs(), [
+                                ['AFNetworking'],
+                                ['Eureka'],
+                                ['HogeLib']
+                            ]);
+                            expect(podsjson_mock.setJsonLibrary.calls.count()).toEqual(3);
+                            compareListWithoutOrder(podsjson_mock.setJsonLibrary.calls.allArgs(), [
+                                ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
+                                ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
+                                ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
+                            ]);
+                            expect(podfile_mock.addSpec.calls.count()).toEqual(3);
+                            compareListWithoutOrder(podfile_mock.addSpec.calls.allArgs(), [
+                                ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
+                                ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
+                                ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
+                            ]);
+                        });
+                });
                 it('should increment count in libraries if already exists', () => {
                     podsjson_mock.getLibrary.and.callFake(library => {
                         if (library === 'AFNetworking') {
@@ -313,11 +321,13 @@ describe('Platform Api', () => {
                             expect(podsjson_mock.incrementLibrary).toHaveBeenCalledWith('podsource!');
                         });
                 });
-                it('on a new framework/pod name/src/key, it should add a new json to podsjson and add a new spec to podfile', () => api.addPlugin(my_plugin)
-                    .then(() => {
-                        expect(podsjson_mock.setJsonLibrary).toHaveBeenCalledWith(my_pod_json.src, jasmine.any(Object));
-                        expect(podfile_mock.addSpec).toHaveBeenCalledWith(my_pod_json.src, my_pod_json.spec);
-                    }));
+                it('on a new framework/pod name/src/key, it should add a new json to podsjson and add a new spec to podfile', () => {
+                    return api.addPlugin(my_plugin)
+                        .then(() => {
+                            expect(podsjson_mock.setJsonLibrary).toHaveBeenCalledWith(my_pod_json.src, jasmine.any(Object));
+                            expect(podfile_mock.addSpec).toHaveBeenCalledWith(my_pod_json.src, my_pod_json.spec);
+                        });
+                });
                 it('should write out podfile and install if podfile was changed', () => {
                     podfile_mock.isDirty.and.returnValue(true);
                     podfile_mock.install.and.returnValue({ then: function () { } });

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -46,15 +46,15 @@ function compareListWithoutOrder (list1, list2) {
     expect(list1.sort()).toEqual(list2.sort());
 }
 
-describe('Platform Api', function () {
-    describe('constructor', function () {
-        it('Test 001 : should throw if provided directory does not contain an xcodeproj file', function () {
+describe('Platform Api', () => {
+    describe('constructor', () => {
+        it('Test 001 : should throw if provided directory does not contain an xcodeproj file', () => {
             expect(() =>
                 new Api('ios', path.join(FIXTURES, '..'), new EventEmitter())
             ).toThrow();
         });
-        it('Test 002 : should create an instance with path, pbxproj, xcodeproj, originalName and cordovaproj properties', function () {
-            expect(function () {
+        it('Test 002 : should create an instance with path, pbxproj, xcodeproj, originalName and cordovaproj properties', () => {
+            expect(() => {
                 const p = new Api('ios', iosProjectFixture, new EventEmitter());
                 expect(p.locations.root).toEqual(iosProjectFixture);
                 expect(p.locations.pbxproj).toEqual(path.join(iosProjectFixture, 'SampleApp.xcodeproj', 'project.pbxproj'));
@@ -65,10 +65,10 @@ describe('Platform Api', function () {
         });
     });
 
-    describe('.prototype', function () {
+    describe('.prototype', () => {
         let api, events;
         const projectRoot = iosProjectFixture;
-        beforeEach(function () {
+        beforeEach(() => {
             events = new EventEmitter();
             api = new Api('ios', projectRoot, events);
             spyOn(fs, 'readdirSync').and.returnValue([api.locations.xcodeProjDir]);
@@ -81,26 +81,26 @@ describe('Platform Api', function () {
         // for information on why we conditionall run this test.
         // tl;dr run_mod requires the ios-sim module, which requires mac OS.
         if (process.platform === 'darwin') {
-            describe('run', function () {
-                beforeEach(function () {
+            describe('run', () => {
+                beforeEach(() => {
                     spyOn(check_reqs, 'run').and.returnValue(Q.resolve());
                 });
-                it('should call into lib/run module', function () {
+                it('should call into lib/run module', () => {
                     spyOn(run_mod, 'run');
-                    return api.run().then(function () {
+                    return api.run().then(() => {
                         expect(run_mod.run).toHaveBeenCalled();
                     });
                 });
             });
         }
 
-        describe('addPlugin', function () {
+        describe('addPlugin', () => {
             const my_plugin = {
                 getHeaderFiles: function () { return []; },
                 getFrameworks: function () { return []; },
                 getPodSpecs: function () { return []; }
             };
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(PluginManager, 'get').and.returnValue({
                     addPlugin: function () { return Q(); }
                 });
@@ -108,34 +108,30 @@ describe('Platform Api', function () {
                 spyOn(Podfile_mod, 'Podfile');
                 spyOn(PodsJson_mod, 'PodsJson');
             });
-            it('should assign a package name to plugin variables if one is not explicitly provided via options', function () {
+            it('should assign a package name to plugin variables if one is not explicitly provided via options', () => {
                 const opts = {};
                 return api.addPlugin(my_plugin, opts)
                     .then(() => expect(opts.variables.PACKAGE_NAME).toEqual('ios.cordova.io'));
             });
-            describe('with header-file of `BridgingHeader` type', function () {
+            describe('with header-file of `BridgingHeader` type', () => {
                 let bridgingHeader_mock;
                 const my_bridgingHeader_json = {
                     type: 'BridgingHeader',
                     src: 'bridgingHeaderSource!'
                 };
-                beforeEach(function () {
+                beforeEach(() => {
                     bridgingHeader_mock = jasmine.createSpyObj('bridgingHeader mock', ['addHeader', 'write']);
                     spyOn(my_plugin, 'getFrameworks').and.returnValue([]);
                     spyOn(my_plugin, 'getHeaderFiles').and.returnValue([my_bridgingHeader_json]);
-                    BridgingHeader_mod.BridgingHeader.and.callFake(function () {
-                        return bridgingHeader_mock;
-                    });
+                    BridgingHeader_mod.BridgingHeader.and.callFake(() => bridgingHeader_mock);
                 });
-                it('should add BridgingHeader', function () {
-                    return api.addPlugin(my_plugin)
-                        .then(function () {
-                            expect(bridgingHeader_mock.addHeader).toHaveBeenCalledWith(my_plugin.id, 'bridgingHeaderSource!');
-                            expect(bridgingHeader_mock.write).toHaveBeenCalled();
-                        });
-                });
+                it('should add BridgingHeader', () => api.addPlugin(my_plugin)
+                    .then(() => {
+                        expect(bridgingHeader_mock.addHeader).toHaveBeenCalledWith(my_plugin.id, 'bridgingHeaderSource!');
+                        expect(bridgingHeader_mock.write).toHaveBeenCalled();
+                    }));
             });
-            describe('adding pods since the plugin contained <podspecs>', function () {
+            describe('adding pods since the plugin contained <podspecs>', () => {
                 let podsjson_mock;
                 let podfile_mock;
                 const my_pod_json = {
@@ -164,41 +160,35 @@ describe('Platform Api', function () {
                         }
                     }
                 };
-                beforeEach(function () {
+                beforeEach(() => {
                     podsjson_mock = jasmine.createSpyObj('podsjson mock', ['getLibrary', 'getSource', 'getDeclaration',
                         'incrementLibrary', 'incrementSource', 'incrementDeclaration', 'write',
                         'setJsonLibrary', 'setJsonSource', 'setJsonDeclaration']);
                     podfile_mock = jasmine.createSpyObj('podfile mock', ['isDirty', 'addSpec', 'addSource', 'addDeclaration', 'write', 'install']);
                     spyOn(my_plugin, 'getFrameworks').and.returnValue([]);
                     spyOn(my_plugin, 'getPodSpecs').and.returnValue([my_pod_json]);
-                    PodsJson_mod.PodsJson.and.callFake(function () {
-                        return podsjson_mock;
-                    });
-                    Podfile_mod.Podfile.and.callFake(function () {
-                        return podfile_mock;
-                    });
+                    PodsJson_mod.PodsJson.and.callFake(() => podsjson_mock);
+                    Podfile_mod.Podfile.and.callFake(() => podfile_mock);
                 });
-                it('on a new declaration, it should add a new json to declarations', function () {
-                    return api.addPlugin(my_plugin)
-                        .then(function () {
-                            expect(podsjson_mock.getDeclaration.calls.count()).toEqual(2);
-                            compareListWithoutOrder(podsjson_mock.getDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
-                            expect(podsjson_mock.setJsonDeclaration.calls.count()).toEqual(2);
-                            compareListWithoutOrder(podsjson_mock.setJsonDeclaration.calls.allArgs(),
-                                [['use_frameworks!', { declaration: 'use_frameworks!', count: 1 }], ['inhibit_all_warnings!', { declaration: 'inhibit_all_warnings!', count: 1 }]]);
-                            expect(podfile_mock.addDeclaration.calls.count()).toEqual(2);
-                            compareListWithoutOrder(podfile_mock.addDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
-                        });
-                });
-                it('should increment count in declarations if already exists', function () {
-                    podsjson_mock.getDeclaration.and.callFake(function (declaration) {
+                it('on a new declaration, it should add a new json to declarations', () => api.addPlugin(my_plugin)
+                    .then(() => {
+                        expect(podsjson_mock.getDeclaration.calls.count()).toEqual(2);
+                        compareListWithoutOrder(podsjson_mock.getDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
+                        expect(podsjson_mock.setJsonDeclaration.calls.count()).toEqual(2);
+                        compareListWithoutOrder(podsjson_mock.setJsonDeclaration.calls.allArgs(),
+                            [['use_frameworks!', { declaration: 'use_frameworks!', count: 1 }], ['inhibit_all_warnings!', { declaration: 'inhibit_all_warnings!', count: 1 }]]);
+                        expect(podfile_mock.addDeclaration.calls.count()).toEqual(2);
+                        compareListWithoutOrder(podfile_mock.addDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
+                    }));
+                it('should increment count in declarations if already exists', () => {
+                    podsjson_mock.getDeclaration.and.callFake(declaration => {
                         if (declaration === 'use_frameworks!') {
                             return { declaration: 'use_frameworks!', count: 1 };
                         }
                         return null;
                     });
                     return api.addPlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getDeclaration.calls.count()).toEqual(2);
                             compareListWithoutOrder(podsjson_mock.getDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
                             expect(podsjson_mock.incrementDeclaration).toHaveBeenCalledWith('use_frameworks!');
@@ -208,29 +198,27 @@ describe('Platform Api', function () {
                             compareListWithoutOrder(podfile_mock.addDeclaration.calls.allArgs(), [['inhibit_all_warnings!']]);
                         });
                 });
-                it('on a new source, it should add a new json to sources', function () {
-                    return api.addPlugin(my_plugin)
-                        .then(function () {
-                            expect(podsjson_mock.getSource.calls.count()).toEqual(2);
-                            compareListWithoutOrder(podsjson_mock.getSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
-                            expect(podsjson_mock.setJsonSource.calls.count()).toEqual(2);
-                            compareListWithoutOrder(podsjson_mock.setJsonSource.calls.allArgs(), [
-                                ['https://github.com/sample/SampleSpecs.git', { source: 'https://github.com/sample/SampleSpecs.git', count: 1 }],
-                                ['https://github.com/CocoaPods/Specs.git', { source: 'https://github.com/CocoaPods/Specs.git', count: 1 }]
-                            ]);
-                            expect(podfile_mock.addSource.calls.count()).toEqual(2);
-                            compareListWithoutOrder(podfile_mock.addSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
-                        });
-                });
-                it('should increment count in sources if already exists', function () {
-                    podsjson_mock.getSource.and.callFake(function (source) {
+                it('on a new source, it should add a new json to sources', () => api.addPlugin(my_plugin)
+                    .then(() => {
+                        expect(podsjson_mock.getSource.calls.count()).toEqual(2);
+                        compareListWithoutOrder(podsjson_mock.getSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
+                        expect(podsjson_mock.setJsonSource.calls.count()).toEqual(2);
+                        compareListWithoutOrder(podsjson_mock.setJsonSource.calls.allArgs(), [
+                            ['https://github.com/sample/SampleSpecs.git', { source: 'https://github.com/sample/SampleSpecs.git', count: 1 }],
+                            ['https://github.com/CocoaPods/Specs.git', { source: 'https://github.com/CocoaPods/Specs.git', count: 1 }]
+                        ]);
+                        expect(podfile_mock.addSource.calls.count()).toEqual(2);
+                        compareListWithoutOrder(podfile_mock.addSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
+                    }));
+                it('should increment count in sources if already exists', () => {
+                    podsjson_mock.getSource.and.callFake(source => {
                         if (source === 'https://github.com/CocoaPods/Specs.git') {
                             return { source: 'https://github.com/CocoaPods/Specs.git', count: 1 };
                         }
                         return null;
                     });
                     return api.addPlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getSource.calls.count()).toEqual(2);
                             compareListWithoutOrder(podsjson_mock.getSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
                             expect(podsjson_mock.incrementSource).toHaveBeenCalledWith('https://github.com/CocoaPods/Specs.git');
@@ -240,38 +228,36 @@ describe('Platform Api', function () {
                             compareListWithoutOrder(podfile_mock.addSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git']]);
                         });
                 });
-                it('on a new library, it should add a new json to library', function () {
-                    return api.addPlugin(my_plugin)
-                        .then(function () {
-                            expect(podsjson_mock.getLibrary.calls.count()).toEqual(3);
-                            compareListWithoutOrder(podsjson_mock.getLibrary.calls.allArgs(), [
-                                ['AFNetworking'],
-                                ['Eureka'],
-                                ['HogeLib']
-                            ]);
-                            expect(podsjson_mock.setJsonLibrary.calls.count()).toEqual(3);
-                            compareListWithoutOrder(podsjson_mock.setJsonLibrary.calls.allArgs(), [
-                                ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
-                                ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
-                                ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
-                            ]);
-                            expect(podfile_mock.addSpec.calls.count()).toEqual(3);
-                            compareListWithoutOrder(podfile_mock.addSpec.calls.allArgs(), [
-                                ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
-                                ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
-                                ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
-                            ]);
-                        });
-                });
-                it('should increment count in libraries if already exists', function () {
-                    podsjson_mock.getLibrary.and.callFake(function (library) {
+                it('on a new library, it should add a new json to library', () => api.addPlugin(my_plugin)
+                    .then(() => {
+                        expect(podsjson_mock.getLibrary.calls.count()).toEqual(3);
+                        compareListWithoutOrder(podsjson_mock.getLibrary.calls.allArgs(), [
+                            ['AFNetworking'],
+                            ['Eureka'],
+                            ['HogeLib']
+                        ]);
+                        expect(podsjson_mock.setJsonLibrary.calls.count()).toEqual(3);
+                        compareListWithoutOrder(podsjson_mock.setJsonLibrary.calls.allArgs(), [
+                            ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
+                            ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
+                            ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
+                        ]);
+                        expect(podfile_mock.addSpec.calls.count()).toEqual(3);
+                        compareListWithoutOrder(podfile_mock.addSpec.calls.allArgs(), [
+                            ['AFNetworking', { name: 'AFNetworking', spec: '~> 3.2', count: 1 }],
+                            ['Eureka', { name: 'Eureka', spec: '4.0', 'swift-version': '4.1', count: 1 }],
+                            ['HogeLib', { name: 'HogeLib', git: 'https://github.com/hoge/HogewLib.git', branch: 'develop', count: 1 }]
+                        ]);
+                    }));
+                it('should increment count in libraries if already exists', () => {
+                    podsjson_mock.getLibrary.and.callFake(library => {
                         if (library === 'AFNetworking') {
                             return { name: 'AFNetworking', spec: '~> 3.2', count: 1 };
                         }
                         return null;
                     });
                     return api.addPlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getLibrary.calls.count()).toEqual(3);
                             compareListWithoutOrder(podsjson_mock.getLibrary.calls.allArgs(), [
                                 ['AFNetworking'],
@@ -292,7 +278,7 @@ describe('Platform Api', function () {
                         });
                 });
             });
-            describe('with frameworks of `podspec` type', function () {
+            describe('with frameworks of `podspec` type', () => {
                 let podsjson_mock;
                 let podfile_mock;
                 const my_pod_json = {
@@ -300,59 +286,53 @@ describe('Platform Api', function () {
                     src: 'podsource!',
                     spec: 'podspec!'
                 };
-                beforeEach(function () {
+                beforeEach(() => {
                     podsjson_mock = jasmine.createSpyObj('podsjson mock', ['getLibrary', 'incrementLibrary', 'write', 'setJsonLibrary']);
                     podfile_mock = jasmine.createSpyObj('podfile mock', ['isDirty', 'addSpec', 'write', 'install']);
                     spyOn(my_plugin, 'getFrameworks').and.returnValue([my_pod_json]);
-                    PodsJson_mod.PodsJson.and.callFake(function () {
-                        return podsjson_mock;
-                    });
-                    Podfile_mod.Podfile.and.callFake(function () {
-                        return podfile_mock;
-                    });
+                    PodsJson_mod.PodsJson.and.callFake(() => podsjson_mock);
+                    Podfile_mod.Podfile.and.callFake(() => podfile_mock);
                 });
                 // TODO: a little help with clearly labeling / describing the tests below? :(
-                it('should warn if Pods JSON contains name/src but differs in spec', function () {
+                it('should warn if Pods JSON contains name/src but differs in spec', () => {
                     podsjson_mock.getLibrary.and.returnValue({
                         spec: 'something different from ' + my_pod_json.spec
                     });
                     spyOn(events, 'emit');
                     return api.addPlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(events.emit).toHaveBeenCalledWith('warn', jasmine.stringMatching(/which conflicts with another plugin/g));
                         });
                 });
-                it('should increment Pods JSON file if pod name/src already exists in file', function () {
+                it('should increment Pods JSON file if pod name/src already exists in file', () => {
                     podsjson_mock.getLibrary.and.returnValue({
                         spec: my_pod_json.spec
                     });
                     return api.addPlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.incrementLibrary).toHaveBeenCalledWith('podsource!');
                         });
                 });
-                it('on a new framework/pod name/src/key, it should add a new json to podsjson and add a new spec to podfile', function () {
-                    return api.addPlugin(my_plugin)
-                        .then(function () {
-                            expect(podsjson_mock.setJsonLibrary).toHaveBeenCalledWith(my_pod_json.src, jasmine.any(Object));
-                            expect(podfile_mock.addSpec).toHaveBeenCalledWith(my_pod_json.src, my_pod_json.spec);
-                        });
-                });
-                it('should write out podfile and install if podfile was changed', function () {
+                it('on a new framework/pod name/src/key, it should add a new json to podsjson and add a new spec to podfile', () => api.addPlugin(my_plugin)
+                    .then(() => {
+                        expect(podsjson_mock.setJsonLibrary).toHaveBeenCalledWith(my_pod_json.src, jasmine.any(Object));
+                        expect(podfile_mock.addSpec).toHaveBeenCalledWith(my_pod_json.src, my_pod_json.spec);
+                    }));
+                it('should write out podfile and install if podfile was changed', () => {
                     podfile_mock.isDirty.and.returnValue(true);
                     podfile_mock.install.and.returnValue({ then: function () { } });
                     return api.addPlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podfile_mock.write).toHaveBeenCalled();
                             expect(podfile_mock.install).toHaveBeenCalled();
                         });
                 });
-                it('if two frameworks with the same name are added, should honour the spec of the first-installed plugin', function () {
+                it('if two frameworks with the same name are added, should honour the spec of the first-installed plugin', () => {
                     podsjson_mock.getLibrary.and.returnValue({
                         spec: 'something different from ' + my_pod_json.spec
                     });
                     return api.addPlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             // Increment will non-destructively set the spec to keep it as it was...
                             expect(podsjson_mock.incrementLibrary).toHaveBeenCalledWith(my_pod_json.src);
                             // ...whereas setJson would overwrite it completely.
@@ -361,20 +341,20 @@ describe('Platform Api', function () {
                 });
             });
         });
-        describe('removePlugin', function () {
+        describe('removePlugin', () => {
             const my_plugin = {
                 getHeaderFiles: function () { return []; },
                 getFrameworks: function () {},
                 getPodSpecs: function () { return []; }
             };
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(PluginManager, 'get').and.returnValue({
                     removePlugin: function () { return Q(); }
                 });
                 spyOn(Podfile_mod, 'Podfile');
                 spyOn(PodsJson_mod, 'PodsJson');
             });
-            describe('removing pods since the plugin contained <podspecs>', function () {
+            describe('removing pods since the plugin contained <podspecs>', () => {
                 let podsjson_mock;
                 let podfile_mock;
                 const my_pod_json = {
@@ -403,24 +383,20 @@ describe('Platform Api', function () {
                         }
                     }
                 };
-                beforeEach(function () {
+                beforeEach(() => {
                     podsjson_mock = jasmine.createSpyObj('podsjson mock', ['getLibrary', 'getSource', 'getDeclaration',
                         'decrementLibrary', 'decrementSource', 'decrementDeclaration', 'write',
                         'setJsonLibrary', 'setJsonSource', 'setJsonDeclaration']);
                     podfile_mock = jasmine.createSpyObj('podfile mock', ['isDirty', 'removeSpec', 'removeSource', 'removeDeclaration', 'write', 'install']);
                     spyOn(my_plugin, 'getFrameworks').and.returnValue([]);
                     spyOn(my_plugin, 'getPodSpecs').and.returnValue([my_pod_json]);
-                    PodsJson_mod.PodsJson.and.callFake(function () {
-                        return podsjson_mock;
-                    });
-                    Podfile_mod.Podfile.and.callFake(function () {
-                        return podfile_mock;
-                    });
+                    PodsJson_mod.PodsJson.and.callFake(() => podsjson_mock);
+                    Podfile_mod.Podfile.and.callFake(() => podfile_mock);
                 });
-                it('on a last declaration, it should remove a json from declarations', function () {
+                it('on a last declaration, it should remove a json from declarations', () => {
                     const json1 = { declaration: 'use_frameworks!', count: 1 };
                     const json2 = { declaration: 'inhibit_all_warnings!', count: 1 };
-                    podsjson_mock.getDeclaration.and.callFake(function (declaration) {
+                    podsjson_mock.getDeclaration.and.callFake(declaration => {
                         if (declaration === 'use_frameworks!') {
                             return json1;
                         } else if (declaration === 'inhibit_all_warnings!') {
@@ -428,7 +404,7 @@ describe('Platform Api', function () {
                         }
                         return null;
                     });
-                    podsjson_mock.decrementDeclaration.and.callFake(function (declaration) {
+                    podsjson_mock.decrementDeclaration.and.callFake(declaration => {
                         if (declaration === 'use_frameworks!') {
                             json1.count--;
                         } else if (declaration === 'inhibit_all_warnings!') {
@@ -436,7 +412,7 @@ describe('Platform Api', function () {
                         }
                     });
                     return api.removePlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getDeclaration.calls.count()).toEqual(2);
                             compareListWithoutOrder(podsjson_mock.getDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
                             expect(podsjson_mock.decrementDeclaration.calls.count()).toEqual(2);
@@ -445,10 +421,10 @@ describe('Platform Api', function () {
                             compareListWithoutOrder(podfile_mock.removeDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
                         });
                 });
-                it('should decrement count in declarations and does not remove if count > 1', function () {
+                it('should decrement count in declarations and does not remove if count > 1', () => {
                     const json1 = { declaration: 'use_frameworks!', count: 2 };
                     const json2 = { declaration: 'inhibit_all_warnings!', count: 1 };
-                    podsjson_mock.getDeclaration.and.callFake(function (declaration) {
+                    podsjson_mock.getDeclaration.and.callFake(declaration => {
                         if (declaration === 'use_frameworks!') {
                             return json1;
                         } else if (declaration === 'inhibit_all_warnings!') {
@@ -456,7 +432,7 @@ describe('Platform Api', function () {
                         }
                         return null;
                     });
-                    podsjson_mock.decrementDeclaration.and.callFake(function (declaration) {
+                    podsjson_mock.decrementDeclaration.and.callFake(declaration => {
                         if (declaration === 'use_frameworks!') {
                             json1.count--;
                         } else if (declaration === 'inhibit_all_warnings!') {
@@ -464,7 +440,7 @@ describe('Platform Api', function () {
                         }
                     });
                     return api.removePlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getDeclaration.calls.count()).toEqual(2);
                             compareListWithoutOrder(podsjson_mock.getDeclaration.calls.allArgs(), [['use_frameworks!'], ['inhibit_all_warnings!']]);
                             expect(podsjson_mock.decrementDeclaration.calls.count()).toEqual(2);
@@ -473,10 +449,10 @@ describe('Platform Api', function () {
                             compareListWithoutOrder(podfile_mock.removeDeclaration.calls.allArgs(), [['inhibit_all_warnings!']]);
                         });
                 });
-                it('on a last source, it should remove a json from sources', function () {
+                it('on a last source, it should remove a json from sources', () => {
                     const json1 = { source: 'https://github.com/sample/SampleSpecs.git', count: 1 };
                     const json2 = { source: 'https://github.com/CocoaPods/Specs.git', count: 1 };
-                    podsjson_mock.getSource.and.callFake(function (source) {
+                    podsjson_mock.getSource.and.callFake(source => {
                         if (source === 'https://github.com/sample/SampleSpecs.git') {
                             return json1;
                         } else if (source === 'https://github.com/CocoaPods/Specs.git') {
@@ -484,7 +460,7 @@ describe('Platform Api', function () {
                         }
                         return null;
                     });
-                    podsjson_mock.decrementSource.and.callFake(function (source) {
+                    podsjson_mock.decrementSource.and.callFake(source => {
                         if (source === 'https://github.com/sample/SampleSpecs.git') {
                             json1.count--;
                         } else if (source === 'https://github.com/CocoaPods/Specs.git') {
@@ -492,7 +468,7 @@ describe('Platform Api', function () {
                         }
                     });
                     return api.removePlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getSource.calls.count()).toEqual(2);
                             compareListWithoutOrder(podsjson_mock.getSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
                             expect(podsjson_mock.decrementSource.calls.count()).toEqual(2);
@@ -501,10 +477,10 @@ describe('Platform Api', function () {
                             compareListWithoutOrder(podfile_mock.removeSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
                         });
                 });
-                it('should decrement count in sources and does not remove if count > 1', function () {
+                it('should decrement count in sources and does not remove if count > 1', () => {
                     const json1 = { source: 'https://github.com/sample/SampleSpecs.git', count: 2 };
                     const json2 = { source: 'https://github.com/CocoaPods/Specs.git', count: 1 };
-                    podsjson_mock.getSource.and.callFake(function (source) {
+                    podsjson_mock.getSource.and.callFake(source => {
                         if (source === 'https://github.com/sample/SampleSpecs.git') {
                             return json1;
                         } else if (source === 'https://github.com/CocoaPods/Specs.git') {
@@ -512,7 +488,7 @@ describe('Platform Api', function () {
                         }
                         return null;
                     });
-                    podsjson_mock.decrementSource.and.callFake(function (source) {
+                    podsjson_mock.decrementSource.and.callFake(source => {
                         if (source === 'https://github.com/sample/SampleSpecs.git') {
                             json1.count--;
                         } else if (source === 'https://github.com/CocoaPods/Specs.git') {
@@ -520,7 +496,7 @@ describe('Platform Api', function () {
                         }
                     });
                     return api.removePlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getSource.calls.count()).toEqual(2);
                             compareListWithoutOrder(podsjson_mock.getSource.calls.allArgs(), [['https://github.com/sample/SampleSpecs.git'], ['https://github.com/CocoaPods/Specs.git']]);
                             expect(podsjson_mock.decrementSource.calls.count()).toEqual(2);
@@ -529,11 +505,11 @@ describe('Platform Api', function () {
                             compareListWithoutOrder(podfile_mock.removeSource.calls.allArgs(), [['https://github.com/CocoaPods/Specs.git']]);
                         });
                 });
-                it('on a last library, it should remove a json from libraries', function () {
+                it('on a last library, it should remove a json from libraries', () => {
                     const json1 = Object.assign({}, my_pod_json.libraries['AFNetworking'], { count: 1 });
                     const json2 = Object.assign({}, my_pod_json.libraries['Eureka'], { count: 1 });
                     const json3 = Object.assign({}, my_pod_json.libraries['HogeLib'], { count: 1 });
-                    podsjson_mock.getLibrary.and.callFake(function (name) {
+                    podsjson_mock.getLibrary.and.callFake(name => {
                         if (name === json1.name) {
                             return json1;
                         } else if (name === json2.name) {
@@ -543,7 +519,7 @@ describe('Platform Api', function () {
                         }
                         return null;
                     });
-                    podsjson_mock.decrementLibrary.and.callFake(function (name) {
+                    podsjson_mock.decrementLibrary.and.callFake(name => {
                         if (name === json1.name) {
                             json1.count--;
                         } else if (name === json2.name) {
@@ -553,7 +529,7 @@ describe('Platform Api', function () {
                         }
                     });
                     return api.removePlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getLibrary.calls.count()).toEqual(3);
                             compareListWithoutOrder(podsjson_mock.getLibrary.calls.allArgs(), [[json1.name], [json2.name], [json3.name]]);
                             expect(podsjson_mock.decrementLibrary.calls.count()).toEqual(3);
@@ -562,11 +538,11 @@ describe('Platform Api', function () {
                             compareListWithoutOrder(podfile_mock.removeSpec.calls.allArgs(), [[json1.name], [json2.name], [json3.name]]);
                         });
                 });
-                it('should decrement count in libraries and does not remove if count > 1', function () {
+                it('should decrement count in libraries and does not remove if count > 1', () => {
                     const json1 = Object.assign({}, my_pod_json.libraries['AFNetworking'], { count: 2 });
                     const json2 = Object.assign({}, my_pod_json.libraries['Eureka'], { count: 1 });
                     const json3 = Object.assign({}, my_pod_json.libraries['HogeLib'], { count: 1 });
-                    podsjson_mock.getLibrary.and.callFake(function (name) {
+                    podsjson_mock.getLibrary.and.callFake(name => {
                         if (name === json1.name) {
                             return json1;
                         } else if (name === json2.name) {
@@ -576,7 +552,7 @@ describe('Platform Api', function () {
                         }
                         return null;
                     });
-                    podsjson_mock.decrementLibrary.and.callFake(function (name) {
+                    podsjson_mock.decrementLibrary.and.callFake(name => {
                         if (name === json1.name) {
                             json1.count--;
                         } else if (name === json2.name) {
@@ -586,7 +562,7 @@ describe('Platform Api', function () {
                         }
                     });
                     return api.removePlugin(my_plugin)
-                        .then(function () {
+                        .then(() => {
                             expect(podsjson_mock.getLibrary.calls.count()).toEqual(3);
                             compareListWithoutOrder(podsjson_mock.getLibrary.calls.allArgs(), [[json1.name], [json2.name], [json3.name]]);
                             expect(podsjson_mock.decrementLibrary.calls.count()).toEqual(3);

--- a/tests/spec/unit/BridgingHeader.spec.js
+++ b/tests/spec/unit/BridgingHeader.spec.js
@@ -23,28 +23,28 @@ const path = require('path');
 const BridgingHeader = require(path.resolve(path.join(__dirname, '..', '..', '..', 'bin', 'templates', 'scripts', 'cordova', 'lib', 'BridgingHeader.js'))).BridgingHeader;
 const fixtureBridgingHeader = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'test-Bridging-Header.h'), 'utf-8');
 
-describe('unit tests for BridgingHeader module', function () {
+describe('unit tests for BridgingHeader module', () => {
     let existsSyncSpy;
     let readFileSyncSpy;
     let writeFileSyncSpy;
     const dummy_path = 'dummy_path';
     const dummy_plugin = { id: 'dummy_plugin', header_path: 'dummy_header_path' };
     const dummy_plugin2 = { id: 'dummy_plugin2', header_path: 'dummy_header_path2' };
-    const headerImportText = function (header_path) { return '#import "' + header_path + '"'; };
+    const headerImportText = header_path => '#import "' + header_path + '"';
 
-    beforeEach(function () {
+    beforeEach(() => {
         existsSyncSpy = spyOn(fs, 'existsSync');
         readFileSyncSpy = spyOn(fs, 'readFileSync');
         writeFileSyncSpy = spyOn(fs, 'writeFileSync');
     });
-    it('Test#001 : should error if BridgingHeader file does not exist', function () {
+    it('Test#001 : should error if BridgingHeader file does not exist', () => {
         existsSyncSpy.and.returnValue(false);
-        expect(function () {
+        expect(() => {
             const _ = new BridgingHeader(fixtureBridgingHeader);
             expect(_).not.toEqual(null); // To avoid ESLINT error "Do not use 'new' for side effects"
         }).toThrow();
     });
-    it('Test#002 : load BridgingHeader file', function () {
+    it('Test#002 : load BridgingHeader file', () => {
         existsSyncSpy.and.returnValue(true);
         readFileSyncSpy.and.returnValue(fixtureBridgingHeader);
 
@@ -52,15 +52,13 @@ describe('unit tests for BridgingHeader module', function () {
         expect(bridgingHeader.path).toEqual(dummy_path);
         expect(bridgingHeader).not.toEqual(null);
     });
-    it('Test#003 : add and remove a BridgingHeader', function () {
+    it('Test#003 : add and remove a BridgingHeader', () => {
         let result_json = null;
         let text_list = null;
         const bridgingHeaderFileContent = fixtureBridgingHeader;
         existsSyncSpy.and.returnValue(true);
-        readFileSyncSpy.and.callFake(function (read_path, charset) {
-            return bridgingHeaderFileContent;
-        });
-        writeFileSyncSpy.and.callFake(function (write_path, text, charset) {
+        readFileSyncSpy.and.callFake((read_path, charset) => bridgingHeaderFileContent);
+        writeFileSyncSpy.and.callFake((write_path, text, charset) => {
             result_json = { write_path: write_path, text: text, charset: charset };
         });
 
@@ -72,7 +70,7 @@ describe('unit tests for BridgingHeader module', function () {
         expect(result_json.text).not.toEqual(null);
         expect(result_json.charset).toEqual('utf8');
         text_list = result_json.text.split('\n');
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin.header_path); }).length).toEqual(1);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin.header_path)).length).toEqual(1);
 
         bridgingHeader = new BridgingHeader(dummy_path);
         bridgingHeader.removeHeader(dummy_plugin.id, dummy_plugin.header_path);
@@ -82,17 +80,15 @@ describe('unit tests for BridgingHeader module', function () {
         expect(result_json.text).not.toEqual(null);
         expect(result_json.charset).toEqual('utf8');
         text_list = result_json.text.split('\n');
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin.header_path); }).length).toEqual(0);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin.header_path)).length).toEqual(0);
     });
-    it('Test#004 : add and remove two BridgingHeaders', function () {
+    it('Test#004 : add and remove two BridgingHeaders', () => {
         let result_json = null;
         let text_list = null;
         let bridgingHeaderFileContent = fixtureBridgingHeader;
         existsSyncSpy.and.returnValue(true);
-        readFileSyncSpy.and.callFake(function (read_path, charset) {
-            return bridgingHeaderFileContent;
-        });
-        writeFileSyncSpy.and.callFake(function (write_path, text, charset) {
+        readFileSyncSpy.and.callFake((read_path, charset) => bridgingHeaderFileContent);
+        writeFileSyncSpy.and.callFake((write_path, text, charset) => {
             bridgingHeaderFileContent = text;
             result_json = { write_path: write_path, text: text, charset: charset };
         });
@@ -106,23 +102,23 @@ describe('unit tests for BridgingHeader module', function () {
         bridgingHeader.write();
 
         text_list = result_json.text.split('\n');
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin.header_path); }).length).toEqual(1);
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin2.header_path); }).length).toEqual(1);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin.header_path)).length).toEqual(1);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin2.header_path)).length).toEqual(1);
 
         bridgingHeader = new BridgingHeader(dummy_path);
         bridgingHeader.removeHeader(dummy_plugin.id, dummy_plugin.header_path);
         bridgingHeader.write();
 
         text_list = result_json.text.split('\n');
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin.header_path); }).length).toEqual(0);
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin2.header_path); }).length).toEqual(1);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin.header_path)).length).toEqual(0);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin2.header_path)).length).toEqual(1);
 
         bridgingHeader = new BridgingHeader(dummy_path);
         bridgingHeader.removeHeader(dummy_plugin2.id, dummy_plugin2.header_path);
         bridgingHeader.write();
 
         text_list = result_json.text.split('\n');
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin.header_path); }).length).toEqual(0);
-        expect(text_list.filter(function (line) { return line === headerImportText(dummy_plugin2.header_path); }).length).toEqual(0);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin.header_path)).length).toEqual(0);
+        expect(text_list.filter(line => line === headerImportText(dummy_plugin2.header_path)).length).toEqual(0);
     });
 });

--- a/tests/spec/unit/Plugman/common.spec.js
+++ b/tests/spec/unit/Plugman/common.spec.js
@@ -37,24 +37,24 @@ const copyFile = common.__get__('copyFile');
 const copyNewFile = common.__get__('copyNewFile');
 const removeFileAndParents = common.__get__('removeFileAndParents');
 
-describe('common handler routines', function () {
-    describe('copyFile', function () {
-        it('Test 001 : should throw if source path not found', function () {
+describe('common handler routines', () => {
+    describe('copyFile', () => {
+        it('Test 001 : should throw if source path not found', () => {
             shell.rm('-rf', test_dir);
-            expect(function () { copyFile(test_dir, src, project_dir, dest); })
+            expect(() => { copyFile(test_dir, src, project_dir, dest); })
                 .toThrow(new Error('"' + src + '" not found!'));
         });
 
-        it('Test 002 : should throw if src not in plugin directory', function () {
+        it('Test 002 : should throw if src not in plugin directory', () => {
             shell.mkdir('-p', project_dir);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');
             const outside_file = '../non_plugin_file';
-            expect(function () { copyFile(test_dir, outside_file, project_dir, dest); })
+            expect(() => { copyFile(test_dir, outside_file, project_dir, dest); })
                 .toThrow(new Error('File "' + path.resolve(test_dir, outside_file) + '" is located outside the plugin directory "' + test_dir + '"'));
             shell.rm('-rf', test_dir);
         });
 
-        it('Test 003 : should allow symlink src, if inside plugin', function () {
+        it('Test 003 : should allow symlink src, if inside plugin', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
 
@@ -67,7 +67,7 @@ describe('common handler routines', function () {
             shell.rm('-rf', project_dir);
         });
 
-        it('Test 004 : should throw if symlink is linked to a file outside the plugin', function () {
+        it('Test 004 : should throw if symlink is linked to a file outside the plugin', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');
 
@@ -76,20 +76,20 @@ describe('common handler routines', function () {
                 return;
             }
 
-            expect(function () { copyFile(test_dir, symlink_file, project_dir, dest); })
+            expect(() => { copyFile(test_dir, symlink_file, project_dir, dest); })
                 .toThrow(new Error('File "' + path.resolve(test_dir, symlink_file) + '" is located outside the plugin directory "' + test_dir + '"'));
             shell.rm('-rf', project_dir);
         });
 
-        it('Test 005 : should throw if dest is outside the project directory', function () {
+        it('Test 005 : should throw if dest is outside the project directory', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
-            expect(function () { copyFile(test_dir, srcFile, project_dir, non_plugin_file); })
+            expect(() => { copyFile(test_dir, srcFile, project_dir, non_plugin_file); })
                 .toThrow(new Error('Destination "' + path.resolve(project_dir, non_plugin_file) + '" for source file "' + path.resolve(test_dir, srcFile) + '" is located outside the project'));
             shell.rm('-rf', project_dir);
         });
 
-        it('Test 006 : should call mkdir -p on target path', function () {
+        it('Test 006 : should call mkdir -p on target path', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
 
@@ -103,7 +103,7 @@ describe('common handler routines', function () {
             shell.rm('-rf', project_dir);
         });
 
-        it('Test 007 : should call cp source/dest paths', function () {
+        it('Test 007 : should call cp source/dest paths', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
 
@@ -119,17 +119,17 @@ describe('common handler routines', function () {
         });
     });
 
-    describe('copyNewFile', function () {
-        it('Test 008 : should throw if target path exists', function () {
+    describe('copyNewFile', () => {
+        it('Test 008 : should throw if target path exists', () => {
             shell.mkdir('-p', dest);
-            expect(function () { copyNewFile(test_dir, src, project_dir, dest); })
+            expect(() => { copyNewFile(test_dir, src, project_dir, dest); })
                 .toThrow(new Error('"' + dest + '" already exists!'));
             shell.rm('-rf', dest);
         });
     });
 
-    describe('deleteJava', function () {
-        it('Test 009 : should call fs.unlinkSync on the provided paths', function () {
+    describe('deleteJava', () => {
+        it('Test 009 : should call fs.unlinkSync on the provided paths', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
 
@@ -141,7 +141,7 @@ describe('common handler routines', function () {
             shell.rm('-rf', srcDirTree);
         });
 
-        it('Test 010 : should delete empty directories after removing source code in path hierarchy', function () {
+        it('Test 010 : should delete empty directories after removing source code in path hierarchy', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
 
@@ -153,7 +153,7 @@ describe('common handler routines', function () {
             shell.rm('-rf', srcDirTree);
         });
 
-        it('Test 011 : should delete the top-level src directory if all plugins added were removed', function () {
+        it('Test 011 : should delete the top-level src directory if all plugins added were removed', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
 

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -42,15 +42,15 @@ const dummy_id = dummyPluginInfo.id;
 const valid_source = dummyPluginInfo.getSourceFiles('ios');
 const valid_headers = dummyPluginInfo.getHeaderFiles('ios');
 const valid_resources = dummyPluginInfo.getResourceFiles('ios');
-const valid_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function (f) { return f.custom; });
-const valid_embeddable_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function (f) { return f.custom && f.embed; });
-const valid_weak_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function (f) { return !(f.custom) && f.weak; });
+const valid_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(f => f.custom);
+const valid_embeddable_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(f => f.custom && f.embed);
+const valid_weak_frameworks = dummyPluginInfo.getFrameworks('ios').filter(f => !(f.custom) && f.weak);
 
 const faultyPluginInfo = new PluginInfo(faultyplugin);
 const invalid_source = faultyPluginInfo.getSourceFiles('ios');
 const invalid_headers = faultyPluginInfo.getHeaderFiles('ios');
 const invalid_resources = faultyPluginInfo.getResourceFiles('ios');
-const invalid_custom_frameworks = faultyPluginInfo.getFrameworks('ios').filter(function (f) { return f.custom; });
+const invalid_custom_frameworks = faultyPluginInfo.getFrameworks('ios').filter(f => f.custom);
 
 const weblessPluginInfo = new PluginInfo(weblessplugin);
 
@@ -64,10 +64,10 @@ function slashJoin () {
     return Array.prototype.join.call(arguments, '/');
 }
 
-describe('ios plugin handler', function () {
+describe('ios plugin handler', () => {
     let dummyProject;
 
-    beforeEach(function () {
+    beforeEach(() => {
         shell.cp('-rf', iosProject, temp);
         projectFile.purgeProjectFileCache(temp);
 
@@ -77,59 +77,59 @@ describe('ios plugin handler', function () {
         });
     });
 
-    afterEach(function () {
+    afterEach(() => {
         shell.rm('-rf', temp);
     });
 
-    describe('installation', function () {
-        describe('of <source-file> elements', function () {
+    describe('installation', () => {
+        describe('of <source-file> elements', () => {
             const install = pluginHandlers.getInstaller('source-file');
 
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'addSourceFile');
             });
 
-            it('Test 001 : should throw if source-file src cannot be found', function () {
+            it('Test 001 : should throw if source-file src cannot be found', () => {
                 const source = copyArray(invalid_source);
-                expect(function () {
+                expect(() => {
                     install(source[1], faultyPluginInfo, dummyProject);
                 }).toThrow();
             });
-            it('Test 002 : should throw if source-file target already exists', function () {
+            it('Test 002 : should throw if source-file target already exists', () => {
                 const source = copyArray(valid_source);
                 const target = path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.m');
                 shell.mkdir('-p', path.dirname(target));
                 fs.writeFileSync(target, 'some bs', 'utf-8');
-                expect(function () {
+                expect(() => {
                     install(source[0], dummyPluginInfo, dummyProject);
                 }).toThrow();
             });
-            it('Test 003 : should call into xcodeproj\'s addSourceFile appropriately when element has no target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir === undefined; });
+            it('Test 003 : should call into xcodeproj\'s addSourceFile appropriately when element has no target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir === undefined);
                 install(source[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addSourceFile)
                     .toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.m'), {});
             });
-            it('Test 004 : should call into xcodeproj\'s addSourceFile appropriately when element has a target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 004 : should call into xcodeproj\'s addSourceFile appropriately when element has a target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir !== undefined);
                 install(source[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addSourceFile)
                     .toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'targetDir', 'TargetDirTest.m'), {});
             });
-            it('Test 005 : should cp the file to the right target location when element has no target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir === undefined; });
+            it('Test 005 : should cp the file to the right target location when element has no target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir === undefined);
                 const spy = spyOn(shell, 'cp');
                 install(source[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'DummyPluginCommand.m'), path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.m'));
             });
-            it('Test 006 : should cp the file to the right target location when element has a target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 006 : should cp the file to the right target location when element has a target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir !== undefined);
                 const spy = spyOn(shell, 'cp');
                 install(source[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'TargetDirTest.m'), path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'targetDir', 'TargetDirTest.m'));
             });
-            it('Test 007 : should call into xcodeproj\'s addFramework appropriately when element has framework=true set', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.framework; });
+            it('Test 007 : should call into xcodeproj\'s addFramework appropriately when element has framework=true set', () => {
+                const source = copyArray(valid_source).filter(s => s.framework);
                 spyOn(dummyProject.xcode, 'addFramework');
                 install(source[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addFramework)
@@ -137,90 +137,90 @@ describe('ios plugin handler', function () {
             });
         });
 
-        describe('of <header-file> elements', function () {
+        describe('of <header-file> elements', () => {
             const install = pluginHandlers.getInstaller('header-file');
 
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'addHeaderFile');
             });
 
-            it('Test 008 : should throw if header-file src cannot be found', function () {
+            it('Test 008 : should throw if header-file src cannot be found', () => {
                 const headers = copyArray(invalid_headers);
-                expect(function () {
+                expect(() => {
                     install(headers[1], faultyPluginInfo, dummyProject);
                 }).toThrow();
             });
-            it('Test 009 : should throw if header-file target already exists', function () {
+            it('Test 009 : should throw if header-file target already exists', () => {
                 const headers = copyArray(valid_headers);
                 const target = path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.h');
                 shell.mkdir('-p', path.dirname(target));
                 fs.writeFileSync(target, 'some bs', 'utf-8');
-                expect(function () {
+                expect(() => {
                     install(headers[0], dummyPluginInfo, dummyProject);
                 }).toThrow();
             });
-            it('Test 010 : should call into xcodeproj\'s addHeaderFile appropriately when element has no target-dir', function () {
-                const headers = copyArray(valid_headers).filter(function (s) { return s.targetDir === undefined; });
+            it('Test 010 : should call into xcodeproj\'s addHeaderFile appropriately when element has no target-dir', () => {
+                const headers = copyArray(valid_headers).filter(s => s.targetDir === undefined);
                 install(headers[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addHeaderFile)
                     .toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.h'));
             });
-            it('Test 011 : should call into xcodeproj\'s addHeaderFile appropriately when element a target-dir', function () {
-                const headers = copyArray(valid_headers).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 011 : should call into xcodeproj\'s addHeaderFile appropriately when element a target-dir', () => {
+                const headers = copyArray(valid_headers).filter(s => s.targetDir !== undefined);
                 install(headers[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addHeaderFile)
                     .toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'targetDir', 'TargetDirTest.h'));
             });
-            it('Test 012 : should cp the file to the right target location when element has no target-dir', function () {
-                const headers = copyArray(valid_headers).filter(function (s) { return s.targetDir === undefined; });
+            it('Test 012 : should cp the file to the right target location when element has no target-dir', () => {
+                const headers = copyArray(valid_headers).filter(s => s.targetDir === undefined);
                 const spy = spyOn(shell, 'cp');
                 install(headers[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'DummyPluginCommand.h'), path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.h'));
             });
-            it('Test 013 : should cp the file to the right target location when element has a target-dir', function () {
-                const headers = copyArray(valid_headers).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 013 : should cp the file to the right target location when element has a target-dir', () => {
+                const headers = copyArray(valid_headers).filter(s => s.targetDir !== undefined);
                 const spy = spyOn(shell, 'cp');
                 install(headers[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'TargetDirTest.h'), path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'targetDir', 'TargetDirTest.h'));
             });
         });
 
-        describe('of <resource-file> elements', function () {
+        describe('of <resource-file> elements', () => {
             const install = pluginHandlers.getInstaller('resource-file');
 
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'addResourceFile');
             });
 
-            it('Test 014 : should throw if resource-file src cannot be found', function () {
+            it('Test 014 : should throw if resource-file src cannot be found', () => {
                 const resources = copyArray(invalid_resources);
-                expect(function () {
+                expect(() => {
                     install(resources[0], faultyPluginInfo, dummyProject);
                 }).toThrow(new Error('Cannot find resource file "' + path.resolve(faultyplugin, 'src/ios/IDontExist.bundle') + '" for plugin ' + faultyPluginInfo.id + ' in iOS platform'));
             });
-            it('Test 015 : should throw if resource-file target already exists', function () {
+            it('Test 015 : should throw if resource-file target already exists', () => {
                 const resources = copyArray(valid_resources);
                 const target = path.join(temp, 'SampleApp', 'Resources', 'DummyPlugin.bundle');
                 shell.mkdir('-p', path.dirname(target));
                 fs.writeFileSync(target, 'some bs', 'utf-8');
-                expect(function () {
+                expect(() => {
                     install(resources[0], dummyPluginInfo, dummyProject);
                 }).toThrow(new Error('File already exists at destination "' + target + '" for resource file specified by plugin ' + dummyPluginInfo.id + ' in iOS platform'));
             });
-            it('Test 016 : should call into xcodeproj\'s addResourceFile', function () {
+            it('Test 016 : should call into xcodeproj\'s addResourceFile', () => {
                 const resources = copyArray(valid_resources);
                 install(resources[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addResourceFile)
                     .toHaveBeenCalledWith(path.join('Resources', 'DummyPlugin.bundle'));
             });
-            it('Test 017 : should cp the file to the right target location', function () {
+            it('Test 017 : should cp the file to the right target location', () => {
                 const resources = copyArray(valid_resources);
                 const spy = spyOn(shell, 'cp');
                 install(resources[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'DummyPlugin.bundle'), path.join(temp, 'SampleApp', 'Resources', 'DummyPlugin.bundle'));
             });
 
-            it('Test 018 : should link files to the right target location', function () {
+            it('Test 018 : should link files to the right target location', () => {
                 const resources = copyArray(valid_resources);
                 const spy = spyOn(fs, 'linkSync');
                 install(resources[0], dummyPluginInfo, dummyProject, { link: true });
@@ -230,13 +230,13 @@ describe('ios plugin handler', function () {
             });
         });
 
-        describe('of <framework> elements', function () {
+        describe('of <framework> elements', () => {
             const install = pluginHandlers.getInstaller('framework');
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'addFramework');
             });
 
-            it('Test 019 : should call into xcodeproj\'s addFramework', function () {
+            it('Test 019 : should call into xcodeproj\'s addFramework', () => {
                 let frameworks = copyArray(valid_custom_frameworks);
                 install(frameworks[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addFramework)
@@ -257,22 +257,22 @@ describe('ios plugin handler', function () {
             // * framework with weak attribute
             // * framework that shouldn't be added/removed
 
-            describe('with custom="true" attribute', function () {
-                it('Test 020 : should throw if framework src cannot be found', function () {
+            describe('with custom="true" attribute', () => {
+                it('Test 020 : should throw if framework src cannot be found', () => {
                     const frameworks = copyArray(invalid_custom_frameworks);
-                    expect(function () {
+                    expect(() => {
                         install(frameworks[0], faultyPluginInfo, dummyProject);
                     }).toThrow(new Error('Cannot find framework "' + path.resolve(faultyplugin, 'src/ios/NonExistantCustomFramework.framework') + '" for plugin ' + faultyPluginInfo.id + ' in iOS platform'));
                 });
-                it('Test 021 : should throw if framework target already exists', function () {
+                it('Test 021 : should throw if framework target already exists', () => {
                     const frameworks = copyArray(valid_custom_frameworks);
                     const target = path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework');
                     shell.mkdir('-p', target);
-                    expect(function () {
+                    expect(() => {
                         install(frameworks[0], dummyPluginInfo, dummyProject);
                     }).toThrow(new Error('Framework "' + target + '" for plugin ' + dummyPluginInfo.id + ' already exists in iOS platform'));
                 });
-                it('Test 022 : should cp the file to the right target location', function () {
+                it('Test 022 : should cp the file to the right target location', () => {
                     const frameworks = copyArray(valid_custom_frameworks);
                     const spy = spyOn(shell, 'cp');
                     install(frameworks[0], dummyPluginInfo, dummyProject);
@@ -280,7 +280,7 @@ describe('ios plugin handler', function () {
                         path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'));
                 });
 
-                it('Test 023 : should deep symlink files to the right target location', function () {
+                it('Test 023 : should deep symlink files to the right target location', () => {
                     const frameworks = copyArray(valid_custom_frameworks);
                     const spy = spyOn(fs, 'linkSync');
                     install(frameworks[0], dummyPluginInfo, dummyProject, { link: true });
@@ -291,31 +291,31 @@ describe('ios plugin handler', function () {
             });
         });
 
-        describe('of <js-module> elements', function () {
+        describe('of <js-module> elements', () => {
             const jsModule = { src: 'www/dummyplugin.js' };
             const install = pluginHandlers.getInstaller('js-module');
             let wwwDest, platformWwwDest;
 
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(fs, 'writeFileSync');
                 wwwDest = path.resolve(dummyProject.www, 'plugins', dummyPluginInfo.id, jsModule.src);
                 platformWwwDest = path.resolve(dummyProject.platformWww, 'plugins', dummyPluginInfo.id, jsModule.src);
             });
 
-            it('Test 024 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
+            it('Test 024 : should put module to both www and platform_www when options.usePlatformWww flag is specified', () => {
                 install(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(fs.writeFileSync).toHaveBeenCalledWith(wwwDest, jasmine.any(String), 'utf-8');
                 expect(fs.writeFileSync).toHaveBeenCalledWith(platformWwwDest, jasmine.any(String), 'utf-8');
             });
 
-            it('Test 025 : should put module to www only when options.usePlatformWww flag is not specified', function () {
+            it('Test 025 : should put module to www only when options.usePlatformWww flag is not specified', () => {
                 install(jsModule, dummyPluginInfo, dummyProject);
                 expect(fs.writeFileSync).toHaveBeenCalledWith(wwwDest, jasmine.any(String), 'utf-8');
                 expect(fs.writeFileSync).not.toHaveBeenCalledWith(platformWwwDest, jasmine.any(String), 'utf-8');
             });
         });
 
-        describe('of <asset> elements', function () {
+        describe('of <asset> elements', () => {
             const asset = { src: 'www/dummyplugin.js', target: 'foo/dummy.js' };
             const install = pluginHandlers.getInstaller('asset');
             /* eslint-disable no-unused-vars */
@@ -323,33 +323,31 @@ describe('ios plugin handler', function () {
             let platformWwwDest;
             /* eslint-enable no-unused-vars */
 
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(shell, 'cp');
                 wwwDest = path.resolve(dummyProject.www, asset.target);
                 platformWwwDest = path.resolve(dummyProject.platformWww, asset.target);
             });
 
-            it('Test 026 : should put asset to both www and platform_www when options.usePlatformWww flag is specified', function () {
+            it('Test 026 : should put asset to both www and platform_www when options.usePlatformWww flag is specified', () => {
                 install(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(shell.cp).toHaveBeenCalledWith('-f', path.resolve(dummyPluginInfo.dir, asset.src), path.resolve(dummyProject.www, asset.target));
                 expect(shell.cp).toHaveBeenCalledWith('-f', path.resolve(dummyPluginInfo.dir, asset.src), path.resolve(dummyProject.platformWww, asset.target));
             });
 
-            it('Test 027 : should put asset to www only when options.usePlatformWww flag is not specified', function () {
+            it('Test 027 : should put asset to www only when options.usePlatformWww flag is not specified', () => {
                 install(asset, dummyPluginInfo, dummyProject);
                 expect(shell.cp).toHaveBeenCalledWith('-f', path.resolve(dummyPluginInfo.dir, asset.src), path.resolve(dummyProject.www, asset.target));
                 expect(shell.cp).not.toHaveBeenCalledWith(path.resolve(dummyPluginInfo.dir, asset.src), path.resolve(dummyProject.platformWww, asset.target));
             });
         });
 
-        it('Test 028 : of two plugins should apply xcode file changes from both', function () {
+        it('Test 028 : of two plugins should apply xcode file changes from both', () => {
             const api = new Api('ios', temp, new EventEmitter());
 
             return api.addPlugin(dummyPluginInfo)
-                .then(function () {
-                    return api.addPlugin(weblessPluginInfo);
-                })
-                .then(function () {
+                .then(() => api.addPlugin(weblessPluginInfo))
+                .then(() => {
                     const xcode = projectFile.parse({
                         root: temp,
                         pbxproj: path.join(temp, 'SampleApp.xcodeproj/project.pbxproj')
@@ -372,79 +370,79 @@ describe('ios plugin handler', function () {
         });
     });
 
-    describe('uninstallation', function () {
-        describe('of <source-file> elements', function () {
+    describe('uninstallation', () => {
+        describe('of <source-file> elements', () => {
             const uninstall = pluginHandlers.getUninstaller('source-file');
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'removeSourceFile');
                 spyOn(dummyProject.xcode, 'removeFramework');
             });
 
-            it('Test 029 : should call into xcodeproj\'s removeSourceFile appropriately when element has no target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir === undefined; });
+            it('Test 029 : should call into xcodeproj\'s removeSourceFile appropriately when element has no target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir === undefined);
                 uninstall(source[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.removeSourceFile).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.m'));
             });
-            it('Test 030 : should call into xcodeproj\'s removeSourceFile appropriately when element a target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 030 : should call into xcodeproj\'s removeSourceFile appropriately when element a target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir !== undefined);
                 uninstall(source[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.removeSourceFile).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'targetDir', 'TargetDirTest.m'));
             });
-            it('Test 031 : should rm the file from the right target location when element has no target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir === undefined; });
+            it('Test 031 : should rm the file from the right target location when element has no target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir === undefined);
                 const spy = spyOn(shell, 'rm');
                 uninstall(source[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-rf', path.join(temp, 'SampleApp', 'Plugins', dummy_id));
             });
-            it('Test 032 : should rm the file from the right target location when element has a target-dir', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 032 : should rm the file from the right target location when element has a target-dir', () => {
+                const source = copyArray(valid_source).filter(s => s.targetDir !== undefined);
                 const spy = spyOn(shell, 'rm');
                 uninstall(source[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-rf', path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'targetDir'));
             });
-            it('Test 033 : should call into xcodeproj\'s removeFramework appropriately when element framework=true set', function () {
-                const source = copyArray(valid_source).filter(function (s) { return s.framework; });
+            it('Test 033 : should call into xcodeproj\'s removeFramework appropriately when element framework=true set', () => {
+                const source = copyArray(valid_source).filter(s => s.framework);
                 uninstall(source[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.removeFramework).toHaveBeenCalledWith(path.join('SampleApp', 'Plugins', dummy_id, 'SourceWithFramework.m'));
             });
         });
 
-        describe('of <header-file> elements', function () {
+        describe('of <header-file> elements', () => {
             const uninstall = pluginHandlers.getUninstaller('header-file');
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'removeHeaderFile');
             });
 
-            it('Test 034 : should call into xcodeproj\'s removeHeaderFile appropriately when element has no target-dir', function () {
-                const headers = copyArray(valid_headers).filter(function (s) { return s.targetDir === undefined; });
+            it('Test 034 : should call into xcodeproj\'s removeHeaderFile appropriately when element has no target-dir', () => {
+                const headers = copyArray(valid_headers).filter(s => s.targetDir === undefined);
                 uninstall(headers[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.removeHeaderFile).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.h'));
             });
-            it('Test 035 : should call into xcodeproj\'s removeHeaderFile appropriately when element a target-dir', function () {
-                const headers = copyArray(valid_headers).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 035 : should call into xcodeproj\'s removeHeaderFile appropriately when element a target-dir', () => {
+                const headers = copyArray(valid_headers).filter(s => s.targetDir !== undefined);
                 uninstall(headers[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.removeHeaderFile).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'targetDir', 'TargetDirTest.h'));
             });
-            it('Test 036 : should rm the file from the right target location', function () {
-                const headers = copyArray(valid_headers).filter(function (s) { return s.targetDir !== undefined; });
+            it('Test 036 : should rm the file from the right target location', () => {
+                const headers = copyArray(valid_headers).filter(s => s.targetDir !== undefined);
                 const spy = spyOn(shell, 'rm');
                 uninstall(headers[0], dummyPluginInfo, dummyProject);
                 expect(spy).toHaveBeenCalledWith('-rf', path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'targetDir'));
             });
         });
 
-        describe('of <resource-file> elements', function () {
+        describe('of <resource-file> elements', () => {
             const uninstall = pluginHandlers.getUninstaller('resource-file');
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'removeResourceFile');
             });
 
-            it('Test 037 : should call into xcodeproj\'s removeResourceFile', function () {
+            it('Test 037 : should call into xcodeproj\'s removeResourceFile', () => {
                 const resources = copyArray(valid_resources);
                 uninstall(resources[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.removeResourceFile).toHaveBeenCalledWith(path.join('Resources', 'DummyPlugin.bundle'));
             });
-            it('Test 038 : should rm the file from the right target location', function () {
+            it('Test 038 : should rm the file from the right target location', () => {
                 const resources = copyArray(valid_resources);
                 const spy = spyOn(shell, 'rm');
                 uninstall(resources[0], dummyPluginInfo, dummyProject);
@@ -452,15 +450,15 @@ describe('ios plugin handler', function () {
             });
         });
 
-        describe('of <framework> elements', function () {
+        describe('of <framework> elements', () => {
             const uninstall = pluginHandlers.getUninstaller('framework');
-            beforeEach(function () {
+            beforeEach(() => {
                 spyOn(dummyProject.xcode, 'removeFramework');
             });
 
             const frameworkPath = path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework').replace(/\\/g, '/');
 
-            it('Test 039 : should call into xcodeproj\'s removeFramework', function () {
+            it('Test 039 : should call into xcodeproj\'s removeFramework', () => {
                 const frameworks = copyArray(valid_custom_frameworks);
                 uninstall(frameworks[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.removeFramework).toHaveBeenCalledWith(frameworkPath, { customFramework: true });
@@ -470,8 +468,8 @@ describe('ios plugin handler', function () {
             // * framework with weak attribute
             // * framework that shouldn't be added/removed
 
-            describe('with custom="true" attribute', function () {
-                it('Test 040 : should rm the file from the right target location', function () {
+            describe('with custom="true" attribute', () => {
+                it('Test 040 : should rm the file from the right target location', () => {
                     const frameworks = copyArray(valid_custom_frameworks);
                     const spy = spyOn(shell, 'rm');
                     uninstall(frameworks[0], dummyPluginInfo, dummyProject);
@@ -479,12 +477,10 @@ describe('ios plugin handler', function () {
                 });
             });
 
-            describe('without custom="true" attribute ', function () {
-                it('Test 041 : should decrease framework counter after uninstallation', function () {
+            describe('without custom="true" attribute ', () => {
+                it('Test 041 : should decrease framework counter after uninstallation', () => {
                     const install = pluginHandlers.getInstaller('framework');
-                    const dummyNonCustomFrameworks = dummyPluginInfo.getFrameworks('ios').filter(function (f) {
-                        return !f.custom;
-                    });
+                    const dummyNonCustomFrameworks = dummyPluginInfo.getFrameworks('ios').filter(f => !f.custom);
                     const dummyFramework = dummyNonCustomFrameworks[0];
                     install(dummyFramework, dummyPluginInfo, dummyProject);
                     install(dummyFramework, dummyPluginInfo, dummyProject);
@@ -498,62 +494,62 @@ describe('ios plugin handler', function () {
             });
         });
 
-        describe('of <js-module> elements', function () {
+        describe('of <js-module> elements', () => {
             const jsModule = { src: 'www/dummyPlugin.js' };
             const uninstall = pluginHandlers.getUninstaller('js-module');
             let wwwDest, platformWwwDest;
 
-            beforeEach(function () {
+            beforeEach(() => {
                 wwwDest = path.resolve(dummyProject.www, 'plugins', dummyPluginInfo.id, jsModule.src);
                 platformWwwDest = path.resolve(dummyProject.platformWww, 'plugins', dummyPluginInfo.id, jsModule.src);
 
                 spyOn(shell, 'rm');
 
                 const existsSyncOrig = fs.existsSync;
-                spyOn(fs, 'existsSync').and.callFake(function (file) {
+                spyOn(fs, 'existsSync').and.callFake(file => {
                     if ([wwwDest, platformWwwDest].indexOf(file) >= 0) return true;
                     return existsSyncOrig.call(fs, file);
                 });
             });
 
-            it('Test 042 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
+            it('Test 042 : should put module to both www and platform_www when options.usePlatformWww flag is specified', () => {
                 uninstall(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
             });
 
-            it('Test 043 : should put module to www only when options.usePlatformWww flag is not specified', function () {
+            it('Test 043 : should put module to www only when options.usePlatformWww flag is not specified', () => {
                 uninstall(jsModule, dummyPluginInfo, dummyProject);
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
                 expect(shell.rm).not.toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
             });
         });
 
-        describe('of <asset> elements', function () {
+        describe('of <asset> elements', () => {
             const asset = { src: 'www/dummyPlugin.js', target: 'foo/dummy.js' };
             const uninstall = pluginHandlers.getUninstaller('asset');
             let wwwDest, platformWwwDest;
 
-            beforeEach(function () {
+            beforeEach(() => {
                 wwwDest = path.resolve(dummyProject.www, asset.target);
                 platformWwwDest = path.resolve(dummyProject.platformWww, asset.target);
 
                 spyOn(shell, 'rm');
 
                 const existsSyncOrig = fs.existsSync;
-                spyOn(fs, 'existsSync').and.callFake(function (file) {
+                spyOn(fs, 'existsSync').and.callFake(file => {
                     if ([wwwDest, platformWwwDest].indexOf(file) >= 0) return true;
                     return existsSyncOrig.call(fs, file);
                 });
             });
 
-            it('Test 044 : should put module to both www and platform_www when options.usePlatformWww flag is specified', function () {
+            it('Test 044 : should put module to both www and platform_www when options.usePlatformWww flag is specified', () => {
                 uninstall(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);
             });
 
-            it('Test 045 : should put module to www only when options.usePlatformWww flag is not specified', function () {
+            it('Test 045 : should put module to www only when options.usePlatformWww flag is not specified', () => {
                 uninstall(asset, dummyPluginInfo, dummyProject);
                 expect(shell.rm).toHaveBeenCalledWith(jasmine.any(String), wwwDest);
                 expect(shell.rm).not.toHaveBeenCalledWith(jasmine.any(String), platformWwwDest);

--- a/tests/spec/unit/Podfile.spec.js
+++ b/tests/spec/unit/Podfile.spec.js
@@ -29,43 +29,43 @@ const fixturePodXcconfigDebug = path.resolve(__dirname, 'fixtures', PROJECT_NAME
 const fixturePodXcconfigRelease = path.resolve(__dirname, 'fixtures', PROJECT_NAME, 'platforms', 'ios', 'pods-release.xcconfig');
 
 // tests are nested in a describe to ensure clean up happens after all unit tests are run
-describe('unit tests for Podfile module', function () {
+describe('unit tests for Podfile module', () => {
     const podfile = new Podfile(fixturePodfile, PROJECT_NAME);
 
-    describe('tests', function () {
-        it('Test 001 : throws CordovaError when the path filename is not named Podfile', function () {
+    describe('tests', () => {
+        it('Test 001 : throws CordovaError when the path filename is not named Podfile', () => {
             const dummyPath = 'NotAPodfile';
-            expect(function () {
+            expect(() => {
                 new Podfile(dummyPath); /* eslint no-new : 0 */
             }).toThrow(new CordovaError(util.format('Podfile: The file at %s is not `%s`.', dummyPath, Podfile.FILENAME)));
         });
 
-        it('Test 002 : throws CordovaError when no projectName provided when creating a Podfile', function () {
-            expect(function () {
+        it('Test 002 : throws CordovaError when no projectName provided when creating a Podfile', () => {
+            expect(() => {
                 new Podfile(fixturePodfile); /* eslint no-new : 0 */
             }).toThrow(new CordovaError('Podfile: The projectName was not specified in the constructor.'));
         });
 
-        it('Test 003 : throws CordovaError when no pod name provided when adding a spec', function () {
-            expect(function () {
+        it('Test 003 : throws CordovaError when no pod name provided when adding a spec', () => {
+            expect(() => {
                 podfile.addSpec(null);
             }).toThrow(new CordovaError('Podfile addSpec: name is not specified.'));
         });
 
-        it('Test 004 : adds the spec', function () {
+        it('Test 004 : adds the spec', () => {
             expect(podfile.existsSpec('Foo')).toBe(false);
             podfile.addSpec('Foo', '1.0');
             expect(podfile.existsSpec('Foo')).toBe(true);
         });
 
-        it('Test 005 : removes the spec', function () {
+        it('Test 005 : removes the spec', () => {
             podfile.addSpec('Baz', '3.0');
             expect(podfile.existsSpec('Baz')).toBe(true);
             podfile.removeSpec('Baz');
             expect(podfile.existsSpec('Baz')).toBe(false);
         });
 
-        it('Test 006 : clears all specs', function () {
+        it('Test 006 : clears all specs', () => {
             podfile.addSpec('Bar', '2.0');
             podfile.clear();
 
@@ -73,7 +73,7 @@ describe('unit tests for Podfile module', function () {
             expect(podfile.existsSpec('Bar')).toBe(false);
         });
 
-        it('Test 007 : isDirty tests', function () {
+        it('Test 007 : isDirty tests', () => {
             podfile.addSpec('Foo', '1.0');
             expect(podfile.isDirty()).toBe(true);
 
@@ -90,7 +90,7 @@ describe('unit tests for Podfile module', function () {
             expect(podfile.isDirty()).toBe(false);
         });
 
-        it('Test 008 : writes specs to the Podfile', function () {
+        it('Test 008 : writes specs to the Podfile', () => {
             podfile.clear();
 
             podfile.addSpec('Foo', '1.0');
@@ -123,7 +123,7 @@ describe('unit tests for Podfile module', function () {
             expect(newPodfile.getSpec('Bla3').options).toEqual(':configurations => [\'Debug\',\'Release\']');
         });
 
-        it('Test 009 : runs before_install to install xcconfig paths', function () {
+        it('Test 009 : runs before_install to install xcconfig paths', () => {
             podfile.before_install();
 
             // Template tokens in order: project name, project name, debug | release
@@ -141,7 +141,7 @@ describe('unit tests for Podfile module', function () {
             expect(actualReleaseContents).toBe(expectedReleaseContents);
         });
 
-        it('Test 010 : escapes single quotes in project name when writing a Podfile', function () {
+        it('Test 010 : escapes single quotes in project name when writing a Podfile', () => {
             podfile.before_install();
 
             const projectName = 'This project\'s name';
@@ -152,7 +152,7 @@ describe('unit tests for Podfile module', function () {
             expect(actualProjectName).toBe(expectedProjectName);
         });
 
-        it('Test 011 : escapes double single quotes in project name when writing a Podfile', function () {
+        it('Test 011 : escapes double single quotes in project name when writing a Podfile', () => {
             podfile.before_install();
 
             const projectName = 'l\'etat c\'est moi';
@@ -164,7 +164,7 @@ describe('unit tests for Podfile module', function () {
         });
     });
 
-    it('Test 012 : tear down', function () {
+    it('Test 012 : tear down', () => {
         podfile.destroy();
 
         const text = '// DO NOT MODIFY -- auto-generated by Apache Cordova\n';

--- a/tests/spec/unit/PodsJson.spec.js
+++ b/tests/spec/unit/PodsJson.spec.js
@@ -26,24 +26,24 @@ const PodsJson = require(path.resolve(path.join(__dirname, '..', '..', '..', 'bi
 const fixturePodsJson = path.resolve(__dirname, 'fixtures', 'testProj', 'platforms', 'ios', 'pods.json');
 
 // tests are nested in a describe to ensure clean up happens after all unit tests are run
-describe('unit tests for Podfile module', function () {
+describe('unit tests for Podfile module', () => {
     let podsjson = null;
-    beforeEach(function () {
+    beforeEach(() => {
         podsjson = new PodsJson(fixturePodsJson);
     });
-    afterEach(function () {
+    afterEach(() => {
         podsjson.destroy();
     });
 
-    describe('tests', function () {
-        it('Test 001 : throws CordovaError when the path filename is not named pods.json', function () {
+    describe('tests', () => {
+        it('Test 001 : throws CordovaError when the path filename is not named pods.json', () => {
             const dummyPath = 'NotPodsJson';
-            expect(function () {
+            expect(() => {
                 new PodsJson(dummyPath); /* eslint no-new : 0 */
             }).toThrow(new CordovaError(util.format('PodsJson: The file at %s is not `%s`.', dummyPath, PodsJson.FILENAME)));
         });
 
-        it('Test 002 : setsJson and gets pod test', function () {
+        it('Test 002 : setsJson and gets pod test', () => {
             const val0 = {
                 name: 'Foo',
                 type: 'podspec',
@@ -60,7 +60,7 @@ describe('unit tests for Podfile module', function () {
             expect(val1.count).toEqual(val0.count);
         });
 
-        it('Test 003 : setsJson and remove pod test', function () {
+        it('Test 003 : setsJson and remove pod test', () => {
             const val0 = {
                 name: 'Bar',
                 type: 'podspec',
@@ -81,7 +81,7 @@ describe('unit tests for Podfile module', function () {
             expect(val1).toBeFalsy();
         });
 
-        it('Test 004 : clears all pods', function () {
+        it('Test 004 : clears all pods', () => {
             const val0 = {
                 name: 'Baz',
                 type: 'podspec',
@@ -96,7 +96,7 @@ describe('unit tests for Podfile module', function () {
             expect(podsjson.getLibrary('Bar')).toBeFalsy();
         });
 
-        it('Test 005 : isDirty tests', function () {
+        it('Test 005 : isDirty tests', () => {
             const val0 = {
                 name: 'Foo',
                 type: 'podspec',
@@ -120,7 +120,7 @@ describe('unit tests for Podfile module', function () {
             expect(podsjson.isDirty()).toBe(false);
         });
 
-        it('Test 006 : increment and decrement count test', function () {
+        it('Test 006 : increment and decrement count test', () => {
             const val0 = {
                 name: 'Bla',
                 type: 'podspec',
@@ -148,7 +148,7 @@ describe('unit tests for Podfile module', function () {
             expect(podsjson.getLibrary(val0.name)).toBeFalsy();
         });
 
-        it('Test 007 : writes pods to the pods.json', function () {
+        it('Test 007 : writes pods to the pods.json', () => {
             podsjson.clear();
 
             const vals = {
@@ -183,10 +183,10 @@ describe('unit tests for Podfile module', function () {
             expect(podEqual(podsjson.getLibrary('Baz'), newPodsJson.getLibrary('Baz'))).toBe(true);
         });
 
-        it('Test 008 : setJson, get, increment, decrement, remove and write for Declaration', function () {
+        it('Test 008 : setJson, get, increment, decrement, remove and write for Declaration', () => {
             let result = null;
             const writeFileSyncSpy = spyOn(fs, 'writeFileSync');
-            writeFileSyncSpy.and.callFake(function (filepath, data, encode) {
+            writeFileSyncSpy.and.callFake((filepath, data, encode) => {
                 result = data;
             });
             const json = {
@@ -214,10 +214,10 @@ describe('unit tests for Podfile module', function () {
             expect(JSON.parse(result).declarations[json2.declaration]).toEqual(json2);
         });
 
-        it('Test 009 : setJson, get, increment, decrement, remove and write for Source', function () {
+        it('Test 009 : setJson, get, increment, decrement, remove and write for Source', () => {
             let result = null;
             const writeFileSyncSpy = spyOn(fs, 'writeFileSync');
-            writeFileSyncSpy.and.callFake(function (filepath, data, encode) {
+            writeFileSyncSpy.and.callFake((filepath, data, encode) => {
                 result = data;
             });
             const json = {

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -21,11 +21,11 @@ const path = require('path');
 const rewire = require('rewire');
 const build = rewire('../../../bin/templates/scripts/cordova/lib/build');
 
-describe('build', function () {
+describe('build', () => {
     let emitSpy;
     const testProjectPath = path.join('/test', 'project', 'path');
 
-    beforeEach(function () {
+    beforeEach(() => {
         // Events spy
         emitSpy = jasmine.createSpy('emitSpy');
         build.__set__('events', {
@@ -33,11 +33,11 @@ describe('build', function () {
         });
     });
 
-    describe('getXcodeBuildArgs method', function () {
+    describe('getXcodeBuildArgs method', () => {
         const getXcodeBuildArgs = build.__get__('getXcodeBuildArgs');
         build.__set__('__dirname', path.join('/test', 'dir'));
 
-        it('should generate appropriate args if a single buildFlag is passed in', function () {
+        it('should generate appropriate args if a single buildFlag is passed in', () => {
             const isDevice = true;
             const buildFlags = '';
 
@@ -60,7 +60,7 @@ describe('build', function () {
             expect(args.length).toEqual(13);
         });
 
-        it('should generate appropriate args if buildFlags are passed in', function () {
+        it('should generate appropriate args if buildFlags are passed in', () => {
             const isDevice = true;
             const buildFlags = [
                 '-workspace TestWorkspaceFlag',
@@ -91,7 +91,7 @@ describe('build', function () {
             expect(args.length).toEqual(13);
         });
 
-        it('should generate appropriate args for device', function () {
+        it('should generate appropriate args for device', () => {
             const isDevice = true;
             const args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null);
             expect(args).toEqual([
@@ -112,7 +112,7 @@ describe('build', function () {
             expect(args.length).toEqual(13);
         });
 
-        it('should generate appropriate args for simulator', function () {
+        it('should generate appropriate args for simulator', () => {
             const isDevice = false;
             const args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null, 'iPhone 5s');
             expect(args).toEqual([
@@ -133,7 +133,7 @@ describe('build', function () {
             expect(args.length).toEqual(13);
         });
 
-        it('should add matched flags that are not overriding for device', function () {
+        it('should add matched flags that are not overriding for device', () => {
             const isDevice = true;
             const buildFlags = '-sdk TestSdkFlag';
 
@@ -158,7 +158,7 @@ describe('build', function () {
             expect(args.length).toEqual(15);
         });
 
-        it('should add matched flags that are not overriding for simulator', function () {
+        it('should add matched flags that are not overriding for simulator', () => {
             const isDevice = false;
             const buildFlags = '-archivePath TestArchivePathFlag';
 
@@ -183,7 +183,7 @@ describe('build', function () {
             expect(args.length).toEqual(15);
         });
 
-        it('should generate appropriate args for automatic provisioning', function () {
+        it('should generate appropriate args for automatic provisioning', () => {
             const isDevice = true;
             const args = getXcodeBuildArgs('TestProjectName', testProjectPath, 'TestConfiguration', isDevice, null, null, true);
             expect(args).toEqual([
@@ -206,10 +206,10 @@ describe('build', function () {
         });
     });
 
-    describe('getXcodeArchiveArgs method', function () {
+    describe('getXcodeArchiveArgs method', () => {
         const getXcodeArchiveArgs = build.__get__('getXcodeArchiveArgs');
 
-        it('should generate the appropriate arguments', function () {
+        it('should generate the appropriate arguments', () => {
             const archiveArgs = getXcodeArchiveArgs('TestProjectName', testProjectPath, '/test/output/path', '/test/export/options/path');
             expect(archiveArgs[0]).toEqual('-exportArchive');
             expect(archiveArgs[1]).toEqual('-archivePath');
@@ -221,7 +221,7 @@ describe('build', function () {
             expect(archiveArgs.length).toEqual(7);
         });
 
-        it('should generate the appropriate arguments for automatic provisioning', function () {
+        it('should generate the appropriate arguments for automatic provisioning', () => {
             const archiveArgs = getXcodeArchiveArgs('TestProjectName', testProjectPath, '/test/output/path', '/test/export/options/path', true);
             expect(archiveArgs[0]).toEqual('-exportArchive');
             expect(archiveArgs[1]).toEqual('-archivePath');
@@ -235,80 +235,80 @@ describe('build', function () {
         });
     });
 
-    describe('parseBuildFlag method', function () {
+    describe('parseBuildFlag method', () => {
         const parseBuildFlag = build.__get__('parseBuildFlag');
 
-        it('should detect a workspace change', function () {
+        it('should detect a workspace change', () => {
             const buildFlag = '-workspace MyTestWorkspace';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.workspace).toEqual('MyTestWorkspace');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should detect a scheme change', function () {
+        it('should detect a scheme change', () => {
             const buildFlag = '-scheme MyTestScheme';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.scheme).toEqual('MyTestScheme');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should detect a configuration change', function () {
+        it('should detect a configuration change', () => {
             const buildFlag = '-configuration MyTestConfiguration';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.configuration).toEqual('MyTestConfiguration');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should detect an sdk change', function () {
+        it('should detect an sdk change', () => {
             const buildFlag = '-sdk NotARealSDK';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.sdk).toEqual('NotARealSDK');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should detect a destination change', function () {
+        it('should detect a destination change', () => {
             const buildFlag = '-destination MyTestDestination';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.destination).toEqual('MyTestDestination');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should detect an archivePath change', function () {
+        it('should detect an archivePath change', () => {
             const buildFlag = '-archivePath MyTestArchivePath';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.archivePath).toEqual('MyTestArchivePath');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should detect a configuration_build_dir change', function () {
+        it('should detect a configuration_build_dir change', () => {
             const buildFlag = 'CONFIGURATION_BUILD_DIR=/path/to/fake/config/build/dir';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.configuration_build_dir).toEqual('CONFIGURATION_BUILD_DIR=/path/to/fake/config/build/dir');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should detect a shared_precomps_dir change', function () {
+        it('should detect a shared_precomps_dir change', () => {
             const buildFlag = 'SHARED_PRECOMPS_DIR=/path/to/fake/shared/precomps/dir';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.shared_precomps_dir).toEqual('SHARED_PRECOMPS_DIR=/path/to/fake/shared/precomps/dir');
             expect(args.otherFlags.length).toEqual(0);
         });
-        it('should parse arbitrary build settings', function () {
+        it('should parse arbitrary build settings', () => {
             const buildFlag = 'MY_ARBITRARY_BUILD_SETTING=ValueOfArbitraryBuildSetting';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.otherFlags[0]).toEqual('MY_ARBITRARY_BUILD_SETTING=ValueOfArbitraryBuildSetting');
             expect(args.otherFlags.length).toEqual(1);
         });
-        it('should parse userdefaults', function () {
+        it('should parse userdefaults', () => {
             const buildFlag = '-myuserdefault=TestUserDefaultValue';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
             expect(args.otherFlags[0]).toEqual('-myuserdefault=TestUserDefaultValue');
             expect(args.otherFlags.length).toEqual(1);
         });
-        it('should parse settings with a space', function () {
+        it('should parse settings with a space', () => {
             const buildFlag = '-anotherxcodebuildsetting withASpace';
             const args = { otherFlags: [] };
             parseBuildFlag(buildFlag, args);
@@ -390,11 +390,9 @@ describe('build', function () {
             }];
 
             // This method will require a module that supports the run method.
-            build.__set__('require', () => {
-                return {
-                    run: () => Promise.resolve(mockedEmulators)
-                };
-            });
+            build.__set__('require', () => ({
+                run: () => Promise.resolve(mockedEmulators)
+            }));
 
             const getDefaultSimulatorTarget = build.__get__('getDefaultSimulatorTarget');
 

--- a/tests/spec/unit/lib/check_reqs.spec.js
+++ b/tests/spec/unit/lib/check_reqs.spec.js
@@ -46,10 +46,12 @@ describe('check_reqs', () => {
             );
         });
 
-        it('should throw error because version is not following semver-notated.', () => checkTool('node', 'a.b.c').then(
-            () => fail('Expected promise to be rejected'),
-            err => expect(err).toEqual(new TypeError('Invalid Version: a.b.c'))
-        ));
+        it('should throw error because version is not following semver-notated.', () => {
+            return checkTool('node', 'a.b.c').then(
+                () => fail('Expected promise to be rejected'),
+                err => expect(err).toEqual(new TypeError('Invalid Version: a.b.c'))
+            );
+        });
 
         it('should resolve passing back tool version.', () => {
             return checkTool('node', '1.0.0').then(result => {
@@ -57,10 +59,12 @@ describe('check_reqs', () => {
             });
         });
 
-        it('should reject because tool does not meet minimum requirement.', () => checkTool('node', '1.0.1').then(
-            () => fail('Expected promise to be rejected'),
-            reason => expect(reason).toContain('version 1.0.1 or greater, you have version 1.0.0')
-        ));
+        it('should reject because tool does not meet minimum requirement.', () => {
+            return checkTool('node', '1.0.1').then(
+                () => fail('Expected promise to be rejected'),
+                reason => expect(reason).toContain('version 1.0.1 or greater, you have version 1.0.0')
+            );
+        });
     });
 
     describe('check_cocoapods method', () => {

--- a/tests/spec/unit/lib/check_reqs.spec.js
+++ b/tests/spec/unit/lib/check_reqs.spec.js
@@ -21,7 +21,7 @@ const rewire = require('rewire');
 const shell = require('shelljs');
 const versions = require('../../../../bin/templates/scripts/cordova/lib/versions');
 
-describe('check_reqs', function () {
+describe('check_reqs', () => {
     let checkReqs;
     beforeEach(() => {
         checkReqs = rewire('../../../../bin/templates/scripts/cordova/lib/check_reqs');
@@ -46,25 +46,19 @@ describe('check_reqs', function () {
             );
         });
 
-        it('should throw error because version is not following semver-notated.', () => {
-            return checkTool('node', 'a.b.c').then(
-                () => fail('Expected promise to be rejected'),
-                err => expect(err).toEqual(new TypeError('Invalid Version: a.b.c'))
-            );
-        });
+        it('should throw error because version is not following semver-notated.', () => checkTool('node', 'a.b.c').then(
+            () => fail('Expected promise to be rejected'),
+            err => expect(err).toEqual(new TypeError('Invalid Version: a.b.c'))
+        ));
 
-        it('should resolve passing back tool version.', () => {
-            return checkTool('node', '1.0.0').then(result => {
-                expect(result).toEqual({ version: '1.0.0' });
-            });
-        });
+        it('should resolve passing back tool version.', () => checkTool('node', '1.0.0').then(result => {
+            expect(result).toEqual({ version: '1.0.0' });
+        }));
 
-        it('should reject because tool does not meet minimum requirement.', () => {
-            return checkTool('node', '1.0.1').then(
-                () => fail('Expected promise to be rejected'),
-                reason => expect(reason).toContain('version 1.0.1 or greater, you have version 1.0.0')
-            );
-        });
+        it('should reject because tool does not meet minimum requirement.', () => checkTool('node', '1.0.1').then(
+            () => fail('Expected promise to be rejected'),
+            reason => expect(reason).toContain('version 1.0.1 or greater, you have version 1.0.0')
+        ));
     });
 
     describe('check_cocoapods method', () => {

--- a/tests/spec/unit/lib/check_reqs.spec.js
+++ b/tests/spec/unit/lib/check_reqs.spec.js
@@ -51,9 +51,11 @@ describe('check_reqs', () => {
             err => expect(err).toEqual(new TypeError('Invalid Version: a.b.c'))
         ));
 
-        it('should resolve passing back tool version.', () => checkTool('node', '1.0.0').then(result => {
-            expect(result).toEqual({ version: '1.0.0' });
-        }));
+        it('should resolve passing back tool version.', () => {
+            return checkTool('node', '1.0.0').then(result => {
+                expect(result).toEqual({ version: '1.0.0' });
+            });
+        });
 
         it('should reject because tool does not meet minimum requirement.', () => checkTool('node', '1.0.1').then(
             () => fail('Expected promise to be rejected'),

--- a/tests/spec/unit/lib/list-devices.spec.js
+++ b/tests/spec/unit/lib/list-devices.spec.js
@@ -26,12 +26,14 @@ describe('cordova/lib/list-devices', () => {
             spyOn(Q, 'all').and.returnValue(Q.resolve([]));
             spyOn(Q, 'nfcall');
         });
-        it('should invoke proper system calls to retrieve connected devices', () => list_devices.run()
-            .then(() => {
-                expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPad/g));
-                expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPod/g));
-                expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPhone/g));
-            }));
+        it('should invoke proper system calls to retrieve connected devices', () => {
+            return list_devices.run()
+                .then(() => {
+                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPad/g));
+                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPod/g));
+                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPhone/g));
+                });
+        });
         it('should trim and split standard output and return as array', () => {
             Q.all.and.returnValue(Q.resolve([['   this is\nmy sweet\nstdout\n    ']]));
             return list_devices.run()

--- a/tests/spec/unit/lib/list-devices.spec.js
+++ b/tests/spec/unit/lib/list-devices.spec.js
@@ -20,24 +20,22 @@
 const list_devices = require('../../../../bin/templates/scripts/cordova/lib/list-devices');
 const Q = require('q');
 
-describe('cordova/lib/list-devices', function () {
-    describe('run method', function () {
-        beforeEach(function () {
+describe('cordova/lib/list-devices', () => {
+    describe('run method', () => {
+        beforeEach(() => {
             spyOn(Q, 'all').and.returnValue(Q.resolve([]));
             spyOn(Q, 'nfcall');
         });
-        it('should invoke proper system calls to retrieve connected devices', function () {
-            return list_devices.run()
-                .then(() => {
-                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPad/g));
-                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPod/g));
-                    expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPhone/g));
-                });
-        });
-        it('should trim and split standard output and return as array', function () {
+        it('should invoke proper system calls to retrieve connected devices', () => list_devices.run()
+            .then(() => {
+                expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPad/g));
+                expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPod/g));
+                expect(Q.nfcall).toHaveBeenCalledWith(jasmine.any(Function), jasmine.stringMatching(/ioreg.*iPhone/g));
+            }));
+        it('should trim and split standard output and return as array', () => {
             Q.all.and.returnValue(Q.resolve([['   this is\nmy sweet\nstdout\n    ']]));
             return list_devices.run()
-                .then(function (results) {
+                .then(results => {
                     expect(results).toContain('this is');
                     expect(results).toContain('my sweet');
                     expect(results).toContain('stdout');

--- a/tests/spec/unit/lib/list-emulator-images.spec.js
+++ b/tests/spec/unit/lib/list-emulator-images.spec.js
@@ -25,12 +25,12 @@ if (process.platform === 'darwin') {
     const list_emus = require('../../../../bin/templates/scripts/cordova/lib/list-emulator-images');
     const iossim = require('ios-sim');
 
-    describe('cordova/lib/list-emulator-images', function () {
-        describe('run method', function () {
-            beforeEach(function () {
+    describe('cordova/lib/list-emulator-images', () => {
+        describe('run method', () => {
+            beforeEach(() => {
                 spyOn(iossim, 'getdevicetypes');
             });
-            it('should delegate to the ios-sim getdevicetypes method', function () {
+            it('should delegate to the ios-sim getdevicetypes method', () => {
                 list_emus.run();
                 expect(iossim.getdevicetypes).toHaveBeenCalled();
             });

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -25,33 +25,27 @@ if (process.platform === 'darwin') {
     const run = require('../../../../bin/templates/scripts/cordova/lib/run');
     const Q = require('q');
 
-    describe('cordova/lib/run', function () {
-        describe('--list option', function () {
+    describe('cordova/lib/run', () => {
+        describe('--list option', () => {
             let deferred;
-            beforeEach(function () {
+            beforeEach(() => {
                 deferred = Q.defer();
                 deferred.resolve();
                 spyOn(run, 'listDevices').and.returnValue(deferred.promise);
                 spyOn(run, 'listEmulators').and.returnValue(deferred.promise);
             });
-            it('should delegate to listDevices method if `options.device` specified', function () {
-                return run.run({ list: true, device: true }).then(() => {
-                    expect(run.listDevices).toHaveBeenCalled();
-                    expect(run.listEmulators).not.toHaveBeenCalled();
-                });
-            });
-            it('should delegate to listEmulators method if `options.device` specified', function () {
-                return run.run({ list: true, emulator: true }).then(() => {
-                    expect(run.listDevices).not.toHaveBeenCalled();
-                    expect(run.listEmulators).toHaveBeenCalled();
-                });
-            });
-            it('should delegate to both listEmulators and listDevices methods if neither `options.device` nor `options.emulator` are specified', () => {
-                return run.run({ list: true }).then(() => {
-                    expect(run.listDevices).toHaveBeenCalled();
-                    expect(run.listEmulators).toHaveBeenCalled();
-                });
-            });
+            it('should delegate to listDevices method if `options.device` specified', () => run.run({ list: true, device: true }).then(() => {
+                expect(run.listDevices).toHaveBeenCalled();
+                expect(run.listEmulators).not.toHaveBeenCalled();
+            }));
+            it('should delegate to listEmulators method if `options.device` specified', () => run.run({ list: true, emulator: true }).then(() => {
+                expect(run.listDevices).not.toHaveBeenCalled();
+                expect(run.listEmulators).toHaveBeenCalled();
+            }));
+            it('should delegate to both listEmulators and listDevices methods if neither `options.device` nor `options.emulator` are specified', () => run.run({ list: true }).then(() => {
+                expect(run.listDevices).toHaveBeenCalled();
+                expect(run.listEmulators).toHaveBeenCalled();
+            }));
         });
     });
 }

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -34,18 +34,24 @@ if (process.platform === 'darwin') {
                 spyOn(run, 'listDevices').and.returnValue(deferred.promise);
                 spyOn(run, 'listEmulators').and.returnValue(deferred.promise);
             });
-            it('should delegate to listDevices method if `options.device` specified', () => run.run({ list: true, device: true }).then(() => {
-                expect(run.listDevices).toHaveBeenCalled();
-                expect(run.listEmulators).not.toHaveBeenCalled();
-            }));
-            it('should delegate to listEmulators method if `options.device` specified', () => run.run({ list: true, emulator: true }).then(() => {
-                expect(run.listDevices).not.toHaveBeenCalled();
-                expect(run.listEmulators).toHaveBeenCalled();
-            }));
-            it('should delegate to both listEmulators and listDevices methods if neither `options.device` nor `options.emulator` are specified', () => run.run({ list: true }).then(() => {
-                expect(run.listDevices).toHaveBeenCalled();
-                expect(run.listEmulators).toHaveBeenCalled();
-            }));
+            it('should delegate to listDevices method if `options.device` specified', () => {
+                return run.run({ list: true, device: true }).then(() => {
+                    expect(run.listDevices).toHaveBeenCalled();
+                    expect(run.listEmulators).not.toHaveBeenCalled();
+                });
+            });
+            it('should delegate to listEmulators method if `options.device` specified', () => {
+                return run.run({ list: true, emulator: true }).then(() => {
+                    expect(run.listDevices).not.toHaveBeenCalled();
+                    expect(run.listEmulators).toHaveBeenCalled();
+                });
+            });
+            it('should delegate to both listEmulators and listDevices methods if neither `options.device` nor `options.emulator` are specified', () => {
+                return run.run({ list: true }).then(() => {
+                    expect(run.listDevices).toHaveBeenCalled();
+                    expect(run.listEmulators).toHaveBeenCalled();
+                });
+            });
         });
     });
 }

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -42,9 +42,9 @@ shell.config.silent = true;
 
 const ConfigParser = require('cordova-common').ConfigParser;
 
-describe('prepare', function () {
+describe('prepare', () => {
     let p, Api;
-    beforeEach(function () {
+    beforeEach(() => {
         Api = rewire('../../../bin/templates/scripts/cordova/Api');
 
         shell.mkdir('-p', iosPlatform);
@@ -52,11 +52,11 @@ describe('prepare', function () {
         p = new Api('ios', iosPlatform, new EventEmitter());
     });
 
-    afterEach(function () {
+    afterEach(() => {
         shell.rm('-rf', path.join(__dirname, 'some'));
     });
 
-    describe('launch storyboard feature (CB-9762)', function () {
+    describe('launch storyboard feature (CB-9762)', () => {
         function makeSplashScreenEntry (src, width, height) {
             return {
                 src: src,
@@ -95,50 +95,50 @@ describe('prepare', function () {
             makeSplashScreenEntry('res/splash/ios/Default@3x~iphone~comany.png')
         ];
 
-        describe('#mapLaunchStoryboardContents', function () {
+        describe('#mapLaunchStoryboardContents', () => {
             const mapLaunchStoryboardContents = prepare.__get__('mapLaunchStoryboardContents');
 
-            it('should return an array with no mapped storyboard images', function () {
+            it('should return an array with no mapped storyboard images', () => {
                 const result = mapLaunchStoryboardContents(noLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-map/empty-map'));
             });
 
-            it('should return an array with one mapped storyboard image', function () {
+            it('should return an array with one mapped storyboard image', () => {
                 const result = mapLaunchStoryboardContents(singleLaunchStoryboardImage, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-map/single-2xanyany-map'));
             });
 
-            it('should return an array with one mapped storyboard image, even with legacy images', function () {
+            it('should return an array with one mapped storyboard image, even with legacy images', () => {
                 const result = mapLaunchStoryboardContents(singleLaunchStoryboardImageWithLegacyLaunchImage, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-map/single-2xanyany-map'));
             });
 
-            it('should return an array with several mapped storyboard images', function () {
+            it('should return an array with several mapped storyboard images', () => {
                 const result = mapLaunchStoryboardContents(typicalLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-map/typical-universal-map'));
             });
 
-            it('should return an array with several mapped storyboard images across device classes', function () {
+            it('should return an array with several mapped storyboard images across device classes', () => {
                 const result = mapLaunchStoryboardContents(multiDeviceLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-map/varied-device-map'));
             });
         });
 
-        describe('#mapLaunchStoryboardResources', function () {
+        describe('#mapLaunchStoryboardResources', () => {
             const mapLaunchStoryboardResources = prepare.__get__('mapLaunchStoryboardResources');
 
-            it('should return an empty object with no mapped storyboard images', function () {
+            it('should return an empty object with no mapped storyboard images', () => {
                 const result = mapLaunchStoryboardResources(noLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual({});
             });
 
-            it('should return an object with one mapped storyboard image', function () {
+            it('should return an object with one mapped storyboard image', () => {
                 const result = mapLaunchStoryboardResources(singleLaunchStoryboardImage, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual({
@@ -146,7 +146,7 @@ describe('prepare', function () {
                 });
             });
 
-            it('should return an object with one mapped storyboard image, even with legacy images', function () {
+            it('should return an object with one mapped storyboard image, even with legacy images', () => {
                 const result = mapLaunchStoryboardResources(singleLaunchStoryboardImageWithLegacyLaunchImage, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual({
@@ -154,7 +154,7 @@ describe('prepare', function () {
                 });
             });
 
-            it('should return an object with several mapped storyboard images', function () {
+            it('should return an object with several mapped storyboard images', () => {
                 const result = mapLaunchStoryboardResources(typicalLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual({
@@ -167,7 +167,7 @@ describe('prepare', function () {
                 });
             });
 
-            it('should return an object with several mapped storyboard images across device classes', function () {
+            it('should return an object with several mapped storyboard images across device classes', () => {
                 const result = mapLaunchStoryboardResources(multiDeviceLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual({
@@ -184,45 +184,45 @@ describe('prepare', function () {
             });
         });
 
-        describe('#getLaunchStoryboardContentsJSON', function () {
+        describe('#getLaunchStoryboardContentsJSON', () => {
             const getLaunchStoryboardContentsJSON = prepare.__get__('getLaunchStoryboardContentsJSON');
 
-            it('should return contents.json with no mapped storyboard images', function () {
+            it('should return contents.json with no mapped storyboard images', () => {
                 const result = getLaunchStoryboardContentsJSON(noLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-json/empty'));
             });
 
-            it('should return contents.json with one mapped storyboard image', function () {
+            it('should return contents.json with one mapped storyboard image', () => {
                 const result = getLaunchStoryboardContentsJSON(singleLaunchStoryboardImage, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-json/single-2xanyany'));
             });
 
-            it('should return contents.json with one mapped storyboard image, even with legacy images', function () {
+            it('should return contents.json with one mapped storyboard image, even with legacy images', () => {
                 const result = getLaunchStoryboardContentsJSON(singleLaunchStoryboardImageWithLegacyLaunchImage, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-json/single-2xanyany'));
             });
 
-            it('should return contents.json with several mapped storyboard images', function () {
+            it('should return contents.json with several mapped storyboard images', () => {
                 const result = getLaunchStoryboardContentsJSON(typicalLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-json/typical-universal'));
             });
 
-            it('should return contents.json with several mapped storyboard images across device classes', function () {
+            it('should return contents.json with several mapped storyboard images across device classes', () => {
                 const result = getLaunchStoryboardContentsJSON(multiDeviceLaunchStoryboardImages, '');
                 expect(result).toBeDefined();
                 expect(result).toEqual(require('./fixtures/launch-storyboard-support/contents-json/varied-device'));
             });
         });
 
-        describe('#getLaunchStoryboardImagesDir', function () {
+        describe('#getLaunchStoryboardImagesDir', () => {
             const getLaunchStoryboardImagesDir = prepare.__get__('getLaunchStoryboardImagesDir');
             const projectRoot = iosProject;
 
-            it('should find the Images.xcassets file in a project with an asset catalog', function () {
+            it('should find the Images.xcassets file in a project with an asset catalog', () => {
                 const platformProjDir = path.join('platforms', 'ios', 'SampleApp');
                 const assetCatalogPath = path.join(iosProject, platformProjDir, 'Images.xcassets');
                 const expectedPath = path.join(platformProjDir, 'Images.xcassets', 'LaunchStoryboard.imageset/');
@@ -234,7 +234,7 @@ describe('prepare', function () {
                 expect(returnPath).toEqual(expectedPath);
             });
 
-            it('should NOT find the Images.xcassets file in a project with no asset catalog', function () {
+            it('should NOT find the Images.xcassets file in a project with no asset catalog', () => {
                 const platformProjDir = path.join('platforms', 'ios', 'SamplerApp');
                 const assetCatalogPath = path.join(iosProject, platformProjDir, 'Images.xcassets');
 
@@ -246,54 +246,54 @@ describe('prepare', function () {
             });
         });
 
-        describe('#platformHasLaunchStoryboardImages', function () {
+        describe('#platformHasLaunchStoryboardImages', () => {
             const platformHasLaunchStoryboardImages = prepare.__get__('platformHasLaunchStoryboardImages');
-            const cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce(function (p, c) {
+            const cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce((p, c) => {
                 p[c] = new ConfigParser(path.join(FIXTURES, 'launch-storyboard-support', 'configs', c + '.xml'));
                 return p;
             }, {});
 
-            it('should be false with no launch images', function () {
+            it('should be false with no launch images', () => {
                 expect(platformHasLaunchStoryboardImages(cfgs.none)).toEqual(false);
             });
-            it('should be false with only legacy images', function () {
+            it('should be false with only legacy images', () => {
                 expect(platformHasLaunchStoryboardImages(cfgs['legacy-only'])).toEqual(false);
             });
-            it('should be true with typical launch storyboard images', function () {
+            it('should be true with typical launch storyboard images', () => {
                 expect(platformHasLaunchStoryboardImages(cfgs['modern-only'])).toEqual(true);
             });
-            it('should be true with typical and legacy launch storyboard images', function () {
+            it('should be true with typical and legacy launch storyboard images', () => {
                 expect(platformHasLaunchStoryboardImages(cfgs['modern-and-legacy'])).toEqual(true);
             });
         });
 
-        describe('#platformHasLegacyLaunchImages', function () {
+        describe('#platformHasLegacyLaunchImages', () => {
             const platformHasLegacyLaunchImages = prepare.__get__('platformHasLegacyLaunchImages');
-            const cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce(function (p, c) {
+            const cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce((p, c) => {
                 p[c] = new ConfigParser(path.join(FIXTURES, 'launch-storyboard-support', 'configs', c + '.xml'));
                 return p;
             }, {});
 
-            it('should be false with no launch images', function () {
+            it('should be false with no launch images', () => {
                 expect(platformHasLegacyLaunchImages(cfgs.none)).toEqual(false);
             });
-            it('should be true with only legacy images', function () {
+            it('should be true with only legacy images', () => {
                 expect(platformHasLegacyLaunchImages(cfgs['legacy-only'])).toEqual(true);
             });
-            it('should be false with typical launch storyboard images', function () {
+            it('should be false with typical launch storyboard images', () => {
                 expect(platformHasLegacyLaunchImages(cfgs['modern-only'])).toEqual(false);
             });
-            it('should be true with typical and legacy launch storyboard images', function () {
+            it('should be true with typical and legacy launch storyboard images', () => {
                 expect(platformHasLegacyLaunchImages(cfgs['modern-and-legacy'])).toEqual(true);
             });
         });
 
-        describe('#updateProjectPlistForLaunchStoryboard', function () {
+        describe('#updateProjectPlistForLaunchStoryboard', () => {
             const updateProjectPlistForLaunchStoryboard = prepare.__get__('updateProjectPlistForLaunchStoryboard');
             const plistFile = path.join(iosPlatform, 'SampleApp', 'SampleApp-Info.plist');
             let cfgs;
-            it('setup', function () {
-                cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce(function (p, c) {
+            it('setup', () => {
+                cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce((p, c) => {
                     p[c] = {
                         config: new ConfigParser(path.join(FIXTURES, 'launch-storyboard-support', 'configs', c + '.xml')),
                         plist: plist.parse(fs.readFileSync(plistFile, 'utf8'))
@@ -302,39 +302,39 @@ describe('prepare', function () {
                 }, {});
             });
 
-            it('should not change the info plist when no launch images are supplied', function () {
+            it('should not change the info plist when no launch images are supplied', () => {
                 const plist = cfgs.none.plist;
                 updateProjectPlistForLaunchStoryboard(cfgs.none.config, plist);
                 expect(plist.UILaunchStoryboardName).toBeUndefined();
             });
-            it('should not change the info plist when only legacy launch images are supplied', function () {
+            it('should not change the info plist when only legacy launch images are supplied', () => {
                 const plist = cfgs['legacy-only'].plist;
                 updateProjectPlistForLaunchStoryboard(cfgs['legacy-only'].config, plist);
                 expect(plist.UILaunchStoryboardName).toBeUndefined();
             });
-            it('should change the info plist when only modern launch images are supplied', function () {
+            it('should change the info plist when only modern launch images are supplied', () => {
                 const plist = cfgs['modern-only'].plist;
                 updateProjectPlistForLaunchStoryboard(cfgs['modern-only'].config, plist);
                 expect(plist.UILaunchStoryboardName).toEqual('CDVLaunchScreen');
             });
-            it('should change the info plist when both legacy and modern launch images are supplied', function () {
+            it('should change the info plist when both legacy and modern launch images are supplied', () => {
                 const plist = cfgs['modern-and-legacy'].plist;
                 updateProjectPlistForLaunchStoryboard(cfgs['modern-and-legacy'].config, plist);
                 expect(plist.UILaunchStoryboardName).toEqual('CDVLaunchScreen');
             });
-            it('should remove the setting when no launch images are supplied but storyboard setting configured', function () {
+            it('should remove the setting when no launch images are supplied but storyboard setting configured', () => {
                 const plist = cfgs.none.plist;
                 plist.UILaunchStoryboardName = 'CDVLaunchScreen';
                 updateProjectPlistForLaunchStoryboard(cfgs.none.config, plist);
                 expect(plist.UILaunchStoryboardName).toBeUndefined();
             });
-            it('should remove the setting when only legacy images are supplied but storyboard setting configured', function () {
+            it('should remove the setting when only legacy images are supplied but storyboard setting configured', () => {
                 const plist = cfgs['legacy-only'].plist;
                 plist.UILaunchStoryboardName = 'CDVLaunchScreen';
                 updateProjectPlistForLaunchStoryboard(cfgs['legacy-only'].config, plist);
                 expect(plist.UILaunchStoryboardName).toBeUndefined();
             });
-            it('should maintain the launch storyboard setting over multiple calls when modern images supplied', function () {
+            it('should maintain the launch storyboard setting over multiple calls when modern images supplied', () => {
                 const plist = cfgs['modern-only'].plist;
                 delete plist.UILaunchStoryboardName;
                 updateProjectPlistForLaunchStoryboard(cfgs['modern-and-legacy'].config, plist);
@@ -342,7 +342,7 @@ describe('prepare', function () {
                 updateProjectPlistForLaunchStoryboard(cfgs['modern-and-legacy'].config, plist);
                 expect(plist.UILaunchStoryboardName).toEqual('CDVLaunchScreen');
             });
-            it('should not attempt to override launch storyboard setting if not set to our storyboard', function () {
+            it('should not attempt to override launch storyboard setting if not set to our storyboard', () => {
                 const plist = cfgs['modern-and-legacy'].plist;
                 plist.UILaunchStoryboardName = 'AnotherStoryboard';
                 updateProjectPlistForLaunchStoryboard(cfgs['modern-and-legacy'].config, plist);
@@ -350,12 +350,12 @@ describe('prepare', function () {
             });
         });
 
-        describe('#updateLaunchStoryboardImages', function () {
+        describe('#updateLaunchStoryboardImages', () => {
             const getLaunchStoryboardImagesDir = prepare.__get__('getLaunchStoryboardImagesDir');
             const updateLaunchStoryboardImages = prepare.__get__('updateLaunchStoryboardImages');
             const logFileOp = prepare.__get__('logFileOp');
 
-            it('should clean storyboard launch images and update contents.json', function () {
+            it('should clean storyboard launch images and update contents.json', () => {
                 // spy!
                 const updatePaths = spyOn(FileUpdater, 'updatePaths');
 
@@ -403,13 +403,13 @@ describe('prepare', function () {
             });
         });
 
-        describe('#cleanLaunchStoryboardImages', function () {
+        describe('#cleanLaunchStoryboardImages', () => {
             const getLaunchStoryboardImagesDir = prepare.__get__('getLaunchStoryboardImagesDir');
             const updateLaunchStoryboardImages = prepare.__get__('updateLaunchStoryboardImages');
             const cleanLaunchStoryboardImages = prepare.__get__('cleanLaunchStoryboardImages');
             const logFileOp = prepare.__get__('logFileOp');
 
-            it('should move launch images and update contents.json', function () {
+            it('should move launch images and update contents.json', () => {
                 const projectRoot = iosProject;
                 const platformProjDir = path.join('platforms', 'ios', 'SampleApp');
                 const storyboardImagesDir = getLaunchStoryboardImagesDir(projectRoot, platformProjDir);
@@ -453,13 +453,13 @@ describe('prepare', function () {
             });
         });
 
-        describe('#checkIfBuildSettingsNeedUpdatedForLaunchStoryboard', function () {
+        describe('#checkIfBuildSettingsNeedUpdatedForLaunchStoryboard', () => {
             const checkIfBuildSettingsNeedUpdatedForLaunchStoryboard = prepare.__get__('checkIfBuildSettingsNeedUpdatedForLaunchStoryboard');
             const updateProjectPlistForLaunchStoryboard = prepare.__get__('updateProjectPlistForLaunchStoryboard');
             const plistFile = path.join(iosPlatform, 'SampleApp', 'SampleApp-Info.plist');
             let cfgs;
-            it('setup', function () {
-                cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce(function (p, c) {
+            it('setup', () => {
+                cfgs = ['none', 'legacy-only', 'modern-only', 'modern-and-legacy'].reduce((p, c) => {
                     p[c] = {
                         config: new ConfigParser(path.join(FIXTURES, 'launch-storyboard-support', 'configs', c + '.xml')),
                         plist: plist.parse(fs.readFileSync(plistFile, 'utf8'))
@@ -468,24 +468,24 @@ describe('prepare', function () {
                 }, {});
             });
 
-            it('should return false with no launch images', function () {
+            it('should return false with no launch images', () => {
                 const cfg = cfgs.none;
                 updateProjectPlistForLaunchStoryboard(cfg.config, cfg.plist);
                 expect(checkIfBuildSettingsNeedUpdatedForLaunchStoryboard(cfg.config, cfg.plist)).toEqual(false);
             });
-            it('should return true with only legacy images', function () {
+            it('should return true with only legacy images', () => {
                 // why? because legacy images require Xcode to compile launch image assets
                 // and we may have previously removed that setting
                 const cfg = cfgs['legacy-only'];
                 updateProjectPlistForLaunchStoryboard(cfg.config, cfg.plist);
                 expect(checkIfBuildSettingsNeedUpdatedForLaunchStoryboard(cfg.config, cfg.plist)).toEqual(true);
             });
-            it('should return true with only storyboard images', function () {
+            it('should return true with only storyboard images', () => {
                 const cfg = cfgs['modern-only'];
                 updateProjectPlistForLaunchStoryboard(cfg.config, cfg.plist);
                 expect(checkIfBuildSettingsNeedUpdatedForLaunchStoryboard(cfg.config, cfg.plist)).toEqual(true);
             });
-            it('should return false with storyboard and legacy images', function () {
+            it('should return false with storyboard and legacy images', () => {
                 // why? because we assume that the build settings will still build the asset catalog
                 // the user has specified both legacy and modern images, so why question it?
                 const cfg = cfgs['modern-and-legacy'];
@@ -494,13 +494,13 @@ describe('prepare', function () {
             });
         });
 
-        describe('#updateBuildSettingsForLaunchStoryboard', function () {
+        describe('#updateBuildSettingsForLaunchStoryboard', () => {
             const updateBuildSettingsForLaunchStoryboard = prepare.__get__('updateBuildSettingsForLaunchStoryboard');
             const updateProjectPlistForLaunchStoryboard = prepare.__get__('updateProjectPlistForLaunchStoryboard');
             const plistFile = path.join(iosPlatform, 'SampleApp', 'SampleApp-Info.plist');
             let cfgs;
-            it('setup', function () {
-                cfgs = ['legacy-only', 'modern-only'].reduce(function (p, c) {
+            it('setup', () => {
+                cfgs = ['legacy-only', 'modern-only'].reduce((p, c) => {
                     p[c] = {
                         config: new ConfigParser(path.join(FIXTURES, 'launch-storyboard-support', 'configs', c + '.xml')),
                         plist: plist.parse(fs.readFileSync(plistFile, 'utf8'))
@@ -509,7 +509,7 @@ describe('prepare', function () {
                 }, {});
             });
 
-            it('should update build property with only legacy images', function () {
+            it('should update build property with only legacy images', () => {
                 const cfg = cfgs['legacy-only'];
                 const proj = new xcode.project(p.locations.pbxproj); /* eslint new-cap : 0 */
                 proj.parseSync();
@@ -517,7 +517,7 @@ describe('prepare', function () {
                 updateBuildSettingsForLaunchStoryboard(proj, cfg.config, cfg.plist);
                 expect(proj.getBuildProperty('ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME')).toEqual('LaunchImage');
             });
-            it('should remove build property with only storyboard images', function () {
+            it('should remove build property with only storyboard images', () => {
                 const cfg = cfgs['modern-only'];
                 const proj = new xcode.project(p.locations.pbxproj); /* eslint new-cap : 0 */
                 proj.parseSync();
@@ -530,7 +530,7 @@ describe('prepare', function () {
         });
     });
 
-    describe('updateProject method', function () {
+    describe('updateProject method', () => {
         /* eslint-disable no-unused-vars */
         let mv;
         let update_name;
@@ -541,7 +541,7 @@ describe('prepare', function () {
 
         const updateProject = prepare.__get__('updateProject');
 
-        beforeEach(function () {
+        beforeEach(() => {
             // Create real config objects before mocking out everything.
             cfg = new ConfigParser(path.join(FIXTURES, 'test-config.xml'));
             cfg2 = new ConfigParser(path.join(FIXTURES, 'test-config-2.xml'));
@@ -552,35 +552,35 @@ describe('prepare', function () {
 
             spyOn(plist, 'parse').and.returnValue({});
             spyOn(plist, 'build').and.returnValue('');
-            spyOn(xcode, 'project').and.callFake(function (pbxproj) {
+            spyOn(xcode, 'project').and.callFake(pbxproj => {
                 const xc = new xcOrig(pbxproj); /* eslint new-cap : 0 */
                 update_name = spyOn(xc, 'updateProductName').and.callThrough();
                 return xc;
             });
-            cfg.name = function () { return 'SampleApp'; }; // this is to match p's original project name (based on .xcodeproj)
-            cfg.packageName = function () { return 'testpkg'; };
-            cfg.version = function () { return 'one point oh'; };
+            cfg.name = () => 'SampleApp'; // this is to match p's original project name (based on .xcodeproj)
+            cfg.packageName = () => 'testpkg';
+            cfg.version = () => 'one point oh';
 
             spyOn(cfg, 'getPreference');
         });
 
-        it('should resolve', function () {
+        it('should resolve', () => {
             // the original name here will be `SampleApp` (based on the xcodeproj basename) from p
-            cfg2.name = function () { return 'SampleApp'; }; // new config does *not* have a name change
+            cfg2.name = () => 'SampleApp'; // new config does *not* have a name change
             return updateProject(cfg2, p.locations); // since the name has not changed it *should not* error
         });
 
-        it('should reject when the app name has changed', function () {
+        it('should reject when the app name has changed', () => {
             // the original name here will be `SampleApp` (based on the xcodeproj basename) from p
-            cfg2.name = function () { return 'NotSampleApp'; }; // new config has name change
+            cfg2.name = () => 'NotSampleApp'; // new config has name change
             return updateProject(cfg2, p.locations).then( // since the name has changed it *should* error
                 () => fail('Expected promise to be rejected'),
                 err => expect(err).toEqual(jasmine.any(Error))
             );
         });
 
-        it('should write target-device preference', function () {
-            cfg2.name = function () { return 'SampleApp'; }; // new config does *not* have a name change
+        it('should write target-device preference', () => {
+            cfg2.name = () => 'SampleApp'; // new config does *not* have a name change
             writeFileSyncSpy.and.callThrough();
 
             return updateProject(cfg2, p.locations).then(() => {
@@ -591,8 +591,8 @@ describe('prepare', function () {
                 expect(prop).toEqual('"1"'); // 1 is handset
             });
         });
-        it('should write deployment-target preference', function () {
-            cfg2.name = function () { return 'SampleApp'; }; // new config does *not* have a name change
+        it('should write deployment-target preference', () => {
+            cfg2.name = () => 'SampleApp'; // new config does *not* have a name change
             writeFileSyncSpy.and.callThrough();
 
             return updateProject(cfg2, p.locations).then(() => {
@@ -603,8 +603,8 @@ describe('prepare', function () {
                 expect(prop).toEqual('8.0');
             });
         });
-        it('should write SwiftVersion preference (4.1)', function () {
-            cfg3.name = function () { return 'SampleApp'; }; // new config does *not* have a name change
+        it('should write SwiftVersion preference (4.1)', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
             writeFileSyncSpy.and.callThrough();
             return updateProject(cfg3, p.locations).then(() => {
                 const xcode = require('xcode');
@@ -614,11 +614,9 @@ describe('prepare', function () {
                 expect(prop).toEqual('4.1');
             });
         });
-        it('should write SwiftVersion preference (3.3)', function () {
-            cfg3.name = function () { return 'SampleApp'; }; // new config does *not* have a name change
-            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference').filter(function (elem) {
-                return elem.attrib.name.toLowerCase() === 'swiftversion';
-            })[0];
+        it('should write SwiftVersion preference (3.3)', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference').filter(elem => elem.attrib.name.toLowerCase() === 'swiftversion')[0];
             pref.attrib.value = '3.3';
             writeFileSyncSpy.and.callThrough();
             return updateProject(cfg3, p.locations).then(() => {
@@ -630,7 +628,7 @@ describe('prepare', function () {
             });
         });
 
-        it('Test#002 : should write out the app id to info plist as CFBundleIdentifier', function () {
+        it('Test#002 : should write out the app id to info plist as CFBundleIdentifier', () => {
             const orig = cfg.getAttribute;
             cfg.getAttribute = function (name) {
                 if (name === 'ios-CFBundleIdentifier') {
@@ -648,7 +646,7 @@ describe('prepare', function () {
                 expect(prop).toEqual('testpkg');
             });
         });
-        it('Test#003 : should write out the app id to info plist as CFBundleIdentifier with ios-CFBundleIdentifier', function () {
+        it('Test#003 : should write out the app id to info plist as CFBundleIdentifier with ios-CFBundleIdentifier', () => {
             const orig = cfg.getAttribute;
             cfg.getAttribute = function (name) {
                 if (name === 'ios-CFBundleIdentifier') {
@@ -667,12 +665,10 @@ describe('prepare', function () {
                 expect(prop).toEqual('testpkg_ios');
             });
         });
-        it('Test#004 : should write out the app version to info plist as CFBundleVersion', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                expect(plist.build.calls.mostRecent().args[0].CFBundleShortVersionString).toEqual('one point oh');
-            });
-        });
-        it('Test#005 : should write out the orientation preference value', function () {
+        it('Test#004 : should write out the app version to info plist as CFBundleVersion', () => updateProject(cfg, p.locations).then(() => {
+            expect(plist.build.calls.mostRecent().args[0].CFBundleShortVersionString).toEqual('one point oh');
+        }));
+        it('Test#005 : should write out the orientation preference value', () => {
             cfg.getPreference.and.callThrough();
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].UISupportedInterfaceOrientations).toEqual(['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown']);
@@ -680,7 +676,7 @@ describe('prepare', function () {
                 expect(plist.build.calls.mostRecent().args[0].UIInterfaceOrientation).toEqual(['UIInterfaceOrientationPortrait']);
             });
         });
-        it('Test#006 : should handle no orientation', function () {
+        it('Test#006 : should handle no orientation', () => {
             cfg.getPreference.and.returnValue('');
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].UISupportedInterfaceOrientations).toBeUndefined();
@@ -688,7 +684,7 @@ describe('prepare', function () {
                 expect(plist.build.calls.mostRecent().args[0].UIInterfaceOrientation).toBeUndefined();
             });
         });
-        it('Test#007 : should handle default orientation', function () {
+        it('Test#007 : should handle default orientation', () => {
             cfg.getPreference.and.returnValue('default');
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].UISupportedInterfaceOrientations).toEqual(['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight']);
@@ -696,28 +692,28 @@ describe('prepare', function () {
                 expect(plist.build.calls.mostRecent().args[0].UIInterfaceOrientation).toBeUndefined();
             });
         });
-        it('Test#008 : should handle portrait orientation', function () {
+        it('Test#008 : should handle portrait orientation', () => {
             cfg.getPreference.and.returnValue('portrait');
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].UISupportedInterfaceOrientations).toEqual(['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown']);
                 expect(plist.build.calls.mostRecent().args[0].UIInterfaceOrientation).toEqual(['UIInterfaceOrientationPortrait']);
             });
         });
-        it('Test#009 : should handle landscape orientation', function () {
+        it('Test#009 : should handle landscape orientation', () => {
             cfg.getPreference.and.returnValue('landscape');
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].UISupportedInterfaceOrientations).toEqual(['UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight']);
                 expect(plist.build.calls.mostRecent().args[0].UIInterfaceOrientation).toEqual(['UIInterfaceOrientationLandscapeLeft']);
             });
         });
-        it('Test#010 : should handle all orientation on ios', function () {
+        it('Test#010 : should handle all orientation on ios', () => {
             cfg.getPreference.and.returnValue('all');
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].UISupportedInterfaceOrientations).toEqual(['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight']);
                 expect(plist.build.calls.mostRecent().args[0].UIInterfaceOrientation).toEqual(['UIInterfaceOrientationPortrait']);
             });
         });
-        it('Test#011 : should handle custom orientation', function () {
+        it('Test#011 : should handle custom orientation', () => {
             cfg.getPreference.and.returnValue('some-custom-orientation');
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].UISupportedInterfaceOrientations).toEqual(['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight']);
@@ -730,25 +726,23 @@ describe('prepare', function () {
         // NOTE: if an ATS value is equal to "null", it means that it was not written,
         // thus it will use the default (check the default for the key).
         // This is to prevent the Info.plist to be too verbose.
-        it('Test#012 : <access> - should handle wildcard', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                expect(ats.NSAllowsArbitraryLoads).toEqual(true);
-                expect(ats.NSAllowsArbitraryLoadsInWebContent).toEqual(undefined);
-                expect(ats.NSAllowsArbitraryLoadsInMedia).toEqual(undefined); // DEPRECATED
-                expect(ats.NSAllowsArbitraryLoadsForMedia).toEqual(undefined);
-                expect(ats.NSAllowsLocalNetworking).toEqual(undefined);
-            });
-        });
+        it('Test#012 : <access> - should handle wildcard', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            expect(ats.NSAllowsArbitraryLoads).toEqual(true);
+            expect(ats.NSAllowsArbitraryLoadsInWebContent).toEqual(undefined);
+            expect(ats.NSAllowsArbitraryLoadsInMedia).toEqual(undefined); // DEPRECATED
+            expect(ats.NSAllowsArbitraryLoadsForMedia).toEqual(undefined);
+            expect(ats.NSAllowsLocalNetworking).toEqual(undefined);
+        }));
 
-        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsInWebContent', function () {
+        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsInWebContent', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="*" allows-arbitrary-loads-in-web-content="true" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -767,14 +761,14 @@ describe('prepare', function () {
             });
         });
 
-        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia set (fixed allows-arbitrary-loads-for-media)', function () {
+        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia set (fixed allows-arbitrary-loads-for-media)', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="*" allows-arbitrary-loads-for-media="true" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -792,14 +786,14 @@ describe('prepare', function () {
             });
         });
 
-        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia not set (fixed allows-arbitrary-loads-for-media)', function () {
+        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia not set (fixed allows-arbitrary-loads-for-media)', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="*" allows-arbitrary-loads-for-media="false" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -817,14 +811,14 @@ describe('prepare', function () {
             });
         });
 
-        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia set (deprecated allows-arbitrary-loads-in-media)', function () {
+        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia set (deprecated allows-arbitrary-loads-in-media)', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="*" allows-arbitrary-loads-in-media="true" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -842,14 +836,14 @@ describe('prepare', function () {
             });
         });
 
-        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia not set (deprecated allows-arbitrary-loads-in-media)', function () {
+        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia not set (deprecated allows-arbitrary-loads-in-media)', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="*" allows-arbitrary-loads-in-media="false" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -867,14 +861,14 @@ describe('prepare', function () {
             });
         });
 
-        it('<access> - should handle wildcard, with NSAllowsLocalNetworking', function () {
+        it('<access> - should handle wildcard, with NSAllowsLocalNetworking', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="*" allows-local-networking="true" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -893,14 +887,14 @@ describe('prepare', function () {
             });
         });
 
-        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', function () {
+        it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="*" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -918,14 +912,14 @@ describe('prepare', function () {
                 expect(ats.NSAllowsLocalNetworking).toEqual(true);
             });
         });
-        it('<access> - sanity check - no wildcard but has NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', function () {
+        it('<access> - sanity check - no wildcard but has NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<access origin="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -944,232 +938,226 @@ describe('prepare', function () {
             });
         });
 
-        it('Test#13 : <access> - https, subdomain wildcard', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+        it('Test#13 : <access> - https, subdomain wildcard', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server01.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server01.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server02.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server02.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server02-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server02-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server02-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server02-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server03.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server03.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server04.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server04.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server04-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server04-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server04-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
+            d = exceptionDomains['server04-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
 
-        it('Test#014 : <access> - http, no wildcard', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+        it('Test#014 : <access> - http, no wildcard', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server05.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server05.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server06.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server06.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server06-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server06-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server06-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server06-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server07.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server07.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server08.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server08.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server08-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server08-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server08-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
-        it('Test#015 : <access> - https, no wildcard', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+            d = exceptionDomains['server08-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
+        it('Test#015 : <access> - https, no wildcard', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server09.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server09.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server10.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server10.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server10-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server10-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server10-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server10-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server11.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server11.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server12.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server12.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server12-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server12-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server12-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
+            d = exceptionDomains['server12-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
         /// ///////////////////////////////////////////////
-        it('Test#016 : <access>, <allow-navigation> - http and https, no clobber', function () {
+        it('Test#016 : <access>, <allow-navigation> - http and https, no clobber', () => {
             // original name here is 'SampleApp' based on p
             // we are not testing a name change here, but testing a new config being used (name change test is above)
             // so we set it to the name expected
-            cfg2.name = function () { return 'SampleApp'; }; // new config does *not* have a name change
+            cfg2.name = () => 'SampleApp'; // new config does *not* have a name change
 
             return updateProject(cfg2, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
@@ -1188,14 +1176,14 @@ describe('prepare', function () {
         });
         /// ///////////////////////////////////////////////
 
-        it('<allow-navigation> - should handle wildcard', function () {
+        it('<allow-navigation> - should handle wildcard', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<allow-navigation href="*" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -1214,14 +1202,14 @@ describe('prepare', function () {
             });
         });
 
-        it('<allow-navigation> - sanity check - no wildcard but has NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', function () {
+        it('<allow-navigation> - sanity check - no wildcard but has NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', () => {
             const origReadFile = fse.readFileSync;
             const readFile = spyOn(fse, 'readFileSync');
             const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
             '<allow-navigation href="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />' +
             '</widget>';
 
-            readFile.and.callFake(function (...args) {
+            readFile.and.callFake((...args) => {
                 if (args[0] === 'fake/path') {
                     return configXml;
                 }
@@ -1240,392 +1228,380 @@ describe('prepare', function () {
             });
         });
 
-        it('<allow-navigation> - https, subdomain wildcard', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+        it('<allow-navigation> - https, subdomain wildcard', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server21.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server21.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server22.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server22.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server22-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server22-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server22-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server22-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server23.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server23.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server24.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server24.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server24-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server24-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server24-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
+            d = exceptionDomains['server24-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
 
-        it('<allow-navigation> - http, no wildcard', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+        it('<allow-navigation> - http, no wildcard', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server25.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server25.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server26.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server26.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server26-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server26-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server26-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server26-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server27.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server27.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server28.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server28.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server28-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server28-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server28-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
+            d = exceptionDomains['server28-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
 
-        it('<allow-navigation> - https, no wildcard', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+        it('<allow-navigation> - https, no wildcard', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server29.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server29.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server30.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server30.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server30-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server30-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server30-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server30-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server31.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server31.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server32.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server32.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server32-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server32-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server32-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
+            d = exceptionDomains['server32-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
 
-        it('Test#017 : <allow-navigation> - wildcard scheme, wildcard subdomain', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+        it('Test#017 : <allow-navigation> - wildcard scheme, wildcard subdomain', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server33.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server33.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server34.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server34.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server34-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server34-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server34-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server34-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server35.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server35.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server36.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server36.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server36-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server36-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server36-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(true);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
-        it('Test#018 : <allow-navigation> - wildcard scheme, no subdomain', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                let d;
+            d = exceptionDomains['server36-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(true);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
+        it('Test#018 : <allow-navigation> - wildcard scheme, no subdomain', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            let d;
 
-                expect(exceptionDomains).toBeTruthy();
+            expect(exceptionDomains).toBeTruthy();
 
-                d = exceptionDomains['server37.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server37.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server38.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server38.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server38-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server38-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server38-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server38-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server39.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server39.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server40.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+            d = exceptionDomains['server40.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-                d = exceptionDomains['server40-1.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            d = exceptionDomains['server40-1.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-                d = exceptionDomains['server40-2.com'];
-                expect(d).toBeTruthy();
-                expect(d.NSIncludesSubdomains).toEqual(undefined);
-                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-                expect(d.NSRequiresCertificateTransparency).toEqual(true);
-            });
-        });
-        it('Test#019 : <allow-navigation> - should ignore wildcards like data:*, https:*, https://*', function () {
-            return updateProject(cfg, p.locations).then(() => {
-                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-                const exceptionDomains = ats.NSExceptionDomains;
-                expect(exceptionDomains['']).toBeUndefined();
-                expect(exceptionDomains['null']).toBeUndefined();
-                expect(exceptionDomains['undefined']).toBeUndefined();
-            });
-        });
-        it('Test#020 : <name> - should write out the display name to info plist as CFBundleDisplayName', function () {
-            cfg.shortName = function () { return 'MyApp'; };
+            d = exceptionDomains['server40-2.com'];
+            expect(d).toBeTruthy();
+            expect(d.NSIncludesSubdomains).toEqual(undefined);
+            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+        }));
+        it('Test#019 : <allow-navigation> - should ignore wildcards like data:*, https:*, https://*', () => updateProject(cfg, p.locations).then(() => {
+            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+            const exceptionDomains = ats.NSExceptionDomains;
+            expect(exceptionDomains['']).toBeUndefined();
+            expect(exceptionDomains['null']).toBeUndefined();
+            expect(exceptionDomains['undefined']).toBeUndefined();
+        }));
+        it('Test#020 : <name> - should write out the display name to info plist as CFBundleDisplayName', () => {
+            cfg.shortName = () => 'MyApp';
             return updateProject(cfg, p.locations).then(() => {
                 expect(plist.build.calls.mostRecent().args[0].CFBundleDisplayName).toEqual('MyApp');
             });
         });
     });
 
-    describe('<resource-file> tests', function () {
+    describe('<resource-file> tests', () => {
         // image-8888.png target attribute is missing in config.xml as a test
         const images = [
             {
@@ -1648,7 +1624,7 @@ describe('prepare', function () {
 
         function findImageFileRef (pbxproj, imageFileName) {
             const buildfiles = pbxproj.pbxBuildFileSection();
-            return Object.keys(buildfiles).filter(function (uuid) {
+            return Object.keys(buildfiles).filter(uuid => {
                 const filename = buildfiles[uuid].fileRef_comment;
                 return (filename === imageFileName);
             });
@@ -1658,15 +1634,13 @@ describe('prepare', function () {
             const resBuildPhase = pbxproj.buildPhaseObject('PBXResourcesBuildPhase', 'Resources');
             let resBuildPhaseFileRefs = [];
             if (resBuildPhase) {
-                resBuildPhaseFileRefs = resBuildPhase.files.filter(function (item) {
-                    return item.value === ref;
-                });
+                resBuildPhaseFileRefs = resBuildPhase.files.filter(item => item.value === ref);
             }
 
             return resBuildPhaseFileRefs;
         }
 
-        it('<resource-file> prepare - copy', function () {
+        it('<resource-file> prepare - copy', () => {
             const cordovaProject = {
                 root: projectRoot,
                 projectConfig: cfgResourceFiles,
@@ -1699,7 +1673,7 @@ describe('prepare', function () {
             }
         });
 
-        it('<resource-file> clean - remove', function () {
+        it('<resource-file> clean - remove', () => {
             cleanFileResources(projectRoot, cfgResourceFiles, p.locations);
             const project = projectFile.parse(p.locations);
 
@@ -1718,11 +1692,11 @@ describe('prepare', function () {
         });
     });
 
-    describe('updateWww method', function () {
+    describe('updateWww method', () => {
         const updateWww = prepare.__get__('updateWww');
         const logFileOp = prepare.__get__('logFileOp');
 
-        beforeEach(function () {
+        beforeEach(() => {
             spyOn(FileUpdater, 'mergeAndUpdateDir').and.returnValue(true);
         });
 
@@ -1731,7 +1705,7 @@ describe('prepare', function () {
             locations: { www: path.join(iosProject, 'www') }
         };
 
-        it('Test#021 : should update project-level www and with platform agnostic www and merges', function () {
+        it('Test#021 : should update project-level www and with platform agnostic www and merges', () => {
             const merges_path = path.join(project.root, 'merges', 'ios');
             shell.mkdir('-p', merges_path);
             updateWww(project, p.locations);
@@ -1741,7 +1715,7 @@ describe('prepare', function () {
                 { rootDir: iosProject },
                 logFileOp);
         });
-        it('Test#022 : should skip merges if merges directory does not exist', function () {
+        it('Test#022 : should skip merges if merges directory does not exist', () => {
             const merges_path = path.join(project.root, 'merges', 'ios');
             shell.rm('-rf', merges_path);
             updateWww(project, p.locations);

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -665,9 +665,11 @@ describe('prepare', () => {
                 expect(prop).toEqual('testpkg_ios');
             });
         });
-        it('Test#004 : should write out the app version to info plist as CFBundleVersion', () => updateProject(cfg, p.locations).then(() => {
-            expect(plist.build.calls.mostRecent().args[0].CFBundleShortVersionString).toEqual('one point oh');
-        }));
+        it('Test#004 : should write out the app version to info plist as CFBundleVersion', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                expect(plist.build.calls.mostRecent().args[0].CFBundleShortVersionString).toEqual('one point oh');
+            });
+        });
         it('Test#005 : should write out the orientation preference value', () => {
             cfg.getPreference.and.callThrough();
             return updateProject(cfg, p.locations).then(() => {
@@ -726,14 +728,16 @@ describe('prepare', () => {
         // NOTE: if an ATS value is equal to "null", it means that it was not written,
         // thus it will use the default (check the default for the key).
         // This is to prevent the Info.plist to be too verbose.
-        it('Test#012 : <access> - should handle wildcard', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            expect(ats.NSAllowsArbitraryLoads).toEqual(true);
-            expect(ats.NSAllowsArbitraryLoadsInWebContent).toEqual(undefined);
-            expect(ats.NSAllowsArbitraryLoadsInMedia).toEqual(undefined); // DEPRECATED
-            expect(ats.NSAllowsArbitraryLoadsForMedia).toEqual(undefined);
-            expect(ats.NSAllowsLocalNetworking).toEqual(undefined);
-        }));
+        it('Test#012 : <access> - should handle wildcard', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                expect(ats.NSAllowsArbitraryLoads).toEqual(true);
+                expect(ats.NSAllowsArbitraryLoadsInWebContent).toEqual(undefined);
+                expect(ats.NSAllowsArbitraryLoadsInMedia).toEqual(undefined); // DEPRECATED
+                expect(ats.NSAllowsArbitraryLoadsForMedia).toEqual(undefined);
+                expect(ats.NSAllowsLocalNetworking).toEqual(undefined);
+            });
+        });
 
         it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsInWebContent', () => {
             const origReadFile = fse.readFileSync;
@@ -938,220 +942,226 @@ describe('prepare', () => {
             });
         });
 
-        it('Test#13 : <access> - https, subdomain wildcard', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+        it('Test#13 : <access> - https, subdomain wildcard', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server01.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server01.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server02.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server02.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server02-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server02-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server02-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server02-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server03.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server03.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server04.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server04.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server04-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server04-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server04-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
+                d = exceptionDomains['server04-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
 
-        it('Test#014 : <access> - http, no wildcard', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+        it('Test#014 : <access> - http, no wildcard', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server05.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server05.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server06.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server06.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server06-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server06-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server06-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server06-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server07.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server07.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server08.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server08.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server08-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server08-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server08-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
-        it('Test#015 : <access> - https, no wildcard', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+                d = exceptionDomains['server08-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
+        it('Test#015 : <access> - https, no wildcard', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server09.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server09.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server10.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server10.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server10-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server10-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server10-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server10-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server11.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server11.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server12.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server12.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server12-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server12-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server12-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
+                d = exceptionDomains['server12-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
         /// ///////////////////////////////////////////////
         it('Test#016 : <access>, <allow-navigation> - http and https, no clobber', () => {
             // original name here is 'SampleApp' based on p
@@ -1228,371 +1238,383 @@ describe('prepare', () => {
             });
         });
 
-        it('<allow-navigation> - https, subdomain wildcard', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+        it('<allow-navigation> - https, subdomain wildcard', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server21.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server21.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server22.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server22.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server22-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server22-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server22-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server22-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server23.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server23.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server24.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server24.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server24-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server24-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server24-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
+                d = exceptionDomains['server24-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
 
-        it('<allow-navigation> - http, no wildcard', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+        it('<allow-navigation> - http, no wildcard', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server25.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server25.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server26.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server26.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server26-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server26-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server26-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server26-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server27.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server27.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server28.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server28.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server28-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server28-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server28-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
+                d = exceptionDomains['server28-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
 
-        it('<allow-navigation> - https, no wildcard', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+        it('<allow-navigation> - https, no wildcard', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server29.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server29.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server30.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server30.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server30-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server30-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server30-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server30-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server31.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server31.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server32.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server32.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server32-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server32-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server32-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
+                d = exceptionDomains['server32-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(undefined);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
 
-        it('Test#017 : <allow-navigation> - wildcard scheme, wildcard subdomain', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+        it('Test#017 : <allow-navigation> - wildcard scheme, wildcard subdomain', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server33.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server33.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server34.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server34.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server34-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server34-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server34-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server34-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server35.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server35.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server36.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server36.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server36-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server36-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server36-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(true);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
-        it('Test#018 : <allow-navigation> - wildcard scheme, no subdomain', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            let d;
+                d = exceptionDomains['server36-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(true);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
+        it('Test#018 : <allow-navigation> - wildcard scheme, no subdomain', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                let d;
 
-            expect(exceptionDomains).toBeTruthy();
+                expect(exceptionDomains).toBeTruthy();
 
-            d = exceptionDomains['server37.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server37.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server38.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server38.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server38-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server38-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server38-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server38-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual(undefined);
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server39.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server39.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server40.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
+                d = exceptionDomains['server40.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(undefined);
 
-            d = exceptionDomains['server40-1.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
+                d = exceptionDomains['server40-1.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(undefined);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
 
-            d = exceptionDomains['server40-2.com'];
-            expect(d).toBeTruthy();
-            expect(d.NSIncludesSubdomains).toEqual(undefined);
-            expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
-            expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
-            expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
-            expect(d.NSRequiresCertificateTransparency).toEqual(true);
-        }));
-        it('Test#019 : <allow-navigation> - should ignore wildcards like data:*, https:*, https://*', () => updateProject(cfg, p.locations).then(() => {
-            const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
-            const exceptionDomains = ats.NSExceptionDomains;
-            expect(exceptionDomains['']).toBeUndefined();
-            expect(exceptionDomains['null']).toBeUndefined();
-            expect(exceptionDomains['undefined']).toBeUndefined();
-        }));
+                d = exceptionDomains['server40-2.com'];
+                expect(d).toBeTruthy();
+                expect(d.NSIncludesSubdomains).toEqual(undefined);
+                expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                expect(d.NSRequiresCertificateTransparency).toEqual(true);
+            });
+        });
+        it('Test#019 : <allow-navigation> - should ignore wildcards like data:*, https:*, https://*', () => {
+            return updateProject(cfg, p.locations).then(() => {
+                const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
+                const exceptionDomains = ats.NSExceptionDomains;
+                expect(exceptionDomains['']).toBeUndefined();
+                expect(exceptionDomains['null']).toBeUndefined();
+                expect(exceptionDomains['undefined']).toBeUndefined();
+            });
+        });
         it('Test#020 : <name> - should write out the display name to info plist as CFBundleDisplayName', () => {
             cfg.shortName = () => 'MyApp';
             return updateProject(cfg, p.locations).then(() => {

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -616,7 +616,8 @@ describe('prepare', () => {
         });
         it('should write SwiftVersion preference (3.3)', () => {
             cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
-            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference').filter(elem => elem.attrib.name.toLowerCase() === 'swiftversion')[0];
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference')
+                .filter(elem => elem.attrib.name.toLowerCase() === 'swiftversion')[0];
             pref.attrib.value = '3.3';
             writeFileSyncSpy.and.callThrough();
             return updateProject(cfg3, p.locations).then(() => {

--- a/tests/spec/unit/preparePlatform.spec.js
+++ b/tests/spec/unit/preparePlatform.spec.js
@@ -35,9 +35,9 @@ const dummyPlugin = path.join(FIXTURES, DUMMY_PLUGIN);
 
 shell.config.silent = true;
 
-describe('prepare after plugin add', function () {
+describe('prepare after plugin add', () => {
     let api;
-    beforeEach(function () {
+    beforeEach(() => {
         shell.mkdir('-p', iosPlatform);
         shell.cp('-rf', iosProjectFixture + '/*', iosPlatform);
         api = new Api('ios', iosPlatform, new EventEmitter());
@@ -68,11 +68,11 @@ describe('prepare after plugin add', function () {
         });
     });
 
-    afterEach(function () {
+    afterEach(() => {
         shell.rm('-rf', iosPlatform);
     });
 
-    it('Test 001 : should not overwrite plugin metadata added by "addPlugin"', function () {
+    it('Test 001 : should not overwrite plugin metadata added by "addPlugin"', () => {
         const project = {
             root: iosProject,
             projectConfig: new ConfigParser(path.join(iosProject, 'config.xml')),
@@ -83,16 +83,16 @@ describe('prepare after plugin add', function () {
         };
 
         return api.prepare(project, {})
-            .then(function () {
+            .then(() => {
                 expect(fs.existsSync(path.join(iosPlatform, 'ios.json'))).toBe(true);
                 expect(DUMMY_PLUGIN).not.toBeInstalledIn(iosProject);
                 return api.addPlugin(new PluginInfo(dummyPlugin), {});
             })
-            .then(function () {
+            .then(() => {
                 expect(DUMMY_PLUGIN).toBeInstalledIn(iosPlatform);
                 return api.prepare(project, {});
             })
-            .then(function () {
+            .then(() => {
                 expect(DUMMY_PLUGIN).toBeInstalledIn(iosPlatform);
             });
     });

--- a/tests/spec/unit/projectFile.spec.js
+++ b/tests/spec/unit/projectFile.spec.js
@@ -30,31 +30,31 @@ const locations = {
     pbxproj: path.join(iosProject, 'SampleApp.xcodeproj/project.pbxproj')
 };
 
-describe('projectFile', function () {
-    beforeEach(function () {
+describe('projectFile', () => {
+    beforeEach(() => {
         shell.cp('-rf', iosProjectFixture, iosProject);
     });
 
-    afterEach(function () {
+    afterEach(() => {
         shell.rm('-rf', iosProject);
     });
 
-    describe('parse method', function () {
-        it('Test#001 : should throw if project is not an xcode project', function () {
+    describe('parse method', () => {
+        it('Test#001 : should throw if project is not an xcode project', () => {
             shell.rm('-rf', path.join(iosProject, 'SampleApp', 'SampleApp.xcodeproj'));
-            expect(function () { projectFile.parse(); }).toThrow();
+            expect(() => { projectFile.parse(); }).toThrow();
         });
-        it('Test#002 : should throw if project does not contain an appropriate config.xml file', function () {
+        it('Test#002 : should throw if project does not contain an appropriate config.xml file', () => {
             shell.rm(path.join(iosProject, 'SampleApp', 'config.xml'));
-            expect(function () { projectFile.parse(locations); })
+            expect(() => { projectFile.parse(locations); })
                 .toThrow(new Error('Could not find *-Info.plist file, or config.xml file.'));
         });
-        it('Test#003 : should throw if project does not contain an appropriate -Info.plist file', function () {
+        it('Test#003 : should throw if project does not contain an appropriate -Info.plist file', () => {
             shell.rm(path.join(iosProject, 'SampleApp', 'SampleApp-Info.plist'));
-            expect(function () { projectFile.parse(locations); })
+            expect(() => { projectFile.parse(locations); })
                 .toThrow(new Error('Could not find *-Info.plist file, or config.xml file.'));
         });
-        it('Test#004 : should return right directory when multiple .plist files are present', function () {
+        it('Test#004 : should return right directory when multiple .plist files are present', () => {
             // Create a folder named A with config.xml and .plist files in it
             const pathToFolderA = path.join(iosProject, 'A');
             shell.mkdir(pathToFolderA);
@@ -75,8 +75,8 @@ describe('projectFile', function () {
         });
     });
 
-    describe('other methods', function () {
-        it('Test#005 : getPackageName method should return the CFBundleIdentifier from the project\'s Info.plist file', function () {
+    describe('other methods', () => {
+        it('Test#005 : getPackageName method should return the CFBundleIdentifier from the project\'s Info.plist file', () => {
             expect(projectFile.parse(locations).getPackageName()).toEqual('com.example.friendstring');
         });
     });

--- a/tests/spec/unit/versions.spec.js
+++ b/tests/spec/unit/versions.spec.js
@@ -28,15 +28,19 @@ if (process.platform === 'darwin') {
         });
 
         describe('get_apple_ios_version method', () => {
-            it('should have found ios version.', () => versions.get_apple_ios_version().then(() => {
-                expect(console.log).not.toHaveBeenCalledWith(undefined);
-            }));
+            it('should have found ios version.', () => {
+                return versions.get_apple_ios_version().then(() => {
+                    expect(console.log).not.toHaveBeenCalledWith(undefined);
+                });
+            });
         });
 
         describe('get_apple_osx_version method', () => {
-            it('should have found osx version.', () => versions.get_apple_osx_version().then(() => {
-                expect(console.log).not.toHaveBeenCalledWith(undefined);
-            }));
+            it('should have found osx version.', () => {
+                return versions.get_apple_osx_version().then(() => {
+                    expect(console.log).not.toHaveBeenCalledWith(undefined);
+                });
+            });
         });
     });
 }

--- a/tests/spec/unit/versions.spec.js
+++ b/tests/spec/unit/versions.spec.js
@@ -22,25 +22,21 @@ const versions = require('../../../bin/templates/scripts/cordova/lib/versions');
 
 // These tests can not run on windows.
 if (process.platform === 'darwin') {
-    describe('versions', function () {
+    describe('versions', () => {
         beforeEach(() => {
             spyOn(console, 'log');
         });
 
         describe('get_apple_ios_version method', () => {
-            it('should have found ios version.', () => {
-                return versions.get_apple_ios_version().then(() => {
-                    expect(console.log).not.toHaveBeenCalledWith(undefined);
-                });
-            });
+            it('should have found ios version.', () => versions.get_apple_ios_version().then(() => {
+                expect(console.log).not.toHaveBeenCalledWith(undefined);
+            }));
         });
 
         describe('get_apple_osx_version method', () => {
-            it('should have found osx version.', () => {
-                return versions.get_apple_osx_version().then(() => {
-                    expect(console.log).not.toHaveBeenCalledWith(undefined);
-                });
-            });
+            it('should have found osx version.', () => versions.get_apple_osx_version().then(() => {
+                expect(console.log).not.toHaveBeenCalledWith(undefined);
+            }));
         });
     });
 }


### PR DESCRIPTION
### Motivation and Context

Modernize code

### Description

* Use `lebab` to apply `--transform arrow` and `--transform arrow-return`.
* Reverted some of the applied `arrow-return` for readability.

### Testing

- `npm t`