### PR TITLE
Remove dead link to wiki from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ Tests
 Futher reading
 -----
 * [http://cordova.apache.org/](http://cordova.apache.org/)
-* [http://wiki.apache.org/cordova/](http://wiki.apache.org/cordova/)


### PR DESCRIPTION
The wiki is moved to Confluence, and there is no Cordova content there. I've also checked the Cordova main site and there are no links to a wiki from there.