### PR TITLE
fix (node): require failure with shebang interpreter

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements. See the NOTICE file

--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -19,6 +19,15 @@
 
 /* jslint node: true */
 
+/**
+ * @todo update coho to update this line.
+ * @todo use `package.json` instead but first
+ *  figure out how this fit in with the platform-centered workflow structure.
+ *  This workflow would not have the `package.json` file.
+ */
+// Coho updates this line
+const VERSION = '6.0.0-dev';
+
 const fs = require('fs');
 const path = require('path');
 const unorm = require('unorm');
@@ -189,7 +198,7 @@ Api.prototype.getPlatformInfo = function () {
     result.locations = this.locations;
     result.root = this.root;
     result.name = this.platform;
-    result.version = require('./version');
+    result.version = Api.version();
     result.projectConfig = new ConfigParser(this.locations.configXml);
 
     return result;
@@ -683,6 +692,10 @@ Api.prototype.clean = function (cleanOptions) {
  */
 Api.prototype.requirements = function () {
     return check_reqs.check_all();
+};
+
+Api.version = function () {
+    return VERSION;
 };
 
 module.exports = Api;

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -88,7 +88,7 @@ function getBundleIdentifier (projectObject) {
  * @return {Promise}
  */
 function getDefaultSimulatorTarget () {
-    return require('./list-emulator-build-targets').run()
+    return require('./listEmulatorBuildTargets').run()
         .then(emulators => {
             let targetEmulator;
             if (emulators.length > 0) {
@@ -137,7 +137,7 @@ module.exports.run = buildOpts => {
         }
     }
 
-    return require('./list-devices').run()
+    return require('./listDevices').run()
         .then(devices => {
             if (devices.length > 0 && !(buildOpts.emulator)) {
                 // we also explicitly set device flag in options as we pass
@@ -155,7 +155,7 @@ module.exports.run = buildOpts => {
                     newTarget = newTarget.split(',')[0];
                 }
                 // a target was given to us, find the matching Xcode destination name
-                const promise = require('./list-emulator-build-targets').targetForSimIdentifier(newTarget);
+                const promise = require('./listEmulatorBuildTargets').targetForSimIdentifier(newTarget);
                 return promise.then(theTarget => {
                     if (!theTarget) {
                         return getDefaultSimulatorTarget().then(defaultTarget => {

--- a/bin/templates/scripts/cordova/lib/list-devices
+++ b/bin/templates/scripts/cordova/lib/list-devices
@@ -19,48 +19,10 @@
        under the License.
 */
 
-var Q = require('q');
-var exec = require('child_process').exec;
+const { run } = require('./listDevices');
 
-/**
- * Gets list of connected iOS devices
- * @return {Promise} Promise fulfilled with list of available iOS devices
- */
-function listDevices () {
-    var commands = [
-        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPad/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPad\"}'"),
-        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPhone/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPhone\"}'"),
-        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPod/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPod\"}'")
-    ];
-
-    // wrap al lexec calls into promises and wait until they're fullfilled
-    return Q.all(commands).then(function (results) {
-        var accumulator = [];
-        results.forEach(function (result) {
-            var devicefound;
-            // Each command promise resolves with array [stout, stderr], and we need stdout only
-            // Append stdout lines to accumulator
-            devicefound = result[0].trim().split('\n');
-            if (devicefound && devicefound.length) {
-                devicefound.forEach(function (device) {
-                    if (device) {
-                        accumulator.push(device);
-                    }
-                });
-            }
-        });
-        return accumulator;
+run().then(devices => {
+    devices.forEach(device => {
+        console.log(device);
     });
-}
-
-exports.run = listDevices;
-
-// Check if module is started as separate script.
-// If so, then invoke main method and print out results.
-if (!module.parent) {
-    listDevices().then(function (devices) {
-        devices.forEach(function (device) {
-            console.log(device);
-        });
-    });
-}
+});

--- a/bin/templates/scripts/cordova/lib/list-emulator-images
+++ b/bin/templates/scripts/cordova/lib/list-emulator-images
@@ -19,25 +19,10 @@
        under the License.
 */
 
-var Q = require('q');
-var iossim = require('ios-sim');
+const { run } = require('./listEmulatorImages');
 
-/**
- * Gets list of iOS devices available for simulation
- * @return {Promise} Promise fulfilled with list of devices available for simulation
- */
-function listEmulatorImages () {
-    return Q.resolve(iossim.getdevicetypes());
-}
-
-exports.run = listEmulatorImages;
-
-// Check if module is started as separate script.
-// If so, then invoke main method and print out results.
-if (!module.parent) {
-    listEmulatorImages().then(function (names) {
-        names.forEach(function (name) {
-            console.log(name);
-        });
+run().then(names => {
+    names.forEach(name => {
+        console.log(name);
     });
-}
+});

--- a/bin/templates/scripts/cordova/lib/list-started-emulators
+++ b/bin/templates/scripts/cordova/lib/list-started-emulators
@@ -19,31 +19,10 @@
        under the License.
 */
 
-var Q = require('q');
-var exec = require('child_process').exec;
+const { run } = require('./listStartedEmulators');
 
-/**
- * Gets list of running iOS simulators
- * @return {Promise} Promise fulfilled with list of running iOS simulators
- */
-function listStartedEmulators () {
-    // wrap exec call into promise
-    return Q.nfcall(exec, 'ps aux | grep -i "[i]OS Simulator"')
-        .then(function () {
-            return Q.nfcall(exec, 'defaults read com.apple.iphonesimulator "SimulateDevice"');
-        }).then(function (stdio) {
-            return stdio[0].trim().split('\n');
-        });
-}
-
-exports.run = listStartedEmulators;
-
-// Check if module is started as separate script.
-// If so, then invoke main method and print out results.
-if (!module.parent) {
-    listStartedEmulators().then(function (emulators) {
-        emulators.forEach(function (emulator) {
-            console.log(emulator);
-        });
+run().then(emulators => {
+    emulators.forEach(emulator => {
+        console.log(emulator);
     });
-}
+});

--- a/bin/templates/scripts/cordova/lib/listDevices.js
+++ b/bin/templates/scripts/cordova/lib/listDevices.js
@@ -1,0 +1,54 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+var Q = require('q');
+var exec = require('child_process').exec;
+
+/**
+ * Gets list of connected iOS devices
+ * @return {Promise} Promise fulfilled with list of available iOS devices
+ */
+function listDevices () {
+    var commands = [
+        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPad/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPad\"}'"),
+        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPhone/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPhone\"}'"),
+        Q.nfcall(exec, "ioreg -p IOUSB -l | sed -n -e '/iPod/,/USB Serial Number/p' | grep 'Serial Number' | awk -F\\\" '{print $4 \" iPod\"}'")
+    ];
+
+    // wrap al lexec calls into promises and wait until they're fullfilled
+    return Q.all(commands).then(function (results) {
+        var accumulator = [];
+        results.forEach(function (result) {
+            var devicefound;
+            // Each command promise resolves with array [stout, stderr], and we need stdout only
+            // Append stdout lines to accumulator
+            devicefound = result[0].trim().split('\n');
+            if (devicefound && devicefound.length) {
+                devicefound.forEach(function (device) {
+                    if (device) {
+                        accumulator.push(device);
+                    }
+                });
+            }
+        });
+        return accumulator;
+    });
+}
+
+exports.run = listDevices;

--- a/bin/templates/scripts/cordova/lib/listEmulatorBuildTargets.js
+++ b/bin/templates/scripts/cordova/lib/listEmulatorBuildTargets.js
@@ -1,0 +1,98 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+var Q = require('q');
+var exec = require('child_process').exec;
+
+/**
+ * Returns a list of available simulator build targets of the form
+ *
+ *     [
+ *         { name: <xcode-destination-name>,
+ *           identifier: <simctl-identifier>,
+ *           simIdentifier: <cordova emulate target>
+ *         }
+ *     ]
+ *
+ */
+function listEmulatorBuildTargets () {
+    return Q.nfcall(exec, 'xcrun simctl list --json')
+        .then(function (stdio) {
+            return JSON.parse(stdio[0]);
+        })
+        .then(function (simInfo) {
+            var devices = simInfo.devices;
+            var deviceTypes = simInfo.devicetypes;
+            return deviceTypes.reduce(function (typeAcc, deviceType) {
+                if (!deviceType.name.match(/^[iPad|iPhone]/)) {
+                // ignore targets we don't support (like Apple Watch or Apple TV)
+                    return typeAcc;
+                }
+                var availableDevices = Object.keys(devices).reduce(function (availAcc, deviceCategory) {
+                    var availableDevicesInCategory = devices[deviceCategory];
+                    availableDevicesInCategory.forEach(function (device) {
+                        if (device.name === deviceType.name || device.name === deviceType.name.replace(/-inch/g, ' inch')) {
+                        // Check new flag isAvailable (XCode 10.1+) or legacy string availability (XCode 10 and lower)
+                            if (device.isAvailable || (device.availability && device.availability.toLowerCase().indexOf('unavailable') < 0)) {
+                                availAcc.push(device);
+                            }
+                        }
+                    });
+                    return availAcc;
+                }, []);
+                // we only want device types that have at least one available device
+                // (regardless of OS); this filters things out like iPhone 4s, which
+                // is present in deviceTypes, but probably not available on the user's
+                // system.
+                if (availableDevices.length > 0) {
+                    typeAcc.push(deviceType);
+                }
+                return typeAcc;
+            }, []);
+        })
+        .then(function (filteredTargets) {
+        // the simIdentifier, or cordova emulate target name, is the very last part
+        // of identifier.
+            return filteredTargets.map(function (target) {
+                var identifierPieces = target.identifier.split('.');
+                target.simIdentifier = identifierPieces[identifierPieces.length - 1];
+                return target;
+            });
+        });
+}
+
+exports.run = listEmulatorBuildTargets;
+
+/**
+ * Given a simIdentifier, return the matching target.
+ *
+ * @param {string} simIdentifier       a target, like "iPhone-SE"
+ * @return {Object}                    the matching target, or undefined if no match
+ */
+exports.targetForSimIdentifier = function (simIdentifier) {
+    return listEmulatorBuildTargets()
+        .then(function (targets) {
+            return targets.reduce(function (acc, target) {
+                if (!acc && target.simIdentifier.toLowerCase() === simIdentifier.toLowerCase()) {
+                    acc = target;
+                }
+                return acc;
+            }, undefined);
+        });
+};

--- a/bin/templates/scripts/cordova/lib/listEmulatorImages.js
+++ b/bin/templates/scripts/cordova/lib/listEmulatorImages.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file
@@ -19,8 +17,15 @@
        under the License.
 */
 
-const { run } = require('./listEmulatorBuildTargets');
+var Q = require('q');
+var iossim = require('ios-sim');
 
-run().then(targets => {
-    console.log(JSON.stringify(targets, null, 2));
-});
+/**
+ * Gets list of iOS devices available for simulation
+ * @return {Promise} Promise fulfilled with list of devices available for simulation
+ */
+function listEmulatorImages () {
+    return Q.resolve(iossim.getdevicetypes());
+}
+
+exports.run = listEmulatorImages;

--- a/bin/templates/scripts/cordova/lib/listStartedEmulators.js
+++ b/bin/templates/scripts/cordova/lib/listStartedEmulators.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file
@@ -19,8 +17,21 @@
        under the License.
 */
 
-const { run } = require('./listEmulatorBuildTargets');
+var Q = require('q');
+var exec = require('child_process').exec;
 
-run().then(targets => {
-    console.log(JSON.stringify(targets, null, 2));
-});
+/**
+ * Gets list of running iOS simulators
+ * @return {Promise} Promise fulfilled with list of running iOS simulators
+ */
+function listStartedEmulators () {
+    // wrap exec call into promise
+    return Q.nfcall(exec, 'ps aux | grep -i "[i]OS Simulator"')
+        .then(function () {
+            return Q.nfcall(exec, 'defaults read com.apple.iphonesimulator "SimulateDevice"');
+        }).then(function (stdio) {
+            return stdio[0].trim().split('\n');
+        });
+}
+
+exports.run = listStartedEmulators;

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -46,7 +46,7 @@ module.exports.run = runOptions => {
 
     let useDevice = !!runOptions.device;
 
-    return require('./list-devices').run()
+    return require('./listDevices').run()
         .then(devices => {
             if (devices.length > 0 && !(runOptions.emulator)) {
                 useDevice = true;
@@ -174,7 +174,7 @@ function deployToSim (appPath, target) {
     events.emit('log', 'Deploying to simulator');
     if (!target) {
         // Select target device for emulator
-        return require('./list-emulator-images').run()
+        return require('./listEmulatorImages').run()
             .then(emulators => {
                 if (emulators.length > 0) {
                     target = emulators[0];
@@ -217,7 +217,7 @@ function iossimLaunch (appPath, devicetypeid, log, exit) {
 }
 
 function listDevices () {
-    return require('./list-devices').run()
+    return require('./listDevices').run()
         .then(devices => {
             events.emit('log', 'Available iOS Devices:');
             devices.forEach(device => {
@@ -227,7 +227,7 @@ function listDevices () {
 }
 
 function listEmulators () {
-    return require('./list-emulator-images').run()
+    return require('./listEmulatorImages').run()
         .then(emulators => {
             events.emit('log', 'Available iOS Simulators:');
             emulators.forEach(emulator => {

--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/scripts/cordova/version
+++ b/bin/templates/scripts/cordova/version
@@ -26,10 +26,6 @@
 */
 
 // Coho updates this line
-var VERSION = '6.0.0-dev';
+const Api = require('./Api');
 
-module.exports.version = VERSION;
-
-if (!module.parent) {
-    console.log(VERSION);
-}
+console.log(Api.version());

--- a/tests/spec/unit/lib/list-devices.spec.js
+++ b/tests/spec/unit/lib/list-devices.spec.js
@@ -17,10 +17,10 @@
        under the License.
 */
 
-const list_devices = require('../../../../bin/templates/scripts/cordova/lib/list-devices');
+const list_devices = require('../../../../bin/templates/scripts/cordova/lib/listDevices');
 const Q = require('q');
 
-describe('cordova/lib/list-devices', () => {
+describe('cordova/lib/listDevices', () => {
     describe('run method', () => {
         beforeEach(() => {
             spyOn(Q, 'all').and.returnValue(Q.resolve([]));

--- a/tests/spec/unit/lib/list-emulator-images.spec.js
+++ b/tests/spec/unit/lib/list-emulator-images.spec.js
@@ -22,10 +22,10 @@
 // allow for interacting with iOS Simulators. On Windows+Linux we are
 // bound to not-have-that.
 if (process.platform === 'darwin') {
-    const list_emus = require('../../../../bin/templates/scripts/cordova/lib/list-emulator-images');
+    const list_emus = require('../../../../bin/templates/scripts/cordova/lib/listEmulatorImages');
     const iossim = require('ios-sim');
 
-    describe('cordova/lib/list-emulator-images', () => {
+    describe('cordova/lib/listEmulatorImages', () => {
         describe('run method', () => {
             beforeEach(() => {
                 spyOn(iossim, 'getdevicetypes');


### PR DESCRIPTION
### Motivation and Context

Fix failing tests.
Bin files that contains the shebang interpreter fails when being required.

Example Error:

> /Users/travis/build/apache/cordova-ios/bin/templates/scripts/cordova/lib/list-devices:1
(function (exports, require, module, __filename, __dirname) { #!/usr/bin/env node
                                                              ^
> SyntaxError: Invalid or unexpected token

https://travis-ci.org/apache/cordova-ios/jobs/649198385#L1474

### Description

* Keep the bin files with the shebang interpreter but pull out all the code into a separate JS file. The bin files require the newly created JS files and execute them as usual.

* Update everywhere else that use to require the bin but now require the newly created JS files which do not contain the shebang interpreter.

**Additional Notes:**

The version bin file, which contains the platform version, is updated by coho during release. Coho should now update the version in `Api.js` instead. It would be better if the version is pulled from `package.json` but the platform-centered workflow does not have this file. Additional investigation to improve this should be done but preferably outside of this PR.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
