### PR TITLE
chore: remove deprecated orientation methods

### DIFF
--- a/CordovaLib/Classes/Public/CDVAppDelegate.m
+++ b/CordovaLib/Classes/Public/CDVAppDelegate.m
@@ -86,11 +86,7 @@
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000  
-- (NSUInteger)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window
-#else //CB-12098.  Defaults to UIInterfaceOrientationMask for iOS 9+
 - (UIInterfaceOrientationMask)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window
-#endif
 {
     // iPhone doesn't support upside down by default, while the iPad does.  Override to allow all orientations always, and let the root view controller decide what's allowed (the supported orientations mask gets intersected).
     NSUInteger supportedInterfaceOrientations = (1 << UIInterfaceOrientationPortrait) | (1 << UIInterfaceOrientationLandscapeLeft) | (1 << UIInterfaceOrientationLandscapeRight) | (1 << UIInterfaceOrientationPortraitUpsideDown);

--- a/CordovaLib/Classes/Public/CDVScreenOrientationDelegate.h
+++ b/CordovaLib/Classes/Public/CDVScreenOrientationDelegate.h
@@ -21,13 +21,8 @@
 
 @protocol CDVScreenOrientationDelegate <NSObject>
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000  
-- (NSUInteger)supportedInterfaceOrientations;  
-#else  
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations;
-#endif
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
 - (BOOL)shouldAutorotate;
 
 @end

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -450,12 +450,7 @@
     return YES;
 }
 
-// CB-12098
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
 {
     NSUInteger ret = 0;
 

--- a/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
@@ -77,30 +77,6 @@
     // Do any additional setup after loading the view from its nib.
 }
 
-/* Comment out the block below to over-ride */
-
-/*
-// CB-12098
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000  
-- (NSUInteger)supportedInterfaceOrientations
-#else  
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
-    return [super supportedInterfaceOrientations];
-}
-
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation 
-{
-    return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];
-}
-
-- (BOOL)shouldAutorotate 
-{
-    return [super shouldAutorotate];
-}
-*/
-
 @end
 
 @implementation MainCommandDelegate

--- a/tests/CordovaLibTests/CordovaLibApp/ViewController.m
+++ b/tests/CordovaLibTests/CordovaLibApp/ViewController.m
@@ -39,9 +39,4 @@
     // Do any additional setup after loading the view, typically from a nib.
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
-{
-    return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];
-}
-
 @end

--- a/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Classes/MainViewController.m
+++ b/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Classes/MainViewController.m
@@ -77,30 +77,6 @@
     // Do any additional setup after loading the view from its nib.
 }
 
-/* Comment out the block below to over-ride */
-
-/*
-// CB-12098
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000  
-- (NSUInteger)supportedInterfaceOrientations
-#else  
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
-    return [super supportedInterfaceOrientations];
-}
-
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation 
-{
-    return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];
-}
-
-- (BOOL)shouldAutorotate 
-{
-    return [super shouldAutorotate];
-}
-*/
-
 @end
 
 @implementation MainCommandDelegate


### PR DESCRIPTION
`- (NSUInteger)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window`, `- (NSUInteger)supportedInterfaceOrientations;` and  `- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation` were deprecated on iOS 6, remove the code as is not being used.

I think it's not breaking since we have the new methods that replaced them.

closes https://github.com/apache/cordova-ios/issues/821 