### PR TITLE
fix: remove q leftover

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -68,4 +68,4 @@ var options = {
 
 require('./templates/scripts/cordova/loggingHelper').adjustLoggerLevel(argv);
 
-Api.createPlatform(projectPath, config, options).done();
+Api.createPlatform(projectPath, config, options);


### PR DESCRIPTION
### Motivation, Context & Description

* Remove leftover q
* Causes an issue when creating project with create binary.

```
TypeError: Api.createPlatform(...).done is not a function
```

### Testing

- create project with binary.

```bash
./bin/create /tmp/cdvTest com.foobar.cdvTest cdvTest
Creating Cordova project for the iOS platform:
	Path: ../../../../../../../../tmp/cordova-coho-tests/iosTest2
	Package: com.foobar.cdvTest
	Name: cdvTest
iOS project created with cordova-ios@6.0.0-dev
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
