### PR TITLE
chore(asf): Update GitHub repo metadata

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,6 +15,30 @@
 # specific language governing permissions and limitations
 # under the License.
 
+github:
+  description: Apache Cordova iOS
+  homepage: https://cordova.apache.org/
+
+  labels:
+    - cordova
+    - cordova-platform
+    - ios
+    - objective-c
+    - mobile
+    - javascript
+    - nodejs
+    - hacktoberfest
+
+  features:
+    wiki: false
+    issues: true
+    projects: true
+
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+
 notifications:
   commits:              commits@cordova.apache.org
   issues:               issues@cordova.apache.org


### PR DESCRIPTION
* Corrects the repo topics to more accurately reflect the languages actually in use (no more "cplusplus" or "csharp" topics)
* Adds the [Hacktoberfest opt-in topic](https://hacktoberfest.digitalocean.com/hacktoberfest-update)
* Turns off GitHub Projects for the repo (we use them at the org instead)
* Aligns with our goal of using squash commits when merging pull requests by disabling the merge and rebase options