### PR TITLE
refactor (cordovaBoolSettingForKey): improve boolean checks and native logging

### DIFF
--- a/CordovaLib/Classes/Public/NSDictionary+CordovaPreferences.m
+++ b/CordovaLib/Classes/Public/NSDictionary+CordovaPreferences.m
@@ -32,8 +32,37 @@
     BOOL value = defaultValue;
     id prefObj = [self cordovaSettingForKey:key];
 
-    if (prefObj != nil) {
-        value = [(NSNumber*)prefObj boolValue];
+    if (prefObj == nil) {
+        NSLog(@"The preference key \"%@\" is not defined and will default to \"%@\"",
+              key,
+              (defaultValue ? @"TRUE" : @"FALSE"));
+
+        return value;
+    }
+
+    if ([prefObj isKindOfClass:NSString.class]) {
+        prefObj = [prefObj lowercaseString];
+
+        if (
+            // True Case
+            [prefObj isEqualToString:@"true"] ||
+            [prefObj isEqualToString:@"1"] ||
+            // False Case
+            [prefObj isEqualToString:@"false"] ||
+            [prefObj isEqualToString:@"0"]
+            )
+        {
+            value = [prefObj isEqualToString:@"true"] || [prefObj isEqualToString:@"1"];
+        }
+    } else if (
+               [prefObj isKindOfClass:NSNumber.class] &&
+               (
+                [prefObj isEqual: @YES] ||
+                [prefObj isEqual: @NO]
+                )
+               )
+    {
+        value = [prefObj isEqual: @YES];
     }
 
     return value;


### PR DESCRIPTION
### Motivation and Context

Improve the boolean checks for preference settings and logging.

### Description

Updated the `cordovaBoolSettingForKey` method.

### Testing

- `npm t`
- `cordova platform add`
- `cordova build`
- Run in simulator and test with different values

### Checklist

- [x] I've run the tests to see all new and existing tests pass
