### PR TITLE
refactor: default to file scheme

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
@@ -45,10 +45,16 @@
 
 - (void)parserDidStartDocument:(NSXMLParser*)parser
 {
-    NSString* scheme = [NSString stringWithFormat:@"%@://",((CDVViewController*)self.viewController).appScheme];
     // file: url <allow-navigations> are added by default
     // navigation to the scheme used by the app is also allowed
-    self.allowNavigations = [[NSMutableArray alloc] initWithArray:@[ @"file://", scheme ]];
+    self.allowNavigations = [[NSMutableArray alloc] initWithArray:@[ @"file://"]];
+
+    // If the custom app scheme is defined, append it to the allow navigation as default
+    NSString* scheme = ((CDVViewController*)self.viewController).appScheme;
+    if (scheme) {
+        [self.allowNavigations addObject: [NSString stringWithFormat:@"%@://", scheme]];
+    }
+
     // no intents are added by default
     self.allowIntents = [[NSMutableArray alloc] init];
 }

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -160,9 +160,9 @@
         if(hostname == nil){
             hostname = @"localhost";
         }
-    }
 
-    self.CDV_ASSETS_URL = [NSString stringWithFormat:@"%@://%@", scheme, hostname];
+        self.CDV_ASSETS_URL = [NSString stringWithFormat:@"%@://%@", scheme, hostname];
+    }
 
     self.uiDelegate = [[CDVWebViewUIDelegate alloc] initWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]];
 
@@ -170,11 +170,14 @@
 
     WKUserContentController* userContentController = [[WKUserContentController alloc] init];
     [userContentController addScriptMessageHandler:weakScriptMessageHandler name:CDV_BRIDGE_NAME];
