### PR TITLE
(iOS) Fix two compile-time type warnings and simplify code by using auto boxing of NSNumber.

### DIFF
--- a/CordovaLib/Classes/Public/CDVPluginResult.m
+++ b/CordovaLib/Classes/Public/CDVPluginResult.m
@@ -103,7 +103,7 @@ id messageFromMultipart(NSArray* theMessages)
 {
     self = [super init];
     if (self) {
-        status = [NSNumber numberWithInt:statusOrdinal];
+        status = @(statusOrdinal);
         message = theMessage;
         keepCallback = [NSNumber numberWithBool:NO];
     }

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -472,7 +472,7 @@
 
 - (BOOL)supportsOrientation:(UIInterfaceOrientation)orientation
 {
-    return [self.supportedOrientations containsObject:[NSNumber numberWithInt:orientation]];
+    return [self.supportedOrientations containsObject:@(orientation)];
 }
 
 - (UIView*)newCordovaViewWithFrame:(CGRect)bounds


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I hate disregarded warnings at compile time.

### Description
<!-- Describe your changes in detail -->

Existing code was converting to NSNumber with wrong init method for the type. 
Rather than change the method called I switched to auto boxing the values which automatically does the right thing in less code.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran npm test

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
