### PR TITLE
breaking: remove MediaPlaybackRequiresUserAction and update MediaTypesRequiringUserActionForPlayback to proper variable types

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -75,29 +75,21 @@
 
     configuration.allowsInlineMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowInlineMediaPlayback" defaultValue:NO];
 
-    /*
-     * If the old preference key "MediaPlaybackRequiresUserAction" exists, use it or default to "YES".
-     * Old to New Preference Mapping
-     *   YES = ALL
-     *   NO = NONE
-     * Check if the new preference key "MediaTypesRequiringUserActionForPlayback" exists and overwrite the "MediaPlaybackRequiresUserAction" value.
-     */
-    BOOL mediaPlaybackRequiresUserAction = [settings cordovaBoolSettingForKey:@"MediaPlaybackRequiresUserAction" defaultValue:YES];
-    WKAudiovisualMediaTypes mediaType = mediaPlaybackRequiresUserAction ? WKAudiovisualMediaTypeAll : WKAudiovisualMediaTypeNone;
+    // Set the media types that are required for user action for playback
+    WKAudiovisualMediaTypes mediaType = WKAudiovisualMediaTypeAll; // default
 
+    // targetMediaType will always exist, either from user's "config.xml" or default ("defaults.xml").
     id targetMediaType = [settings cordovaSettingForKey:@"MediaTypesRequiringUserActionForPlayback"];
