### PR TITLE
fix (CDVWebViewEngine): JavaScript to Native Call Not Working

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/config.xml
+++ b/bin/templates/project/__PROJECT_NAME__/config.xml
@@ -62,6 +62,9 @@
     <preference name="PaginationBreakingMode" value="page" /> <!-- page, column -->
     <preference name="PaginationMode" value="unpaginated" /> <!-- unpaginated, leftToRight, topToBottom, bottomToTop, rightToLeft -->
 
+    <feature name="CDVWebViewEngine">
+        <param name="ios-package" value="CDVWebViewEngine" />
+    </feature>
     <feature name="LocalStorage">
         <param name="ios-package" value="CDVLocalStorage"/>
     </feature>

--- a/bin/templates/scripts/cordova/defaults.xml
+++ b/bin/templates/scripts/cordova/defaults.xml
@@ -36,6 +36,9 @@
     <preference name="PaginationBreakingMode" value="page" /> <!-- page, column -->
     <preference name="PaginationMode" value="unpaginated" /> <!-- unpaginated, leftToRight, topToBottom, bottomToTop, rightToLeft -->
 
+    <feature name="CDVWebViewEngine">
+        <param name="ios-package" value="CDVWebViewEngine" />
+    </feature>
     <feature name="LocalStorage">
         <param name="ios-package" value="CDVLocalStorage"/>
     </feature>


### PR DESCRIPTION
### Motivation and Context

Fix error when calling WebViewEngine JavaScript Code.

### Description

When calling the WebViewEngine JavaScript

```
window.WkWebView.allowsBackForwardNavigationGestures(true);
```

The code does not process and an error displays in the Native logs,

> 2020-02-13 18:51:12.416046+0900 MyAppName[48951:8545412] ERROR: Plugin 'CDVWebViewEngine' not found, or is not a CDVPlugin. Check your plugin mapping in config.xml.
2020-02-13 18:51:12.416177+0900 MyAppName[48951:8545412] FAILED pluginJSON = ["INVALID","CDVWebViewEngine","allowsBackForwardNavigationGestures",[true]]

This PR adds the missing declaration which makes the JavaScript work again. 

### Testing

- `npm t`
- `cordova platform add`
- `cordova build ios`
- Run Simulator
- Test JavaScript method and verify execution

### Checklist

- [x] I've run the tests to see all new and existing tests pass
