### PR TITLE
Proxy requests through WKURLSchemeHandler to bypass Cookies and ITP restrictions

### DIFF
--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.h
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.h
@@ -25,6 +25,7 @@
 @interface CDVURLSchemeHandler : NSObject <WKURLSchemeHandler>
 
 @property (nonatomic, strong) CDVViewController* viewController;
+@property (nonatomic) Boolean isRunning;
 
 - (instancetype)initWithVC:(CDVViewController *)controller;
 

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -94,7 +94,7 @@
                     };
                 }
 
-                // Do not use urlSchemeTask if it has been closed in stopURLSchemeTask
+                // Do not use urlSchemeTask if it has been closed in stopURLSchemeTask. Otherwise the app will crash.
                 if(self.isRunning) {
                     [urlSchemeTask didReceiveResponse:response];
                     [urlSchemeTask didReceiveData:data];
@@ -142,7 +142,7 @@
 
 - (void)webView:(nonnull WKWebView *)webView stopURLSchemeTask:(nonnull id<WKURLSchemeTask>)urlSchemeTask
 {
-
+    self.isRunning = false;
 }
 
 -(NSString *) getMimeType:(NSString *)fileExtension {

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -37,8 +37,14 @@
 {
     NSString * startPath = [[NSBundle mainBundle] pathForResource:self.viewController.wwwFolderName ofType: nil];
     NSURL * url = urlSchemeTask.request.URL;
-    NSString * stringToLoad = url.path;
     NSString * scheme = url.scheme;
+    self.isRunning = true;
+    Boolean loadFile = true;
+    NSDictionary * header = urlSchemeTask.request.allHTTPHeaderFields;
+    NSMutableString * stringToLoad = [NSMutableString string];
+    [stringToLoad appendString:url.path];
+    NSString * method = urlSchemeTask.request.HTTPMethod;
+    NSData * body = urlSchemeTask.request.HTTPBody;
 
     if ([scheme isEqualToString:self.viewController.appScheme]) {
         if ([stringToLoad hasPrefix:@"/_app_file_"]) {
@@ -104,31 +110,33 @@
         }
     }
 
-    NSError * fileError = nil;
-    NSData * data = nil;
-    if ([self isMediaExtension:url.pathExtension]) {
-        data = [NSData dataWithContentsOfFile:startPath options:NSDataReadingMappedIfSafe error:&fileError];
-    }
-    if (!data || fileError) {
-        data =  [[NSData alloc] initWithContentsOfFile:startPath];
-    }
-    NSInteger statusCode = 200;
-    if (!data) {
-        statusCode = 404;
-    }
-    NSURL * localUrl = [NSURL URLWithString:url.absoluteString];
-    NSString * mimeType = [self getMimeType:url.pathExtension];
-    id response = nil;
-    if (data && [self isMediaExtension:url.pathExtension]) {
-        response = [[NSURLResponse alloc] initWithURL:localUrl MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil];
-    } else {
-        NSDictionary * headers = @{ @"Content-Type" : mimeType, @"Cache-Control": @"no-cache"};
-        response = [[NSHTTPURLResponse alloc] initWithURL:localUrl statusCode:statusCode HTTPVersion:nil headerFields:headers];
-    }
+    if(loadFile) {
+        NSError * fileError = nil;
+        NSData * data = nil;
+        if ([self isMediaExtension:url.pathExtension]) {
+            data = [NSData dataWithContentsOfFile:startPath options:NSDataReadingMappedIfSafe error:&fileError];
+        }
+        if (!data || fileError) {
+            data =  [[NSData alloc] initWithContentsOfFile:startPath];
+        }
+        NSInteger statusCode = 200;
+        if (!data) {
+            statusCode = 404;
+        }
+        NSURL * localUrl = [NSURL URLWithString:url.absoluteString];
+        NSString * mimeType = [self getMimeType:url.pathExtension];
+        id response = nil;
+        if (data && [self isMediaExtension:url.pathExtension]) {
+            response = [[NSURLResponse alloc] initWithURL:localUrl MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil];
+        } else {
+            NSDictionary * headers = @{ @"Content-Type" : mimeType, @"Cache-Control": @"no-cache"};
+            response = [[NSHTTPURLResponse alloc] initWithURL:localUrl statusCode:statusCode HTTPVersion:nil headerFields:headers];
+        }
 
-    [urlSchemeTask didReceiveResponse:response];
-    [urlSchemeTask didReceiveData:data];
-    [urlSchemeTask didFinish];
+        [urlSchemeTask didReceiveResponse:response];
+        [urlSchemeTask didReceiveData:data];
+        [urlSchemeTask didFinish];
+    }
 
 }
 

--- a/CordovaLib/cordova.js
+++ b/CordovaLib/cordova.js
@@ -1798,6 +1798,12 @@ var WkWebKit = {
         if (path.startsWith('file://')) {
             return window.CDV_ASSETS_URL + path.replace('file://', '/_app_file_');
         }
+        if (path.startsWith('http://')) {
+            return window.CDV_ASSETS_URL + '/_http_proxy_' + encodeURIComponent(path.replace('http://', ''));
+        }
+        if (path.startsWith('https://')) {
+            return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
+        }
         return path;
     }
 };

--- a/CordovaLib/cordova.js
+++ b/CordovaLib/cordova.js
@@ -1805,6 +1805,18 @@ var WkWebKit = {
             return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
         }
         return path;
+    },
+    convertProxyUrl: function (path) {
+        if (!path || !window.CDV_ASSETS_URL) {
+            return path;
+        }
+        if (path.startsWith('http://')) {
+            return window.CDV_ASSETS_URL + '/_http_proxy_' + encodeURIComponent(path.replace('http://', ''));
+        }
+        if (path.startsWith('https://')) {
+            return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
+        }
+        return path;
     }
 };
 

