### PR TITLE
Revert "Don't pre-fill orientation"

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
+++ b/bin/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
@@ -32,5 +32,18 @@
 	<string>CDVLaunchScreen</string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Reverts apache/cordova-ios#615

These defaults actually match the default values from a standard blank iOS app generated by Xcode, and the lack of these defaults are causing unexpected behaviour (#899).

To restrict the orientation, use the `Orientation` preference in config.xml.