### PR TITLE
Don't silently ignore creation of new windows

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -174,7 +174,9 @@
         self.CDV_ASSETS_URL = [NSString stringWithFormat:@"%@://%@", scheme, hostname];
     }
 
-    self.uiDelegate = [[CDVWebViewUIDelegate alloc] initWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]];
+    CDVWebViewUIDelegate* uiDelegate = [[CDVWebViewUIDelegate alloc] initWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]];
+    uiDelegate.allowNewWindows = [settings cordovaBoolSettingForKey:@"AllowNewWindows" defaultValue:NO];
+    self.uiDelegate = uiDelegate;
 
     CDVWebViewWeakScriptMessageHandler *weakScriptMessageHandler = [[CDVWebViewWeakScriptMessageHandler alloc] initWithScriptMessageHandler:self];
 

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
@@ -20,8 +20,12 @@
 #import <WebKit/WebKit.h>
 
 @interface CDVWebViewUIDelegate : NSObject <WKUIDelegate>
+{
+    NSMutableArray<UIViewController*>* windows;
+}
 
 @property (nonatomic, copy) NSString* title;
+@property (nonatomic, assign) BOOL allowNewWindows;
 
 - (instancetype)initWithTitle:(NSString*)title;
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, attempts to create new windows (via links with `target="_blank"` or JS `window.open`) for pages within the application have no effect and are silently ignored. (Links to pages outside the application trigger the allow-intent functionality and open in Safari.)


### Description
<!-- Describe your changes in detail -->
With this PR, the default behaviour will be to open those links in the **same** Web View (without creating a new window).

This also introduces a preference (`AllowNewWindows`) that allows the creation of a new UIViewController to present the new page in a new Web View frame on top of the existing Web View.
**Note:** This new window provides no controls, so it can only be closed with `window.close()` in JS.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing in a new Cordova app.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] I've updated the documentation if necessary
