### PR TITLE
refactor: deprecate mediaPlaybackRequiresUserAction

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -74,7 +74,15 @@
     }
 
     configuration.allowsInlineMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowInlineMediaPlayback" defaultValue:NO];
-    configuration.mediaPlaybackRequiresUserAction = [settings cordovaBoolSettingForKey:@"MediaPlaybackRequiresUserAction" defaultValue:YES];
+
+    // Check for usage of the older preference key, alert, and use.
+    BOOL mediaTypesRequiringUserActionForPlayback = [settings cordovaBoolSettingForKey:@"MediaTypesRequiringUserActionForPlayback" defaultValue:YES];
+    NSString *mediaPlaybackRequiresUserActionKey = [settings cordovaSettingForKey:@"MediaPlaybackRequiresUserAction"];
+    if(mediaPlaybackRequiresUserActionKey != nil) {
+        mediaTypesRequiringUserActionForPlayback = [settings cordovaBoolSettingForKey:@"MediaPlaybackRequiresUserAction" defaultValue:YES];
+    }
+    configuration.mediaTypesRequiringUserActionForPlayback = mediaTypesRequiringUserActionForPlayback;
+
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
     configuration.mediaPlaybackAllowsAirPlay = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
     return configuration;

--- a/bin/templates/project/__PROJECT_NAME__/config.xml
+++ b/bin/templates/project/__PROJECT_NAME__/config.xml
@@ -53,7 +53,7 @@
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
-    <preference name="MediaPlaybackRequiresUserAction" value="false" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="SuppressesLongPressGesture" value="false" />
     <preference name="Suppresses3DTouchGesture" value="false" />

--- a/bin/templates/scripts/cordova/defaults.xml
+++ b/bin/templates/scripts/cordova/defaults.xml
@@ -27,7 +27,7 @@
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
-    <preference name="MediaPlaybackRequiresUserAction" value="false" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="SuppressesLongPressGesture" value="false" />
     <preference name="Suppresses3DTouchGesture" value="false" />

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -60,6 +60,9 @@ module.exports.prepare = function (cordovaProject, options) {
             updateFileResources(cordovaProject, this.locations);
         })
         .then(() => {
+            alertDeprecatedPreference(this._config);
+        })
+        .then(() => {
             events.emit('verbose', 'Prepared iOS project successfully');
         });
 };
@@ -515,6 +518,28 @@ function updateFileResources (cordovaProject, locations) {
         resourceMap, { rootDir: cordovaProject.root }, logFileOp);
 
     project.write();
