### PR TITLE
breaking(pod): remove unused API & bump minimum version requirements to 1.8.0

### DIFF
--- a/bin/templates/scripts/cordova/lib/check_reqs.js
+++ b/bin/templates/scripts/cordova/lib/check_reqs.js
@@ -33,11 +33,8 @@ const IOS_DEPLOY_MIN_VERSION = '1.9.2';
 const IOS_DEPLOY_NOT_FOUND_MESSAGE =
     `Please download, build and install version ${IOS_DEPLOY_MIN_VERSION} or greater from https://github.com/ios-control/ios-deploy into your path, or do 'npm install -g ios-deploy'`;
 
-const COCOAPODS_MIN_VERSION = '1.0.1';
-const COCOAPODS_NOT_FOUND_MESSAGE =
-    `Please install version ${COCOAPODS_MIN_VERSION} or greater from https://cocoapods.org/`;
-const COCOAPODS_NOT_SYNCED_MESSAGE =
-    'The CocoaPods repo has not been synced yet, this will take a long time (approximately 500MB as of Sept 2016). Please run `pod setup` first to sync the repo.';
+const COCOAPODS_MIN_VERSION = '1.8.0';
+const COCOAPODS_NOT_FOUND_MESSAGE = `Please install version ${COCOAPODS_MIN_VERSION} or greater from https://cocoapods.org/`;
 
 /**
  * Checks if xcode util is available
@@ -66,43 +63,12 @@ function os_platform_is_supported () {
     return (SUPPORTED_OS_PLATFORMS.indexOf(process.platform) !== -1);
 }
 
-function check_cocoapod_tool (toolChecker) {
-    toolChecker = toolChecker || checkTool;
-    if (os_platform_is_supported()) { // CB-12856
-        return toolChecker('pod', COCOAPODS_MIN_VERSION, COCOAPODS_NOT_FOUND_MESSAGE, 'CocoaPods');
-    } else {
-        return Q.resolve({
-            ignore: true,
-            ignoreMessage: `CocoaPods check and installation ignored on ${process.platform}`
-        });
-    }
-}
-
 /**
- * Checks if cocoapods is available, and whether the repo is synced (because it takes a long time to download)
+ * Checks if cocoapods is available.
  * @return {Promise} Returns a promise either resolved or rejected
  */
 module.exports.check_cocoapods = toolChecker => {
-    return check_cocoapod_tool(toolChecker)
-        // check whether the cocoapods repo has been synced through `pod repo` command
-        // a value of '0 repos' means it hasn't been synced
-        .then(toolOptions => {
-            if (toolOptions.ignore) return toolOptions;
-
-            // starting with 1.8.0 cocoapods now use cdn and we dont need to sync first
-            if (versions.compareVersions(toolOptions.version, '1.8.0') >= 0) {
-                return toolOptions;
-            }
-
-            const code = shell.exec('pod repo | grep -e "^0 repos"', { silent: true }).code;
-            const repoIsSynced = (code !== 0);
-
-            if (repoIsSynced) {
-                return toolOptions;
-            } else {
-                return Promise.reject(COCOAPODS_NOT_SYNCED_MESSAGE);
-            }
-        });
+    return checkTool('pod', COCOAPODS_MIN_VERSION, COCOAPODS_NOT_FOUND_MESSAGE, 'CocoaPods');
 };
 
 /**

--- a/tests/spec/unit/lib/check_reqs.spec.js
+++ b/tests/spec/unit/lib/check_reqs.spec.js
@@ -66,48 +66,4 @@ describe('check_reqs', () => {
             );
         });
     });
-
-    describe('check_cocoapods method', () => {
-        let toolsChecker;
-        beforeEach(() => {
-            toolsChecker = jasmine.createSpy('toolsChecker')
-                .and.returnValue(Promise.resolve({ version: '1.2.3' }));
-        });
-
-        it('should resolve when on an unsupported platform', () => {
-            checkReqs.__set__({
-                os_platform_is_supported: () => false
-            });
-
-            return checkReqs.check_cocoapods(toolsChecker).then(toolOptions => {
-                expect(toolsChecker).not.toHaveBeenCalled();
-                expect(toolOptions.ignore).toBeDefined();
-                expect(toolOptions.ignoreMessage).toBeDefined();
-            });
-        });
-
-        it('should resolve when toolsChecker resolves', () => {
-            checkReqs.__set__({
-                os_platform_is_supported: () => true
-            });
-            spyOn(shell, 'exec').and.returnValue({ code: 1 });
-
-            return checkReqs.check_cocoapods(toolsChecker).then(() => {
-                expect(shell.exec).toHaveBeenCalled();
-            });
-        });
-
-        it('should reject when toolsChecker rejects', () => {
-            checkReqs.__set__({
-                os_platform_is_supported: () => true
-            });
-            const testError = new Error();
-            toolsChecker.and.callFake(() => Promise.reject(testError));
-
-            return checkReqs.check_cocoapods(toolsChecker).then(
-                () => fail('Expected promise to be rejected'),
-                err => expect(err).toBe(testError)
-            );
-        });
-    });
 });


### PR DESCRIPTION
### Motivation, Context, & Description

Improve `cocoapods` support by increasing the minimum required version and removing unused logic.

* Increase minimum supported version starting at 1.8.0
  * Since 1.8.0, CDN is enabled by default and is highly recommended as it no longer requires to checkout and sync the cocoapods repo. This greatly improves the speed.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
