### PR TITLE
[BREAKING TEST] try removing internal -Info.plist filter - DO NOT MERGE

### DIFF
--- a/bin/templates/scripts/cordova/lib/projectFile.js
+++ b/bin/templates/scripts/cordova/lib/projectFile.js
@@ -41,7 +41,7 @@ function parseProjectFile (locations) {
     xcodeproj.parseSync();
 
     const xcBuildConfiguration = xcodeproj.pbxXCBuildConfigurationSection();
-    const plist_file_entry = _.find(xcBuildConfiguration, entry => entry.buildSettings && entry.buildSettings.INFOPLIST_FILE);
+    const plist_file_entry = _.find(xcBuildConfiguration, entry => entry.buildSettings);
     const plist_file = path.join(project_dir, plist_file_entry.buildSettings.INFOPLIST_FILE.replace(/^"(.*)"$/g, '$1').replace(/\\&/g, '&'));
     const config_file = path.join(path.dirname(plist_file), 'config.xml');
 


### PR DESCRIPTION
From review of changes proposed in PR #765, I discovered that the following change would not cause a test failure:

```diff
diff --git a/bin/templates/scripts/cordova/lib/projectFile.js b/bin/templates/scripts/cordova/lib/projectFile.js
index 35a5a917..6ab43422 100644
--- a/bin/templates/scripts/cordova/lib/projectFile.js
+++ b/bin/templates/scripts/cordova/lib/projectFile.js
@@ -41,7 +41,7 @@ function parseProjectFile (locations) {
     xcodeproj.parseSync();
 
     const xcBuildConfiguration = xcodeproj.pbxXCBuildConfigurationSection();
-    const plist_file_entry = _.find(xcBuildConfiguration, entry => entry.buildSettings && entry.buildSettings.INFOPLIST_FILE);
+    const plist_file_entry = _.find(xcBuildConfiguration, entry => entry.buildSettings);
     const plist_file = path.join(project_dir, plist_file_entry.buildSettings.INFOPLIST_FILE.replace(/^"(.*)"$/g, '$1').replace(/\\&/g, '&'));
     const config_file = path.join(path.dirname(plist_file), 'config.xml');
 
```

Considering that this internal filter needs to be adapted to resolve issue #764, I would conclude that this indicates a missing test case.

I think we need to add a test case for this we can proceed with further consideration of PR #765.