### PR TITLE
refactor: bump eslint w/ lint fix & rebuilt package-lock

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -602,7 +602,7 @@ Api.prototype.setSwiftVersionForCocoaPodsLibraries = function (podsjsonFile) {
                         .map(buildConfiguration => buildConfiguration.value)
                         .forEach(buildId => {
                             __dirty = true;
-                            podConfigs[buildId].buildSettings['SWIFT_VERSION'] = swiftVersion;
+                            podConfigs[buildId].buildSettings.SWIFT_VERSION = swiftVersion;
                         });
                 }
             });

--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -320,7 +320,7 @@ Podfile.prototype.write = function () {
                 .map(tag => `:${tag} => '${json[tag]}'`);
 
             if ('configurations' in json) {
-                options.push(`:configurations => [${json['configurations'].split(',').map(conf => `'${conf.trim()}'`).join(',')}]`);
+                options.push(`:configurations => [${json.configurations.split(',').map(conf => `'${conf.trim()}'`).join(',')}]`);
             }
             if ('options' in json) {
                 options = [json.options];

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -190,24 +190,24 @@ function updateProject (platformConfig, locations) {
     const infoPlist = plist.parse(fs.readFileSync(plistFile, 'utf8'));
 
     // Update version (bundle version)
-    infoPlist['CFBundleShortVersionString'] = version;
+    infoPlist.CFBundleShortVersionString = version;
     const CFBundleVersion = platformConfig.getAttribute('ios-CFBundleVersion') || default_CFBundleVersion(version);
-    infoPlist['CFBundleVersion'] = CFBundleVersion;
+    infoPlist.CFBundleVersion = CFBundleVersion;
 
     if (platformConfig.getAttribute('defaultlocale')) {
-        infoPlist['CFBundleDevelopmentRegion'] = platformConfig.getAttribute('defaultlocale');
+        infoPlist.CFBundleDevelopmentRegion = platformConfig.getAttribute('defaultlocale');
     }
 
     if (displayName) {
-        infoPlist['CFBundleDisplayName'] = displayName;
+        infoPlist.CFBundleDisplayName = displayName;
     }
 
     // replace Info.plist ATS entries according to <access> and <allow-navigation> config.xml entries
     const ats = writeATSEntries(platformConfig);
     if (Object.keys(ats).length > 0) {
-        infoPlist['NSAppTransportSecurity'] = ats;
+        infoPlist.NSAppTransportSecurity = ats;
     } else {
-        delete infoPlist['NSAppTransportSecurity'];
+        delete infoPlist.NSAppTransportSecurity;
     }
 
     handleOrientationSettings(platformConfig, infoPlist);
@@ -242,24 +242,24 @@ function updateProject (platformConfig, locations) {
 function handleOrientationSettings (platformConfig, infoPlist) {
     switch (getOrientationValue(platformConfig)) {
     case 'portrait':
-        infoPlist['UIInterfaceOrientation'] = ['UIInterfaceOrientationPortrait'];
-        infoPlist['UISupportedInterfaceOrientations'] = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown'];
+        infoPlist.UIInterfaceOrientation = ['UIInterfaceOrientationPortrait'];
+        infoPlist.UISupportedInterfaceOrientations = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown'];
         infoPlist['UISupportedInterfaceOrientations~ipad'] = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown'];
         break;
     case 'landscape':
-        infoPlist['UIInterfaceOrientation'] = ['UIInterfaceOrientationLandscapeLeft'];
-        infoPlist['UISupportedInterfaceOrientations'] = ['UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
+        infoPlist.UIInterfaceOrientation = ['UIInterfaceOrientationLandscapeLeft'];
+        infoPlist.UISupportedInterfaceOrientations = ['UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
         infoPlist['UISupportedInterfaceOrientations~ipad'] = ['UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
         break;
     case 'all':
-        infoPlist['UIInterfaceOrientation'] = ['UIInterfaceOrientationPortrait'];
-        infoPlist['UISupportedInterfaceOrientations'] = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
+        infoPlist.UIInterfaceOrientation = ['UIInterfaceOrientationPortrait'];
+        infoPlist.UISupportedInterfaceOrientations = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
         infoPlist['UISupportedInterfaceOrientations~ipad'] = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
         break;
     case 'default':
-        infoPlist['UISupportedInterfaceOrientations'] = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
+        infoPlist.UISupportedInterfaceOrientations = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
         infoPlist['UISupportedInterfaceOrientations~ipad'] = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight'];
-        delete infoPlist['UIInterfaceOrientation'];
+        delete infoPlist.UIInterfaceOrientation;
     }
 }
 
@@ -461,7 +461,7 @@ function alertDeprecatedPreference (configParser) {
             if (newPreferenceKey) {
                 log.push(`It is recommended to replace this preference with "${newPreferenceKey}."`);
             } else {
-                log.push(`There is no replacement for this preference.`);
+                log.push('There is no replacement for this preference.');
             }
 
             /**
@@ -472,7 +472,7 @@ function alertDeprecatedPreference (configParser) {
              * Typically caused by implementation nature or third-party requirement changes.
              */
             if (!isDeprecated) {
-                log.push(`Please note that this preference will be removed in the near future.`);
+                log.push('Please note that this preference will be removed in the near future.');
             }
 
             events.emit('warn', log.join(' '));
@@ -957,17 +957,17 @@ function writeATSEntries (config) {
             if (hostname === '*') {
                 // always write this, for iOS 9, since in iOS 10 it will be overriden if
                 // any of the other three keys are written
-                ats['NSAllowsArbitraryLoads'] = true;
+                ats.NSAllowsArbitraryLoads = true;
 
                 // at least one of the overriding keys is present
                 if (entry.NSAllowsArbitraryLoadsInWebContent) {
-                    ats['NSAllowsArbitraryLoadsInWebContent'] = true;
+                    ats.NSAllowsArbitraryLoadsInWebContent = true;
                 }
                 if (entry.NSAllowsArbitraryLoadsForMedia) {
-                    ats['NSAllowsArbitraryLoadsForMedia'] = true;
+                    ats.NSAllowsArbitraryLoadsForMedia = true;
                 }
                 if (entry.NSAllowsLocalNetworking) {
-                    ats['NSAllowsLocalNetworking'] = true;
+                    ats.NSAllowsLocalNetworking = true;
                 }
 
                 continue;
@@ -981,11 +981,11 @@ function writeATSEntries (config) {
                 }
             }
 
-            if (!ats['NSExceptionDomains']) {
-                ats['NSExceptionDomains'] = {};
+            if (!ats.NSExceptionDomains) {
+                ats.NSExceptionDomains = {};
             }
 
-            ats['NSExceptionDomains'][hostname] = exceptionDomain;
+            ats.NSExceptionDomains[hostname] = exceptionDomain;
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
-      "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.0.tgz",
+      "integrity": "sha512-FGgV2XyPoVtYDvbFXlukEWt13Afka4mBRQ2CoTsHxpgVGO6XfgtT6eI+WyjQRGGTL90IDkIVmme8riFCLZ8lUw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.6",
+        "@babel/generator": "^7.10.0",
         "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helpers": "^7.9.6",
-        "@babel/parser": "^7.9.6",
-        "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.9.6",
-        "@babel/types": "^7.9.6",
+        "@babel/helpers": "^7.10.0",
+        "@babel/parser": "^7.10.0",
+        "@babel/template": "^7.10.0",
+        "@babel/traverse": "^7.10.0",
+        "@babel/types": "^7.10.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -46,12 +46,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
-      "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.0.tgz",
+      "integrity": "sha512-ThoWCJHlgukbtCP79nAK4oLqZt5fVo70AHUni/y8Jotyg5rtJiG2FVl+iJjRNKIyl4hppqztLyAoEWcCvqyOFQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.9.6",
+        "@babel/types": "^7.10.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -78,12 +78,12 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.0.tgz",
+      "integrity": "sha512-xKLTpbMkJcvwEsDaTfs9h0IlfUiBLPFfybxaPpPPsQDsZTRg+UKh+86oK7sctHF3OUiRQkb10oS9MXSqgyV6/g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.0"
       }
     },
     "@babel/helper-module-imports": {
@@ -111,24 +111,24 @@
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.0.tgz",
+      "integrity": "sha512-HgMd8QKA8wMJs5uK/DYKdyzJAEuGt1zyDp9wLMlMR6LitTQTHPUE+msC82ZsEDwq+U3/yHcIXIngRm9MS4IcIg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.0"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
-      "integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.0.tgz",
+      "integrity": "sha512-erl4iVeiANf14JszXP7b69bSrz3e3+qW09pVvEmTWwzRQEOoyb1WFlYCA8d/VjVZGYW8+nGpLh7swf9CifH5wg==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.9.6",
-        "@babel/types": "^7.9.6"
+        "@babel/helper-member-expression-to-functions": "^7.10.0",
+        "@babel/helper-optimise-call-expression": "^7.10.0",
+        "@babel/traverse": "^7.10.0",
+        "@babel/types": "^7.10.0"
       }
     },
     "@babel/helper-simple-access": {
@@ -157,14 +157,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
-      "integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.0.tgz",
+      "integrity": "sha512-lQtFJoDZAGf/t2PgR6Z59Q2MwjvOGGsxZ0BAlsrgyDhKuMbe63EfbQmVmcLfyTBj8J4UtiadQimcotvYVg/kVQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.9.6",
-        "@babel/types": "^7.9.6"
+        "@babel/template": "^7.10.0",
+        "@babel/traverse": "^7.10.0",
+        "@babel/types": "^7.10.0"
       }
     },
     "@babel/highlight": {
@@ -179,34 +179,34 @@
       }
     },
     "@babel/parser": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
-      "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.0.tgz",
+      "integrity": "sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.0.tgz",
+      "integrity": "sha512-aMLEQn5tcG49LEWrsEwxiRTdaJmvLem3+JMCMSeCy2TILau0IDVyWdm/18ACx7XOCady64FLt6KkHy28tkDQHQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/parser": "^7.10.0",
+        "@babel/types": "^7.10.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
-      "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.0.tgz",
+      "integrity": "sha512-NZsFleMaLF1zX3NxbtXI/JCs2RPOdpGru6UBdGsfhdsDsP+kFF+h2QQJnMJglxk0kc69YmMFs4A44OJY0tKo5g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.6",
+        "@babel/generator": "^7.10.0",
         "@babel/helper-function-name": "^7.9.5",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.6",
-        "@babel/types": "^7.9.6",
+        "@babel/parser": "^7.10.0",
+        "@babel/types": "^7.10.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -221,9 +221,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
-      "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.0.tgz",
+      "integrity": "sha512-t41W8yWFyQFPOAAvPvjyRhejcLGnJTA3iRpFcDbEKwVJ3UnHQePFzLk8GagTsucJlImyNwrGikGsYURrWbQG8w==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.5",
@@ -232,16 +232,15 @@
       }
     },
     "@cordova/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@cordova/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-Wz0fYU1MohlVaB3938EWBCg1MfSbaevg3ZBXTdrpMBrwXaWTAuV/Z5m/KKbw0xOQmP3POtBOeDxNy9VbkmyUOg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cordova/eslint-config/-/eslint-config-3.0.0.tgz",
+      "integrity": "sha512-YOZn/G5foKFzZc8R/oBM+BLG6vHufOmZiJtiZHNxifsrqzORwyjq1EiUSvQ6s0bm6Ydh3zwwyuGVbYyDBil67w==",
       "dev": true,
       "requires": {
-        "eslint": "^6.6.0",
-        "eslint-config-semistandard": "^15.0.0",
-        "eslint-config-standard": "^13.0.1",
-        "eslint-plugin-import": "^2.18.2",
-        "eslint-plugin-node": "^10.0.0",
+        "eslint": "^6.8.0",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.20.1",
+        "eslint-plugin-node": "^11.0.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^4.0.1"
       }
@@ -693,9 +692,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-      "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -934,16 +933,10 @@
         }
       }
     },
