### PR TITLE
Add PreferredContentMode preference

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -137,9 +137,9 @@
 
     if (@available(iOS 13.0, *)) {
         NSString *contentMode = [settings cordovaSettingForKey:@"PreferredContentMode"];
-        if ([contentMode  isEqual: @"mobile"]) {
+        if ([contentMode isEqual: @"mobile"]) {
             configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
-        } else if ([contentMode  isEqual: @"desktop"]) {
+        } else if ([contentMode isEqual: @"desktop"]) {
             configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
         }
         

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -135,6 +135,16 @@
     }
     configuration.applicationNameForUserAgent = userAgent;
 
+    if (@available(iOS 13.0, *)) {
+        NSString *contentMode = [settings cordovaSettingForKey:@"PreferredContentMode"];
+        if ([contentMode  isEqual: @"mobile"]) {
+            configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
+        } else if ([contentMode  isEqual: @"desktop"]) {
+            configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
+        }
+        
+    }
+
     return configuration;
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This adds a prefrence to the webview which is useful for iPads. Apple introduced a setting which by defaults changes the useragent of iPads from `iPad` to `Macintosh` to provide a "desktop browsing experience". The new preference allows to change the default value.

See original issue from IAB: apache/cordova-plugin-inappbrowser#687

### Description
<!-- Describe your changes in detail -->
Changed like : apache/cordova-plugin-inappbrowser#688

Documenation: https://github.com/apache/cordova-docs/pull/1083

### Testing
<!-- Please describe in detail how you tested your changes. -->
Automatic tests still pass. I found no automatic tests for preferences at build time.

I created a blank new app, added this platform and checked `navigator.userAgent` while changing the preference. It should be `iPad` for `mobile` and `Macintosh` for `desktop`.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
