### PR TITLE
Change to use PROVISIONING_PROFILE_SPECIFIER for manual signing

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -185,7 +185,7 @@ module.exports.run = buildOpts => {
                 extraConfig += `CODE_SIGN_RESOURCE_RULES_PATH = ${buildOpts.codeSignResourceRules}\n`;
             }
             if (buildOpts.provisioningProfile) {
-                extraConfig += `PROVISIONING_PROFILE = ${buildOpts.provisioningProfile}\n`;
+                extraConfig += `PROVISIONING_PROFILE_SPECIFIER = ${buildOpts.provisioningProfile}\n`;
             }
             if (buildOpts.developmentTeam) {
                 extraConfig += `DEVELOPMENT_TEAM = ${buildOpts.developmentTeam}\n`;


### PR DESCRIPTION
For manual signing, when a build is started (using the new build system) platform/ios/cordova/lib/build.js creates file build-extras.xcconfig in platforms/ios/cordova. This incorrectly has
`PROVISIONING_PROFILE = profile name`
when it needs to have
`PROVISIONING_PROFILE_SPECIFIER = profile name`

### Platforms affected
Cordova ios 5.1.1

### Motivation and Context
If using manual signing then the provisioning profile not recognised
https://github.com/apache/cordova-ios/issues/536#issuecomment-610941360

### Description
When manually signing the file build-extras.xcconfig is created to specify extra parameters to send to xcodebuild as part of bin/templates/scripts/cordova/build-debug.xcconfig or build-release.xcconfig.
The provisioning profile name is specified currently for PROVISIONING_PROFILE.
To work, it has to be given for PROVISIONING_PROFILE_SPECIFIER.

### Testing
I've run the changed code locally in Xcode 11.4 in Catalina and in Xcode 11.3 in Mojave in a Travis build - see Travis build script here which changes the code using sed.
https://github.com/Freegle/iznik-nuxt/blob/app-ios/.travis.yml

Locally I've tested the code with a profile name and a profile UUID.

The branch passes Travis testing:
https://travis-ci.com/github/chriscant/cordova-ios/builds/159430800

The ios6.0.0-dev master builds fails in cordova-plugin-wkwebview-engine for me on my test environment. Within my branch it fails for the same reason.

As far as I can tell there is no test coverage for PROVISIONING_PROFILE.

### Checklist

- [X ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [ ] I've updated the documentation if necessary
