### PR TITLE
fix: Append startURL to the initial url loaded

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -309,7 +309,7 @@ static void * KVOContext = &KVOContext;
             NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
             NSURL *url = [[NSURL URLWithString:self.CDV_ASSETS_URL] URLByAppendingPathComponent:request.URL.path];
             if ([request.URL.path isEqualToString:startFilePath]) {
-                url = [NSURL URLWithString:self.CDV_ASSETS_URL];
+                url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@", self.CDV_ASSETS_URL, startURL]];
             }
             if(request.URL.query) {
                 url = [NSURL URLWithString:[@"?" stringByAppendingString:request.URL.query] relativeToURL:url];


### PR DESCRIPTION
When using a custom scheme (app in example), the initial url loaded is `app://localhost`

This PR makes the initial url loaded to append the startURL to the url, in example `app://localhost/index.html`

This makes possible to run the tests as they use `<content src="cdvtests/index.html" />`, so now the url loaded will be `app://localhost/cdvtests/index.html` instead of `app://localhost`.