--- a/CordovaLib/cordova.js
+++ b/CordovaLib/cordova.js
@@ -1798,12 +1798,6 @@ var WkWebKit = {
         if (path.startsWith('file://')) {
             return window.CDV_ASSETS_URL + path.replace('file://', '/_app_file_');
         }
-        if (path.startsWith('http://')) {
-            return window.CDV_ASSETS_URL + '/_http_proxy_' + encodeURIComponent(path.replace('http://', ''));
-        }
-        if (path.startsWith('https://')) {
-            return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
-        }
         return path;
     },
     convertProxyUrl: function (path) {

--- a/cordova-js-src/plugin/ios/wkwebkit.js
+++ b/cordova-js-src/plugin/ios/wkwebkit.js
@@ -42,6 +42,18 @@ var WkWebKit = {
             return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
         }
         return path;
+    },
+    convertProxyUrl: function (path) {
+        if (!path || !window.CDV_ASSETS_URL) {
+            return path;
+        }
+        if (path.startsWith('http://')) {
+            return window.CDV_ASSETS_URL + '/_http_proxy_' + encodeURIComponent(path.replace('http://', ''));
+        }
+        if (path.startsWith('https://')) {
+            return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
+        }
+        return path;
     }
 };
 

--- a/cordova-js-src/plugin/ios/wkwebkit.js
+++ b/cordova-js-src/plugin/ios/wkwebkit.js
@@ -35,6 +35,12 @@ var WkWebKit = {
         if (path.startsWith('file://')) {
             return window.CDV_ASSETS_URL + path.replace('file://', '/_app_file_');
         }
+        if (path.startsWith('http://')) {
+            return window.CDV_ASSETS_URL + '/_http_proxy_' + encodeURIComponent(path.replace('http://', ''));
+        }
+        if (path.startsWith('https://')) {
+            return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
+        }
         return path;
     }
 };

--- a/cordova-js-src/plugin/ios/wkwebkit.js
+++ b/cordova-js-src/plugin/ios/wkwebkit.js
@@ -35,13 +35,6 @@ var WkWebKit = {
         if (path.startsWith('file://')) {
             return window.CDV_ASSETS_URL + path.replace('file://', '/_app_file_');
         }
-        if (path.startsWith('http://')) {
-            return window.CDV_ASSETS_URL + '/_http_proxy_' + encodeURIComponent(path.replace('http://', ''));
-        }
-        if (path.startsWith('https://')) {
-            return window.CDV_ASSETS_URL + '/_https_proxy_' + encodeURIComponent(path.replace('https://', ''));
-        }
-        return path;
     },
     convertProxyUrl: function (path) {
         if (!path || !window.CDV_ASSETS_URL) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
iOS became more restrictive for CORS and tracking prevention which makes it hard for some apps to communicate with their server and use cookies.

See #922 #605 and possibly many more

### Description
<!-- Describe your changes in detail -->
This PR implements a kind of "proxy" that takes requests like the normal webview and runs them through native code to make the request work without the CORS restrictions. Cookies are synced with the webview.

Originally taken from a modification in Ionics webview: https://github.com/ionic-team/cordova-plugin-ionic-webview/pull/448

**TODO**

⚠️ **The whitelist settings need to be part of this**

- [ ] Should this be part of the ios platform or better a (third) party plugin?
- [ ] Tests?
- [ ] Docs

### Testing
<!-- Please describe in detail how you tested your changes. -->
In a sample app for now. Use this code snippet to run code through the proxy:

`fetch(window.WkWebView.convertProxyUrl("https://cordova.apache.org"));`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