+}
+
+function alertDeprecatedPreference (configParser) {
+    const deprecatedToNewPreferences = {
+        MediaPlaybackRequiresUserAction: 'MediaTypesRequiringUserActionForPlayback'
+    };
+
+    Object.keys(deprecatedToNewPreferences).forEach(oldKey => {
+        if (configParser.getPreference(oldKey)) {
+            const log = [`The preference name "${oldKey}" is being deprecated.`];
+
+            if (deprecatedToNewPreferences[oldKey]) {
+                log.push(`It is recommended to update this preference with "${deprecatedToNewPreferences[oldKey]}."`);
+            } else {
+                log.push(`There is no replacement for this preference.`);
+            }
+
+            log.push(`Please note that this preference will be removed in the near future.`);
+
+            events.emit('warn', log.join(' '));
+        }
+    });
 }
 
 function cleanFileResources (projectRoot, projectConfig, locations) {

--- a/tests/CordovaLibTests/CDVWebViewEngineTest.m
+++ b/tests/CordovaLibTests/CDVWebViewEngineTest.m
@@ -87,13 +87,10 @@
     id<CDVWebViewEngineProtocol> webViewEngineProtocol = self.plugin;
     WKWebView* wkWebView = (WKWebView*)self.plugin.engineWebView;
     
-    // iOS >=10 defaults to NO, < 10 defaults to YES.
-    BOOL mediaPlaybackRequiresUserActionDefault = IsAtLeastiOSVersion(@"10.0")? NO : YES;
-    
     NSDictionary* preferences = @{
                                [@"MinimumFontSize" lowercaseString] : @1.1, // default is 0.0
                                [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
-                               [@"MediaPlaybackRequiresUserAction" lowercaseString] : @(!mediaPlaybackRequiresUserActionDefault), // default is NO on iOS >= 10, YES for < 10
+                               [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @YES, // default is NO
                                [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
                                [@"MediaPlaybackAllowsAirPlay" lowercaseString] : @NO, // default is YES
                                [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO
@@ -108,11 +105,7 @@
     XCTAssertEqualWithAccuracy(wkWebView.configuration.preferences.minimumFontSize, 1.1, 0.0001);
     
     // the WKWebViewConfiguration properties, we **cannot** change outside of initialization
-    if (IsAtLeastiOSVersion(@"10.0")) {
-        XCTAssertFalse(wkWebView.configuration.mediaPlaybackRequiresUserAction);
-    } else {
-        XCTAssertTrue(wkWebView.configuration.mediaPlaybackRequiresUserAction);
-    }
+    XCTAssertTrue(wkWebView.configuration.mediaTypesRequiringUserActionForPlayback);
     XCTAssertFalse(wkWebView.configuration.allowsInlineMediaPlayback);
     XCTAssertFalse(wkWebView.configuration.suppressesIncrementalRendering);
     XCTAssertTrue(wkWebView.configuration.mediaPlaybackAllowsAirPlay);
@@ -137,13 +130,10 @@
     self.viewController = [[CDVViewController alloc] init];
     
     // generate the app settings
-    // iOS >=10 defaults to NO, < 10 defaults to YES.
-    BOOL mediaPlaybackRequiresUserActionDefault = IsAtLeastiOSVersion(@"10.0")? NO : YES;
-
     NSDictionary* settings = @{
                                   [@"MinimumFontSize" lowercaseString] : @1.1, // default is 0.0
                                   [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
-                                  [@"MediaPlaybackRequiresUserAction" lowercaseString] : @(!mediaPlaybackRequiresUserActionDefault), // default is NO on iOS >= 10, YES for < 10
+                                  [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @YES, // default is NO
                                   [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
                                   [@"MediaPlaybackAllowsAirPlay" lowercaseString] : @NO, // default is YES
                                   [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO
@@ -163,11 +153,7 @@
     XCTAssertEqualWithAccuracy(wkWebView.configuration.preferences.minimumFontSize, 1.1, 0.0001);
     
     // the WKWebViewConfiguration properties, we **cannot** change outside of initialization
-    if (IsAtLeastiOSVersion(@"10.0")) {
-        XCTAssertTrue(wkWebView.configuration.mediaPlaybackRequiresUserAction);
-    } else {
-        XCTAssertFalse(wkWebView.configuration.mediaPlaybackRequiresUserAction);
-    }
+    XCTAssertTrue(wkWebView.configuration.mediaTypesRequiringUserActionForPlayback);
     XCTAssertTrue(wkWebView.configuration.allowsInlineMediaPlayback);
     XCTAssertTrue(wkWebView.configuration.suppressesIncrementalRendering);
     // The test case below is in a separate test "testConfigurationWithMediaPlaybackAllowsAirPlay" (Apple bug)

--- a/tests/CordovaLibTests/CordovaLibApp/config.xml
+++ b/tests/CordovaLibTests/CordovaLibApp/config.xml
@@ -41,7 +41,7 @@
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
-    <preference name="MediaPlaybackRequiresUserAction" value="false" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="SuppressesLongPressGesture" value="true" />
     <preference name="Suppresses3DTouchGesture" value="false" />

--- a/tests/spec/unit/fixtures/ios-config-xml/SampleApp/config.xml
+++ b/tests/spec/unit/fixtures/ios-config-xml/SampleApp/config.xml
@@ -37,7 +37,7 @@
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
-    <preference name="MediaPlaybackRequiresUserAction" value="false" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="SuppressesLongPressGesture" value="false" />
     <preference name="Suppresses3DTouchGesture" value="false" />


### PR DESCRIPTION
### Motivation and Context

Apple has deprecated the `mediaPlaybackRequiresUserAction` property in iOS 8.0–9.0.
This property should be replaced with `mediaTypesRequiringUserActionForPlayback`.

https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/1614727-mediaplaybackrequiresuseraction

### Description

This PR:
* Updates the native side to use the new property name.
* Updates to read the new preference name (`MediaTypesRequiringUserActionForPlayback`) from `config.xml`
* Warn users that the preference is being deprecated in the near future if it is still being used.
* Fallback on the the value from the old preference name if it still remains.

### Testing

- `npm t`
- `cordova platform add`
- `cordova build ios`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] I've updated the documentation if necessary
