### PR TITLE
chore: remove deprecated method viewDidUnload

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
@@ -77,13 +77,6 @@
     // Do any additional setup after loading the view from its nib.
 }
 
-- (void)viewDidUnload
-{
-    [super viewDidUnload];
-    // Release any retained subviews of the main view.
-    // e.g. self.myOutlet = nil;
-}
-
 /* Comment out the block below to over-ride */
 
 /*

--- a/tests/CordovaLibTests/CordovaLibApp/ViewController.m
+++ b/tests/CordovaLibTests/CordovaLibApp/ViewController.m
@@ -39,12 +39,6 @@
     // Do any additional setup after loading the view, typically from a nib.
 }
 
-- (void)viewDidUnload
-{
-    [super viewDidUnload];
-    // Release any retained subviews of the main view.
-}
-
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
     return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];

--- a/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Classes/MainViewController.m
+++ b/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Classes/MainViewController.m
@@ -77,13 +77,6 @@
     // Do any additional setup after loading the view from its nib.
 }
 
-- (void)viewDidUnload
-{
-    [super viewDidUnload];
-    // Release any retained subviews of the main view.
-    // e.g. self.myOutlet = nil;
-}
-
 /* Comment out the block below to over-ride */
 
 /*


### PR DESCRIPTION
### Motivation and Context

Remove deprecated code.
https://developer.apple.com/documentation/uikit/uiviewcontroller/1621383-viewdidunload

### Description

Deleted `viewDidUnload` usage.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
