### PR TITLE
Fix - WKWebView doesn't layout properly at initial launch (CB-13987) 

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -203,6 +203,14 @@
 
     // re-create WKWebView, since we need to update configuration
     WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:self.engineWebView.frame configuration:configuration];
+
+    //Fix CB-13987
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+        if (@available(iOS 11.0, *)) {
+            [wkWebView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+        }
+    #endif
+
     wkWebView.UIDelegate = self.uiDelegate;
 
     /*


### PR DESCRIPTION
- When App is installed and run, it  was adding extra space from footer.
Although it was getting fixed on next app launch.

### Platforms affected
iOS


### Motivation and Context
WKWebview was adding extra space at footer section at initial launch when app is installed in device. Getting fixed when app is killed and re-launched.

Issue - https://issues.apache.org/jira/browse/CB-13987


### Testing
Tested in iPhone XR. 
Earlier I've forked `cordova-plugin-wkwebview-engine` plugin and was using that, But now I've updated to cordova-ios@6.0.0 so its needs to be fixed here now. This fix works correctly.
