### PR TITLE
fix: replace deprecated stringByAddingPercentEscapesUsingEncoding usage

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -388,7 +388,8 @@ static void * KVOContext = &KVOContext;
 
     NSURL* errorUrl = vc.errorURL;
     if (errorUrl) {
-        errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] relativeToURL:errorUrl];
+        NSCharacterSet *charSet = [NSCharacterSet URLFragmentAllowedCharacterSet];
+        errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEncodingWithAllowedCharacters:charSet]] relativeToURL:errorUrl];
         NSLog(@"%@", [errorUrl absoluteString]);
         [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
     }


### PR DESCRIPTION
### Motivation, Context & Description

Replace deprecated `stringByAddingPercentEscapesUsingEncoding` method with `stringByAddingPercentEncodingWithAllowedCharacters`

https://developer.apple.com/documentation/foundation/nsstring/1415058-stringbyaddingpercentescapesusin

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
