### PR TITLE
chore (npm): add ignore list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,18 @@
+# Config related files
+.*
+
+# Testing, code coverage, and linting
+coverage
+tests
+appveyor.yml
+
+# Logging
+logs
+*.log
+npm-debug.log*
+
+# others
+guides
+hooks
+Cordova.podspec
+update_podspec.sh


### PR DESCRIPTION
### Motivation, Context & Description

- Add `.npmignore` file
- Remove files that are not needed to be packaged with the release build.
- Decrease package size

#### Before Ignore

```
=== Tarball Details ===
package size:  1.9 MB
unpacked size: 3.5 MB
total files:   390
```

#### After Ignore

```
=== Tarball Details ===
package size:  420.0 kB
unpacked size: 1.2 MB
total files:   185
```

### Testing

- `cordova platform add`
- `cordova build`
- `cordova run`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