-    NSString * scriptCode = [NSString stringWithFormat:@"window.CDV_ASSETS_URL = '%@';", self.CDV_ASSETS_URL];
-    WKUserScript *wkScript =
-    [[WKUserScript alloc] initWithSource:scriptCode injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
-    if (wkScript) {
-        [userContentController addUserScript:wkScript];
+
+    if(self.CDV_ASSETS_URL) {
+        NSString *scriptCode = [NSString stringWithFormat:@"window.CDV_ASSETS_URL = '%@';", self.CDV_ASSETS_URL];
+        WKUserScript *wkScript = [[WKUserScript alloc] initWithSource:scriptCode injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+
+        if (wkScript) {
+            [userContentController addUserScript:wkScript];
+        }
     }
 
     WKWebViewConfiguration* configuration = [self createConfigurationFromSettings:settings];

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -44,6 +44,7 @@
 @property (nonatomic, weak) id <WKScriptMessageHandler> weakScriptMessageHandler;
 @property (nonatomic, strong) CDVURLSchemeHandler * schemeHandler;
 @property (nonatomic, readwrite) NSString *CDV_ASSETS_URL;
+@property (nonatomic, readwrite) Boolean cdvIsFileScheme;
 
 @end
 
@@ -143,15 +144,24 @@
     CDVViewController* vc = (CDVViewController*)self.viewController;
     NSDictionary* settings = self.commandDelegate.settings;
 
-    NSString *hostname = [settings cordovaSettingForKey:@"hostname"];
-    if(hostname == nil){
-        hostname = @"localhost";
-    }
     NSString *scheme = [settings cordovaSettingForKey:@"scheme"];
-    if(scheme == nil || [WKWebView handlesURLScheme:scheme]){
-        scheme = @"app";
+
+    // If scheme is file or nil, then default to file scheme
+    self.cdvIsFileScheme = [scheme isEqualToString: @"file"] || scheme == nil;
+
+    NSString *hostname = @"";
+    if(!self.cdvIsFileScheme) {
+        if(scheme == nil || [WKWebView handlesURLScheme:scheme]){
+            scheme = @"app";
+        }
+        vc.appScheme = scheme;
+
+        hostname = [settings cordovaSettingForKey:@"hostname"];
+        if(hostname == nil){
+            hostname = @"localhost";
+        }
     }
-    vc.appScheme = scheme;
+
     self.CDV_ASSETS_URL = [NSString stringWithFormat:@"%@://%@", scheme, hostname];
 
     self.uiDelegate = [[CDVWebViewUIDelegate alloc] initWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]];
@@ -170,8 +180,12 @@
     WKWebViewConfiguration* configuration = [self createConfigurationFromSettings:settings];
     configuration.userContentController = userContentController;
 
-    self.schemeHandler = [[CDVURLSchemeHandler alloc] initWithVC:vc];
-    [configuration setURLSchemeHandler:self.schemeHandler forURLScheme:scheme];
+    // Do not configure the scheme handler if the scheme is default (file)
+    if(!self.cdvIsFileScheme) {
+        self.schemeHandler = [[CDVURLSchemeHandler alloc] initWithVC:vc];
+        [configuration setURLSchemeHandler:self.schemeHandler forURLScheme:scheme];
+    }
+
     // re-create WKWebView, since we need to update configuration
     WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:self.engineWebView.frame configuration:configuration];
     wkWebView.UIDelegate = self.uiDelegate;
@@ -272,7 +286,10 @@ static void * KVOContext = &KVOContext;
 - (id)loadRequest:(NSURLRequest*)request
 {
     if ([self canLoadRequest:request]) { // can load, differentiate between file urls and other schemes
-        if (request.URL.fileURL) {
+        if(request.URL.fileURL && self.cdvIsFileScheme) {
+            NSURL* readAccessUrl = [request.URL URLByDeletingLastPathComponent];
+            return [(WKWebView*)_engineWebView loadFileURL:request.URL allowingReadAccessToURL:readAccessUrl];
+        } else if (request.URL.fileURL) {
             NSURL* startURL = [NSURL URLWithString:((CDVViewController *)self.viewController).startPage];
             NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
             NSURL *url = [[NSURL URLWithString:self.CDV_ASSETS_URL] URLByAppendingPathComponent:request.URL.path];

--- a/CordovaLib/cordova.js
+++ b/CordovaLib/cordova.js
@@ -1771,7 +1771,7 @@ var WkWebKit = {
         exec(null, null, 'CDVWebViewEngine', 'allowsBackForwardNavigationGestures', [allow]);
     },
     convertFilePath: function (path) {
-        if (!path) {
+        if (!path || !window.CDV_ASSETS_URL) {
             return path;
         }
         if (path.startsWith('/')) {

--- a/cordova-js-src/plugin/ios/wkwebkit.js
+++ b/cordova-js-src/plugin/ios/wkwebkit.js
@@ -26,7 +26,7 @@ var WkWebKit = {
         exec(null, null, 'CDVWebViewEngine', 'allowsBackForwardNavigationGestures', [allow]);
     },
     convertFilePath: function (path) {
-        if (!path) {
+        if (!path || !window.CDV_ASSETS_URL) {
             return path;
         }
         if (path.startsWith('/')) {


### PR DESCRIPTION
### Motivation and Context

Use `file` as default scheme to avoid break in current apps/

### Description

1. defaults to `file` if preference `scheme` is not set.
2. continue to uses `file` if preference scheme is set to `file`.
3. use what ever value the user defines in as preference `scheme` as a custom scheme handler, excluding `file` which was defined in the above case 2.
4. preference `hostname` is only used when `scheme` is not `file`.
5. `CDV_ASSETS_URL` is set to `<scheme>://<hostname>` 
  -> if `file`, `hostname = “”`.
  -> if `!file`, `hostname = "localhost"` or user define value for preference `hostname`.
6. Extension of above case 3, if `scheme` is set and is not `file`, it will also validate against `WKWebView handlesURLScheme`, if it is not valid, it will default to `app`
 
### Testing

- cordova build
- run in simulator

### Checklist

- [x] I've run the tests to see all new and existing tests pass