-    "eslint-config-semistandard": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-15.0.0.tgz",
-      "integrity": "sha512-volIMnosUvzyxGkYUA5QvwkahZZLeUx7wcS0+7QumPn+MMEBbV6P7BY1yukamMst0w3Et3QZlCjQEwQ8tQ6nug==",
-      "dev": true
-    },
     "eslint-config-standard": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-13.0.1.tgz",
-      "integrity": "sha512-zLKp4QOgq6JFgRm1dDCVv1Iu0P5uZ4v5Wa4DTOkg2RFMxdCX/9Qf7lz9ezRj2dBRa955cWQF/O/LWEiYWAHbTw==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
+      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -1001,15 +994,24 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
-      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^1.4.2",
+        "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
       },
       "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
         "regexpp": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -1066,23 +1068,32 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
-      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^2.0.0",
-        "eslint-utils": "^1.4.2",
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
         "ignore": "^5.1.1",
         "minimatch": "^3.0.4",
         "resolve": "^1.10.1",
         "semver": "^6.1.0"
       },
       "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
         "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz",
+          "integrity": "sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA==",
           "dev": true
         },
         "semver": {
@@ -1942,9 +1953,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2773,9 +2784,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@cordova/eslint-config": "^2.0.0",
+    "@cordova/eslint-config": "^3.0.0",
     "find-process": "^1.4.3",
     "jasmine": "^3.5.0",
     "nyc": "^15.0.1",

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -516,9 +516,9 @@ describe('Platform Api', () => {
                         });
                 });
                 it('on a last library, it should remove a json from libraries', () => {
-                    const json1 = Object.assign({}, my_pod_json.libraries['AFNetworking'], { count: 1 });
-                    const json2 = Object.assign({}, my_pod_json.libraries['Eureka'], { count: 1 });
-                    const json3 = Object.assign({}, my_pod_json.libraries['HogeLib'], { count: 1 });
+                    const json1 = Object.assign({}, my_pod_json.libraries.AFNetworking, { count: 1 });
+                    const json2 = Object.assign({}, my_pod_json.libraries.Eureka, { count: 1 });
+                    const json3 = Object.assign({}, my_pod_json.libraries.HogeLib, { count: 1 });
                     podsjson_mock.getLibrary.and.callFake(name => {
                         if (name === json1.name) {
                             return json1;
@@ -549,9 +549,9 @@ describe('Platform Api', () => {
                         });
                 });
                 it('should decrement count in libraries and does not remove if count > 1', () => {
-                    const json1 = Object.assign({}, my_pod_json.libraries['AFNetworking'], { count: 2 });
-                    const json2 = Object.assign({}, my_pod_json.libraries['Eureka'], { count: 1 });
-                    const json3 = Object.assign({}, my_pod_json.libraries['HogeLib'], { count: 1 });
+                    const json1 = Object.assign({}, my_pod_json.libraries.AFNetworking, { count: 2 });
+                    const json2 = Object.assign({}, my_pod_json.libraries.Eureka, { count: 1 });
+                    const json3 = Object.assign({}, my_pod_json.libraries.HogeLib, { count: 1 });
                     podsjson_mock.getLibrary.and.callFake(name => {
                         if (name === json1.name) {
                             return json1;

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -271,7 +271,8 @@ describe('prepare', () => {
                     'Default@2x~universal~anyany.png': 'res/screen/ios/Default@2x~universal~anyany.png',
                     'Default@3x~universal~comany.png': 'res/screen/ios/Default@3x~universal~comany.png',
                     'Default@3x~universal~anycom.png': 'res/screen/ios/Default@3x~universal~anycom.png',
-                    'Default@3x~universal~anyany.png': 'res/screen/ios/Default@3x~universal~anyany.png' };
+                    'Default@3x~universal~anyany.png': 'res/screen/ios/Default@3x~universal~anyany.png'
+                };
                 // update keys with path to storyboardImagesDir
                 for (const k in expectedResourceMap) {
                     if (Object.prototype.hasOwnProperty.call(expectedResourceMap, k)) {
@@ -320,7 +321,8 @@ describe('prepare', () => {
                     'Default@2x~universal~anyany.png': null,
                     'Default@3x~universal~comany.png': null,
                     'Default@3x~universal~anycom.png': null,
-                    'Default@3x~universal~anyany.png': null };
+                    'Default@3x~universal~anyany.png': null
+                };
                 // update keys with path to storyboardImagesDir
                 for (const k in expectedResourceMap) {
                     if (Object.prototype.hasOwnProperty.call(expectedResourceMap, k)) {
@@ -1287,8 +1289,8 @@ describe('prepare', () => {
                 const ats = plist.build.calls.mostRecent().args[0].NSAppTransportSecurity;
                 const exceptionDomains = ats.NSExceptionDomains;
                 expect(exceptionDomains['']).toBeUndefined();
-                expect(exceptionDomains['null']).toBeUndefined();
-                expect(exceptionDomains['undefined']).toBeUndefined();
+                expect(exceptionDomains.null).toBeUndefined();
+                expect(exceptionDomains.undefined).toBeUndefined();
             });
         });
         it('Test#020 : <name> - should write out the display name to info plist as CFBundleDisplayName', () => {


### PR DESCRIPTION
### Motivation, Context & Description

- Use our latest version of ESlint config dev dependency.
- Apply lint corrections
- Include a rebuilt `package-lock.json`

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
