### PR TITLE
breaking: add & use fs-extra w/ fixes

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -20,7 +20,7 @@
 const shell = require('shelljs');
 const Q = require('q');
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
 const xmlescape = require('xml-escape');
 const ROOT = path.join(__dirname, '..', '..');
 const events = require('cordova-common').events;

--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -28,7 +28,7 @@
 // Coho updates this line
 const VERSION = '6.0.0-dev';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const unorm = require('unorm');
 const projectFile = require('./lib/projectFile');

--- a/bin/templates/scripts/cordova/lib/BridgingHeader.js
+++ b/bin/templates/scripts/cordova/lib/BridgingHeader.js
@@ -18,7 +18,7 @@
 */
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const CordovaError = require('cordova-common').CordovaError;
 
 function BridgingHeader (bridgingHeaderPath) {

--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -18,7 +18,7 @@
 */
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const util = require('util');
 const events = require('cordova-common').events;

--- a/bin/templates/scripts/cordova/lib/PodsJson.js
+++ b/bin/templates/scripts/cordova/lib/PodsJson.js
@@ -17,7 +17,7 @@
        under the License.
 */
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const util = require('util');
 const events = require('cordova-common').events;

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -21,7 +21,7 @@ const Q = require('q');
 const path = require('path');
 const shell = require('shelljs');
 const superspawn = require('cordova-common').superspawn;
-const fs = require('fs');
+const fs = require('fs-extra');
 const plist = require('plist');
 const util = require('util');
 

--- a/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
+++ b/bin/templates/scripts/cordova/lib/plugman/pluginHandlers.js
@@ -15,7 +15,7 @@
        under the License.
 */
 'use strict';
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const shell = require('shelljs');
 const util = require('util');

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -19,7 +19,7 @@
 
 'use strict';
 const Q = require('q');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const shell = require('shelljs');
 const unorm = require('unorm');

--- a/bin/templates/scripts/cordova/lib/projectFile.js
+++ b/bin/templates/scripts/cordova/lib/projectFile.js
@@ -21,7 +21,7 @@ const xcode = require('xcode');
 const plist = require('plist');
 const _ = require('underscore');
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
 const shell = require('shelljs');
 
 const pluginHandlers = require('./plugman/pluginHandlers');

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "cordova-common": "^4.0.1",
+    "fs-extra": "^9.0.0",
     "ios-sim": "^9.0.0",
     "nopt": "^4.0.3",
     "plist": "^3.0.1",

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -18,7 +18,7 @@
  */
 
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
 const EventEmitter = require('events');
 const PluginManager = require('cordova-common').PluginManager;
 const Api = require('../../../bin/templates/scripts/cordova/Api');

--- a/tests/spec/unit/BridgingHeader.spec.js
+++ b/tests/spec/unit/BridgingHeader.spec.js
@@ -17,7 +17,7 @@
  under the License.
  */
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 
 const BridgingHeader = require(path.resolve(path.join(__dirname, '..', '..', '..', 'bin', 'templates', 'scripts', 'cordova', 'lib', 'BridgingHeader.js'))).BridgingHeader;

--- a/tests/spec/unit/Plugman/common.spec.js
+++ b/tests/spec/unit/Plugman/common.spec.js
@@ -16,7 +16,7 @@
  *
 */
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const osenv = require('os');
 const shell = require('shelljs');
@@ -129,14 +129,14 @@ describe('common handler routines', () => {
     });
 
     describe('deleteJava', () => {
-        it('Test 009 : should call fs.unlinkSync on the provided paths', () => {
+        // This is testing that shelljs.rm is removing the source file.
+        it('Test 009 : source file should have been removed', () => {
             shell.mkdir('-p', srcDirTree);
             fs.writeFileSync(srcFile, 'contents', 'utf-8');
 
-            const s = spyOn(fs, 'unlinkSync').and.callThrough();
+            expect(fs.existsSync(srcFile)).toBe(true);
             removeFileAndParents(project_dir, srcFile);
-            expect(s).toHaveBeenCalled();
-            expect(s).toHaveBeenCalledWith(path.resolve(project_dir, srcFile));
+            expect(fs.existsSync(srcFile)).toBe(false);
 
             shell.rm('-rf', srcDirTree);
         });

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -18,7 +18,7 @@
 */
 
 const os = require('os');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const rewire = require('rewire');
 const shell = require('shelljs');

--- a/tests/spec/unit/Podfile.spec.js
+++ b/tests/spec/unit/Podfile.spec.js
@@ -19,7 +19,7 @@
 
 const path = require('path');
 const util = require('util');
-const fs = require('fs');
+const fs = require('fs-extra');
 const CordovaError = require('cordova-common').CordovaError;
 
 const PROJECT_NAME = 'testProj';

--- a/tests/spec/unit/PodsJson.spec.js
+++ b/tests/spec/unit/PodsJson.spec.js
@@ -17,7 +17,7 @@
        under the License.
 */
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const util = require('util');
 const CordovaError = require('cordova-common').CordovaError;

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-false.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-false.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="*" allows-arbitrary-loads-for-media="false" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-true.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="*" allows-arbitrary-loads-for-media="true" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-false.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-false.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="*" allows-arbitrary-loads-in-media="false" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-true.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="*" allows-arbitrary-loads-in-media="true" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-web-content-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-web-content-true.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="*" allows-arbitrary-loads-in-web-content="true" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/allows-local-networking-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-local-networking-true.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="*" allows-local-networking="true" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/set-origin-with-mixed-nsallows.xml
+++ b/tests/spec/unit/fixtures/prepare/set-origin-with-mixed-nsallows.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/wildcard-navigation-with-mixed-nsallows.xml
+++ b/tests/spec/unit/fixtures/prepare/wildcard-navigation-with-mixed-nsallows.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <allow-navigation href="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/wildcard-navigation.xml
+++ b/tests/spec/unit/fixtures/prepare/wildcard-navigation.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <allow-navigation href="*" />
+</widget>

--- a/tests/spec/unit/fixtures/prepare/wildcard-with-mixed-nsallows.xml
+++ b/tests/spec/unit/fixtures/prepare/wildcard-with-mixed-nsallows.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <access origin="*" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />
+</widget>

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -18,8 +18,7 @@
  */
 
 'use strict';
-const fs = require('fs');
-const fse = require('fs-extra');
+const fs = require('fs-extra');
 
 const EventEmitter = require('events');
 const os = require('os');
@@ -740,21 +739,7 @@ describe('prepare', () => {
         });
 
         it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsInWebContent', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="*" allows-arbitrary-loads-in-web-content="true" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
-
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'allows-arbitrary-loads-in-web-content-true.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -766,20 +751,7 @@ describe('prepare', () => {
         });
 
         it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia set (fixed allows-arbitrary-loads-for-media)', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="*" allows-arbitrary-loads-for-media="true" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'allows-arbitrary-loads-for-media-true.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -791,20 +763,7 @@ describe('prepare', () => {
         });
 
         it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia not set (fixed allows-arbitrary-loads-for-media)', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="*" allows-arbitrary-loads-for-media="false" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'allows-arbitrary-loads-for-media-false.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -816,20 +775,7 @@ describe('prepare', () => {
         });
 
         it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia set (deprecated allows-arbitrary-loads-in-media)', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="*" allows-arbitrary-loads-in-media="true" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'allows-arbitrary-loads-in-media-true.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -841,20 +787,7 @@ describe('prepare', () => {
         });
 
         it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsForMedia not set (deprecated allows-arbitrary-loads-in-media)', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="*" allows-arbitrary-loads-in-media="false" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'allows-arbitrary-loads-in-media-false.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -866,21 +799,7 @@ describe('prepare', () => {
         });
 
         it('<access> - should handle wildcard, with NSAllowsLocalNetworking', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="*" allows-local-networking="true" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
-
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'allows-local-networking-true.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -892,21 +811,7 @@ describe('prepare', () => {
         });
 
         it('<access> - should handle wildcard, with NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="*" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
-
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'wildcard-with-mixed-nsallows.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -917,21 +822,7 @@ describe('prepare', () => {
             });
         });
         it('<access> - sanity check - no wildcard but has NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<access origin="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
-
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'set-origin-with-mixed-nsallows.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(undefined);
@@ -1187,21 +1078,7 @@ describe('prepare', () => {
         /// ///////////////////////////////////////////////
 
         it('<allow-navigation> - should handle wildcard', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<allow-navigation href="*" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
-
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'wildcard-navigation.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(true);
@@ -1213,21 +1090,7 @@ describe('prepare', () => {
         });
 
         it('<allow-navigation> - sanity check - no wildcard but has NSAllowsArbitraryLoadsInWebContent, NSAllowsArbitraryLoadsForMedia, NSAllowsLocalNetworking', () => {
-            const origReadFile = fse.readFileSync;
-            const readFile = spyOn(fse, 'readFileSync');
-            const configXml = '<?xml version="1.0" encoding="UTF-8"?><widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0"><name>SampleApp</name>' +
-            '<allow-navigation href="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />' +
-            '</widget>';
-
-            readFile.and.callFake((...args) => {
-                if (args[0] === 'fake/path') {
-                    return configXml;
-                }
-                return origReadFile(...args);
-            });
-
-            const my_config = new ConfigParser('fake/path');
-
+            const my_config = new ConfigParser(path.join(FIXTURES, 'prepare', 'wildcard-navigation-with-mixed-nsallows.xml'));
             return updateProject(my_config, p.locations).then(() => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 expect(ats.NSAllowsArbitraryLoads).toEqual(undefined);

--- a/tests/spec/unit/preparePlatform.spec.js
+++ b/tests/spec/unit/preparePlatform.spec.js
@@ -18,7 +18,7 @@
  */
 
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
 const shell = require('shelljs');
 const EventEmitter = require('events').EventEmitter;
 const ConfigParser = require('cordova-common').ConfigParser;


### PR DESCRIPTION
### Motivation, Context & Description

* Add `fs-extra` dependency
* Replace `fs` usage with `fs-extra`
* Replace test spec xml generating logic and use pre-made xml test fixtures. Lower the amount of call mocks with actual tool usage for improved testing. 

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
