### PR TITLE
refactor: transform split out variables

### DIFF
--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -66,7 +66,8 @@ describe('Platform Api', () => {
     });
 
     describe('.prototype', () => {
-        let api, events;
+        let api;
+        let events;
         const projectRoot = iosProjectFixture;
         beforeEach(() => {
             events = new EventEmitter();

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -294,7 +294,8 @@ describe('ios plugin handler', () => {
         describe('of <js-module> elements', () => {
             const jsModule = { src: 'www/dummyplugin.js' };
             const install = pluginHandlers.getInstaller('js-module');
-            let wwwDest, platformWwwDest;
+            let wwwDest;
+            let platformWwwDest;
 
             beforeEach(() => {
                 spyOn(fs, 'writeFileSync');
@@ -497,7 +498,8 @@ describe('ios plugin handler', () => {
         describe('of <js-module> elements', () => {
             const jsModule = { src: 'www/dummyPlugin.js' };
             const uninstall = pluginHandlers.getUninstaller('js-module');
-            let wwwDest, platformWwwDest;
+            let wwwDest;
+            let platformWwwDest;
 
             beforeEach(() => {
                 wwwDest = path.resolve(dummyProject.www, 'plugins', dummyPluginInfo.id, jsModule.src);
@@ -528,7 +530,8 @@ describe('ios plugin handler', () => {
         describe('of <asset> elements', () => {
             const asset = { src: 'www/dummyPlugin.js', target: 'foo/dummy.js' };
             const uninstall = pluginHandlers.getUninstaller('asset');
-            let wwwDest, platformWwwDest;
+            let wwwDest;
+            let platformWwwDest;
 
             beforeEach(() => {
                 wwwDest = path.resolve(dummyProject.www, asset.target);

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -43,7 +43,8 @@ shell.config.silent = true;
 const ConfigParser = require('cordova-common').ConfigParser;
 
 describe('prepare', () => {
-    let p, Api;
+    let p;
+    let Api;
     beforeEach(() => {
         Api = rewire('../../../bin/templates/scripts/cordova/Api');
 
@@ -533,7 +534,9 @@ describe('prepare', () => {
         /* eslint-enable no-unused-vars */
         const xcOrig = xcode.project;
         let writeFileSyncSpy;
-        let cfg, cfg2, cfg3;
+        let cfg;
+        let cfg2;
+        let cfg3;
 
         const updateProject = prepare.__get__('updateProject');
 


### PR DESCRIPTION
### Motivation and Context

This maybe a personal opinion but, I feel that split out the variables can make it:

* easier to search for the variable declaration.
* quicker to distinguish the change/add/remove of a variable in a diff when on its own line.

### Description

* Use `lebab` to apply `--transform multi-var `.

### Testing

- `npm t`