### PR TITLE
refactor: deprecate mediaPlaybackAllowsAirPlay

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -91,7 +91,7 @@
      */
     BOOL allowsAirPlayForMediaPlayback = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
     if([settings cordovaSettingForKey:@"AllowsAirPlayForMediaPlayback"] != nil) {
-        allowsAirPlayForMediaPlayback = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
+        allowsAirPlayForMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowsAirPlayForMediaPlayback" defaultValue:YES];
     }
     configuration.allowsAirPlayForMediaPlayback = allowsAirPlayForMediaPlayback;
 

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -84,7 +84,17 @@
     configuration.mediaTypesRequiringUserActionForPlayback = mediaTypesRequiringUserActionForPlayback;
 
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
-    configuration.mediaPlaybackAllowsAirPlay = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
+
+    /*
+     * If the old preference key "MediaPlaybackAllowsAirPlay" exists, use it or default to "YES".
+     * Check if the new preference key "AllowsAirPlayForMediaPlayback" exists and overwrite the "MediaPlaybackAllowsAirPlay" value.
+     */
+    BOOL allowsAirPlayForMediaPlayback = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
+    if([settings cordovaSettingForKey:@"AllowsAirPlayForMediaPlayback"] != nil) {
+        allowsAirPlayForMediaPlayback = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
+    }
+    configuration.allowsAirPlayForMediaPlayback = allowsAirPlayForMediaPlayback;
+
     return configuration;
 }
 

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -522,7 +522,8 @@ function updateFileResources (cordovaProject, locations) {
 
 function alertDeprecatedPreference (configParser) {
     const deprecatedToNewPreferences = {
-        MediaPlaybackRequiresUserAction: 'MediaTypesRequiringUserActionForPlayback'
+        MediaPlaybackRequiresUserAction: 'MediaTypesRequiringUserActionForPlayback',
+        MediaPlaybackAllowsAirPlay: 'AllowsAirPlayForMediaPlayback'
     };
 
     Object.keys(deprecatedToNewPreferences).forEach(oldKey => {

--- a/tests/CordovaLibTests/CDVWebViewEngineTest.m
+++ b/tests/CordovaLibTests/CDVWebViewEngineTest.m
@@ -92,7 +92,7 @@
                                [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
                                [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @YES, // default is NO
                                [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
-                               [@"MediaPlaybackAllowsAirPlay" lowercaseString] : @NO, // default is YES
+                               [@"AllowsAirPlayForMediaPlayback" lowercaseString] : @NO, // default is YES
                                [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO
                                [@"WKWebViewDecelerationSpeed" lowercaseString] : @"fast" // default is 'normal'
                                };
@@ -108,7 +108,7 @@
     XCTAssertTrue(wkWebView.configuration.mediaTypesRequiringUserActionForPlayback);
     XCTAssertFalse(wkWebView.configuration.allowsInlineMediaPlayback);
     XCTAssertFalse(wkWebView.configuration.suppressesIncrementalRendering);
-    XCTAssertTrue(wkWebView.configuration.mediaPlaybackAllowsAirPlay);
+    XCTAssertTrue(wkWebView.configuration.allowsAirPlayForMediaPlayback);
 
     // in the test above, DisallowOverscroll is YES, so no bounce
     if ([wkWebView respondsToSelector:@selector(scrollView)]) {
@@ -135,7 +135,7 @@
                                   [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
                                   [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @YES, // default is NO
                                   [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
-                                  [@"MediaPlaybackAllowsAirPlay" lowercaseString] : @NO, // default is YES
+                                  [@"AllowsAirPlayForMediaPlayback" lowercaseString] : @NO, // default is YES
                                   [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO
                                   [@"WKWebViewDecelerationSpeed" lowercaseString] : @"fast" // default is 'normal'
                                   };
@@ -157,7 +157,7 @@
     XCTAssertTrue(wkWebView.configuration.allowsInlineMediaPlayback);
     XCTAssertTrue(wkWebView.configuration.suppressesIncrementalRendering);
     // The test case below is in a separate test "testConfigurationWithMediaPlaybackAllowsAirPlay" (Apple bug)
-    // XCTAssertFalse(wkWebView.configuration.mediaPlaybackAllowsAirPlay);
+    // XCTAssertFalse(wkWebView.configuration.allowsAirPlayForMediaPlayback);
 
     // in the test above, DisallowOverscroll is YES, so no bounce
     if ([wkWebView respondsToSelector:@selector(scrollView)]) {


### PR DESCRIPTION
### Motivation and Context

Apple has deprecated the `mediaPlaybackAllowsAirPlay` property in iOS iOS 8.0-9.0.
This property should be replaced with `allowsAirPlayForMediaPlayback`.

https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/1614726-mediaplaybackallowsairplay

### Description

This PR:
* Updates the native side to use the new property name.
* Updates to read the new preference name (`AllowsAirPlayForMediaPlayback`) from `config.xml`
* Warn users that the preference is being deprecated in the near future if it is still being used.
* Fallback on the the value from the old preference name if it still remains.

### Testing

- `npm t`
- `cordova platform add`
- `cordova build ios`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] I've updated the documentation if necessary
