### PR TITLE
(ios) issue-912: fix deployment to device

### DIFF
--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -86,7 +86,7 @@ module.exports.run = runOptions => {
                         // delete the existing platform/ios/build/device/appname.app
                         fs.removeSync(appFile);
                         // move the platform/ios/build/device/Payload/appname.app to parent
-                        fs.moveSync(appFileInflated, buildOutputDir);
+                        fs.moveSync(appFileInflated, appFile);
                         // delete the platform/ios/build/device/Payload folder
                         fs.removeSync(payloadFolder);
 


### PR DESCRIPTION
cordova-ios used to use "mv -f" and it was replaced with fs-extra.moveSync.  moveSync behaves
differently than mv, which broke deployment to devices.  This fixes the folder move and
subsequently deployment to device (when using "cordova run ios --device ..."

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
This was motivated by wanting to run an ios app on the device.  This worked in versions of cordova-ios <= 5.1.1 and was broken in 6.0.0 and 6.1.0.

fixes: https://github.com/apache/cordova-ios/issues/912



### Description
Fix a file copy.  The behavior of `moveSync` is not exactly the same as `mv -f` which was previously used.



### Testing
I have tested by deploying ios apps with `cordova run ios --device` from the command line.  This restores the functionality from the old versions of cordova-ios.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