-    if(targetMediaType != nil) {
-        if ([targetMediaType isEqualToString:@"none"]) {
-            mediaType = WKAudiovisualMediaTypeNone;
-        } else if ([targetMediaType isEqualToString:@"audio"]) {
-            mediaType = WKAudiovisualMediaTypeAudio;
-        } else if ([targetMediaType isEqualToString:@"video"]) {
-            mediaType = WKAudiovisualMediaTypeVideo;
-        } else if ([targetMediaType isEqualToString:@"all"]) {
-            mediaType = WKAudiovisualMediaTypeAll;
-        } else {
-            NSLog(@"Invalid \"MediaTypesRequiringUserActionForPlayback\" was detected. Fallback to default value.");
-        }
+    if ([targetMediaType isEqualToString:@"none"]) {
+        mediaType = WKAudiovisualMediaTypeNone;
+    } else if ([targetMediaType isEqualToString:@"audio"]) {
+        mediaType = WKAudiovisualMediaTypeAudio;
+    } else if ([targetMediaType isEqualToString:@"video"]) {
+        mediaType = WKAudiovisualMediaTypeVideo;
+    } else if ([targetMediaType isEqualToString:@"all"]) {
+        mediaType = WKAudiovisualMediaTypeAll;
+    } else {
+        NSLog(@"Invalid \"MediaTypesRequiringUserActionForPlayback\" was detected. Fallback to default value of \"all\" types.");
     }
     configuration.mediaTypesRequiringUserActionForPlayback = mediaType;
 

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -75,13 +75,31 @@
 
     configuration.allowsInlineMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowInlineMediaPlayback" defaultValue:NO];
 
-    // Check for usage of the older preference key, alert, and use.
-    BOOL mediaTypesRequiringUserActionForPlayback = [settings cordovaBoolSettingForKey:@"MediaTypesRequiringUserActionForPlayback" defaultValue:YES];
-    NSString *mediaPlaybackRequiresUserActionKey = [settings cordovaSettingForKey:@"MediaPlaybackRequiresUserAction"];
-    if(mediaPlaybackRequiresUserActionKey != nil) {
-        mediaTypesRequiringUserActionForPlayback = [settings cordovaBoolSettingForKey:@"MediaPlaybackRequiresUserAction" defaultValue:YES];
+    /*
+     * If the old preference key "MediaPlaybackRequiresUserAction" exists, use it or default to "YES".
+     * Old to New Preference Mapping
+     *   YES = ALL
+     *   NO = NONE
+     * Check if the new preference key "MediaTypesRequiringUserActionForPlayback" exists and overwrite the "MediaPlaybackRequiresUserAction" value.
+     */
+    BOOL mediaPlaybackRequiresUserAction = [settings cordovaBoolSettingForKey:@"MediaPlaybackRequiresUserAction" defaultValue:YES];
+    WKAudiovisualMediaTypes mediaType = mediaPlaybackRequiresUserAction ? WKAudiovisualMediaTypeAll : WKAudiovisualMediaTypeNone;
+
+    id targetMediaType = [settings cordovaSettingForKey:@"MediaTypesRequiringUserActionForPlayback"];
+    if(targetMediaType != nil) {
+        if ([targetMediaType isEqualToString:@"none"]) {
+            mediaType = WKAudiovisualMediaTypeNone;
+        } else if ([targetMediaType isEqualToString:@"audio"]) {
+            mediaType = WKAudiovisualMediaTypeAudio;
+        } else if ([targetMediaType isEqualToString:@"video"]) {
+            mediaType = WKAudiovisualMediaTypeVideo;
+        } else if ([targetMediaType isEqualToString:@"all"]) {
+            mediaType = WKAudiovisualMediaTypeAll;
+        } else {
+            NSLog(@"Invalid \"MediaTypesRequiringUserActionForPlayback\" was detected. Fallback to default value.");
+        }
     }
-    configuration.mediaTypesRequiringUserActionForPlayback = mediaTypesRequiringUserActionForPlayback;
+    configuration.mediaTypesRequiringUserActionForPlayback = mediaType;
 
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
 

--- a/bin/templates/scripts/cordova/defaults.xml
+++ b/bin/templates/scripts/cordova/defaults.xml
@@ -27,7 +27,7 @@
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
-    <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="SuppressesLongPressGesture" value="false" />
     <preference name="Suppresses3DTouchGesture" value="false" />

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -522,21 +522,40 @@ function updateFileResources (cordovaProject, locations) {
 
 function alertDeprecatedPreference (configParser) {
     const deprecatedToNewPreferences = {
-        MediaPlaybackRequiresUserAction: 'MediaTypesRequiringUserActionForPlayback',
-        MediaPlaybackAllowsAirPlay: 'AllowsAirPlayForMediaPlayback'
+        MediaPlaybackRequiresUserAction: {
+            newPreference: 'MediaTypesRequiringUserActionForPlayback',
+            isDeprecated: true
+        },
+        MediaPlaybackAllowsAirPlay: {
+            newPreference: 'AllowsAirPlayForMediaPlayback',
+            isDeprecated: false
+        }
     };
 
     Object.keys(deprecatedToNewPreferences).forEach(oldKey => {
         if (configParser.getPreference(oldKey)) {
-            const log = [`The preference name "${oldKey}" is being deprecated.`];
+            const isDeprecated = deprecatedToNewPreferences[oldKey].isDeprecated;
+            const verb = isDeprecated ? 'has been' : 'is being';
+            const newPreferenceKey = deprecatedToNewPreferences[oldKey].newPreference;
 
-            if (deprecatedToNewPreferences[oldKey]) {
-                log.push(`It is recommended to update this preference with "${deprecatedToNewPreferences[oldKey]}."`);
+            // Create the Log Message
+            const log = [`The preference name "${oldKey}" ${verb} deprecated.`];
+            if (newPreferenceKey) {
+                log.push(`It is recommended to replace this preference with "${newPreferenceKey}."`);
             } else {
                 log.push(`There is no replacement for this preference.`);
             }
 
-            log.push(`Please note that this preference will be removed in the near future.`);
+            /**
+             * If the preference has been deprecated, the usage of the old preference is no longer used.
+             * Therefore, the following line is not appended. It is added only if the old preference is still used.
+             * We are only keeping the top lines for deprecated items only for an additional major release when
+             * the pre-warning was not provided in a past major release due to a necessary quick deprecation.
+             * Typically caused by implementation nature or third-party requirement changes.
+             */
+            if (!isDeprecated) {
+                log.push(`Please note that this preference will be removed in the near future.`);
+            }
 
             events.emit('warn', log.join(' '));
         }

--- a/tests/CordovaLibTests/CDVWebViewEngineTest.m
+++ b/tests/CordovaLibTests/CDVWebViewEngineTest.m
@@ -90,7 +90,7 @@
     NSDictionary* preferences = @{
                                [@"MinimumFontSize" lowercaseString] : @1.1, // default is 0.0
                                [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
-                               [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @YES, // default is NO
+                               [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @"all", // default is NO
                                [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
                                [@"AllowsAirPlayForMediaPlayback" lowercaseString] : @NO, // default is YES
                                [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO
@@ -133,7 +133,7 @@
     NSDictionary* settings = @{
                                   [@"MinimumFontSize" lowercaseString] : @1.1, // default is 0.0
                                   [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
-                                  [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @YES, // default is NO
+                                  [@"MediaTypesRequiringUserActionForPlayback" lowercaseString] : @"all", // default is NO
                                   [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
                                   [@"AllowsAirPlayForMediaPlayback" lowercaseString] : @NO, // default is YES
                                   [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO


### PR DESCRIPTION
### Motivation and Context

`MediaPlaybackRequiresUserAction` was replaced with `MediaTypesRequiringUserActionForPlayback` in a previous PR. Since the `MediaTypesRequiringUserActionForPlayback` defaults will always exist in `defaults.xml`, `MediaPlaybackRequiresUserAction` will never be read. The old preference logic should actually be removed.

Additionally, the old preference `MediaPlaybackRequiresUserAction`  accepted `boolean` values but the new `MediaTypesRequiringUserActionForPlayback` preference does not accept boolean. This needs to be corrected to accept proper value types.

### Description

This PR removes all of `MediaPlaybackRequiresUserAction` logic except for the deprecated warning. The warning is used to provide users a migration step. It will be removed in a later release.

This PR has also updated the native code to pass in the correct variable types for the new 
`MediaTypesRequiringUserActionForPlayback` preference option.

Example valid preference option with proper values are:

```
<preference name="MediaTypesRequiringUserActionForPlayback" value="all" />
<preference name="MediaTypesRequiringUserActionForPlayback" value="audio" />
<preference name="MediaTypesRequiringUserActionForPlayback" value="video" />
<preference name="MediaTypesRequiringUserActionForPlayback" value="none" />
```

### Testing

- `npm t`
- `cordova platform add`
- `cordova build ios`
- Run in simulator

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I've updated the documentation if necessary
