### PR TITLE
Add Python 3 compatibility to bin/cordova_plist_to_config_xml

### DIFF
--- a/bin/cordova_plist_to_config_xml
+++ b/bin/cordova_plist_to_config_xml
@@ -26,17 +26,13 @@ Usage:
 from __future__ import print_function
 
 import fileinput
+import io
 import os
 import plistlib
 import re
 import sys
 from xml.dom import minidom
 from xml.etree import ElementTree
-
-try:  # Python 2
-  from StringIO import StringIO
-except ImportError:  # Python 3
-  from io import StringIO
 
 
 def Usage():
@@ -93,10 +89,10 @@ def ConvertPlist(src_path, dst_path):
     root.append(ElementTree.Element('access', attrib={'origin':value}))
 
   tree = ElementTree.ElementTree(root)
-  s = StringIO()
-  tree.write(s, encoding='UTF-8')
-  mini_dom = minidom.parseString(s.getvalue())
-  with open(dst_path, 'w') as out:
+  with io.BytesIO() as s:
+    tree.write(s, encoding='UTF-8')
+    mini_dom = minidom.parseString(s.getvalue())
+  with open(dst_path, 'wb') as out:
     out.write(mini_dom.toprettyxml(encoding='UTF-8'))
 
 

--- a/bin/cordova_plist_to_config_xml
+++ b/bin/cordova_plist_to_config_xml
@@ -23,15 +23,20 @@ Converts a project's Cordova.plist file into a config.xml one. This conversion i
 Usage:
   plist2xml.py path/to/project
 """
+from __future__ import print_function
 
-import StringIO
 import fileinput
-import plistlib
 import os
+import plistlib
 import re
 import sys
 from xml.dom import minidom
 from xml.etree import ElementTree
+
+try:  # Python 2
+  from StringIO import StringIO
+except ImportError:  # Python 3
+  from io import StringIO
 
 
 def Usage():
@@ -88,7 +93,7 @@ def ConvertPlist(src_path, dst_path):
     root.append(ElementTree.Element('access', attrib={'origin':value}))
 
   tree = ElementTree.ElementTree(root)
-  s = StringIO.StringIO()
+  s = StringIO()
   tree.write(s, encoding='UTF-8')
   mini_dom = minidom.parseString(s.getvalue())
   with open(dst_path, 'w') as out:
@@ -101,7 +106,7 @@ def UpdateProjectFile(path):
     if 'Cordova.plist' in line:
       line = line.replace('Cordova.plist', 'config.xml')
       line = line.replace('lastKnownFileType = text.plist.xml', 'lastKnownFileType = text.xml')
-    print line,
+    print(line, end='')
   file_handle.close()
 
 

--- a/bin/cordova_plist_to_config_xml
+++ b/bin/cordova_plist_to_config_xml
@@ -106,7 +106,7 @@ def UpdateProjectFile(path):
     if 'Cordova.plist' in line:
       line = line.replace('Cordova.plist', 'config.xml')
       line = line.replace('lastKnownFileType = text.plist.xml', 'lastKnownFileType = text.xml')
-    print(line, end='')
+    print(line, end=' ')
   file_handle.close()
 
 


### PR DESCRIPTION
These changes should be compatible with both Python 2 and Python 3.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
