### PR TITLE
feat: support multiple provisioning profiles

### DIFF
--- a/bin/templates/scripts/cordova/build
+++ b/bin/templates/scripts/cordova/build
@@ -40,7 +40,7 @@ var buildOpts = nopt({
     emulator: Boolean,
     codeSignIdentity: String,
     codeSignResourceRules: String,
-    provisioningProfile: String,
+    provisioningProfile: [String, Array],
     automaticProvisioning: Boolean,
     developmentTeam: String,
     packageType: String,

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -239,7 +239,7 @@ module.exports.run = buildOpts => {
                 if (typeof buildOpts.provisioningProfile === 'string') {
                     exportOptions.provisioningProfiles = { [bundleIdentifier]: String(buildOpts.provisioningProfile) };
                 } else {
-                    console.log('Setting multiple provisioning profiles for signing');
+                    events.emit('log', 'Setting multiple provisioning profiles for signing');
                     exportOptions.provisioningProfiles = buildOpts.provisioningProfile;
                 }
                 exportOptions.signingStyle = 'manual';

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -168,7 +168,16 @@ module.exports.run = buildOpts => {
                 extraConfig += `CODE_SIGN_RESOURCE_RULES_PATH = ${buildOpts.codeSignResourceRules}\n`;
             }
             if (buildOpts.provisioningProfile) {
-                extraConfig += `PROVISIONING_PROFILE = ${buildOpts.provisioningProfile}\n`;
+                if (typeof(buildOpts.provisioningProfile) === 'string') {
+                    extraConfig += `PROVISIONING_PROFILE = ${buildOpts.provisioningProfile}\n`;
+                } else {
+                    // HM TODO: this can probably be improved...
+                    const project = createProjectObject(projectPath, projectName);
+                    const bundleIdentifier = project.getPackageName();
+                    console.log("bundleIdentifier is: ", bundleIdentifier);
+                    const keys = Object.keys(buildOpts.provisioningProfile);
+                    extraConfig += `PROVISIONING_PROFILE = ${buildOpts.provisioningProfile[keys[0]]}\n`;
+                }
             }
             if (buildOpts.developmentTeam) {
                 extraConfig += `DEVELOPMENT_TEAM = ${buildOpts.developmentTeam}\n`;
@@ -231,7 +240,12 @@ module.exports.run = buildOpts => {
             }
 
             if (buildOpts.provisioningProfile && bundleIdentifier) {
-                exportOptions.provisioningProfiles = { [bundleIdentifier]: String(buildOpts.provisioningProfile) };
+                if (typeof(buildOpts.provisioningProfile) === 'string') {
+                    exportOptions.provisioningProfiles = { [bundleIdentifier]: String(buildOpts.provisioningProfile) };
+                } else {
+                    console.log("Setting multiple provisioning profiles:", buildOpts.provisioningProfile);
+                    exportOptions.provisioningProfiles = buildOpts.provisioningProfile;
+                }
                 exportOptions.signingStyle = 'manual';
             }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -168,7 +168,7 @@ module.exports.run = buildOpts => {
                 extraConfig += `CODE_SIGN_RESOURCE_RULES_PATH = ${buildOpts.codeSignResourceRules}\n`;
             }
             if (buildOpts.provisioningProfile) {
-                if (typeof(buildOpts.provisioningProfile) === 'string') {
+                if (typeof buildOpts.provisioningProfile === 'string') {
                     extraConfig += `PROVISIONING_PROFILE = ${buildOpts.provisioningProfile}\n`;
                 } else {
                     const keys = Object.keys(buildOpts.provisioningProfile); // using keys[0] due to issue #955
@@ -236,10 +236,10 @@ module.exports.run = buildOpts => {
             }
 
             if (buildOpts.provisioningProfile && bundleIdentifier) {
-                if (typeof(buildOpts.provisioningProfile) === 'string') {
+                if (typeof buildOpts.provisioningProfile === 'string') {
                     exportOptions.provisioningProfiles = { [bundleIdentifier]: String(buildOpts.provisioningProfile) };
                 } else {
-                    console.log("Setting multiple provisioning profiles for signing");
+                    console.log('Setting multiple provisioning profiles for signing');
                     exportOptions.provisioningProfiles = buildOpts.provisioningProfile;
                 }
                 exportOptions.signingStyle = 'manual';

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -171,11 +171,7 @@ module.exports.run = buildOpts => {
                 if (typeof(buildOpts.provisioningProfile) === 'string') {
                     extraConfig += `PROVISIONING_PROFILE = ${buildOpts.provisioningProfile}\n`;
                 } else {
-                    // HM TODO: this can probably be improved...
-                    const project = createProjectObject(projectPath, projectName);
-                    const bundleIdentifier = project.getPackageName();
-                    console.log("bundleIdentifier is: ", bundleIdentifier);
-                    const keys = Object.keys(buildOpts.provisioningProfile);
+                    const keys = Object.keys(buildOpts.provisioningProfile); // using keys[0] due to issue #955
                     extraConfig += `PROVISIONING_PROFILE = ${buildOpts.provisioningProfile[keys[0]]}\n`;
                 }
             }
@@ -243,7 +239,7 @@ module.exports.run = buildOpts => {
                 if (typeof(buildOpts.provisioningProfile) === 'string') {
                     exportOptions.provisioningProfiles = { [bundleIdentifier]: String(buildOpts.provisioningProfile) };
                 } else {
-                    console.log("Setting multiple provisioning profiles:", buildOpts.provisioningProfile);
+                    console.log("Setting multiple provisioning profiles for signing");
                     exportOptions.provisioningProfiles = buildOpts.provisioningProfile;
                 }
                 exportOptions.signingStyle = 'manual';


### PR DESCRIPTION
### Platforms affected
ios


### Motivation and Context
When using a plugin that creates a new target it is currently impossible to sign it using cordova command line.
See issue #953 

Resolves #953

### Description
<!-- Describe your changes in detail -->
Added the option to set multiple provisioning profiles only in the build.json file.


### Testing
I've tested this code on the app I'm writing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
~I added automated test coverage as appropriate for this change~ Couldn't understand how... :-(
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
~I've updated the documentation if necessary~ not sure how to do it since this is only available when using a json file.
