### PR TITLE
breaking: bump cordova-common@4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "cordova-common": "^3.1.0",
+    "cordova-common": "^4.0.1",
     "ios-sim": "^9.0.0",
     "nopt": "^4.0.3",
     "plist": "^3.0.1",


### PR DESCRIPTION
### Motivation and Context

Bump `cordova-common` dependency to latest version.

* cordova-common@^4.0.1

*NOTE: currently using a patch release git tag and will migrate to official released package before merging*

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
