### PR TITLE
Fix BackgroundColor parsing for lowercase letters

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -416,7 +416,7 @@ function getBackgroundColorDir (projectRoot, platformProjDir) {
 }
 
 function colorPreferenceToComponents (pref) {
-    if (!pref || !pref.match(/^(#[0-9A-F]{3}|(0x|#)([0-9A-F]{2})?[0-9A-F]{6})$/)) {
+    if (!pref || !pref.match(/^(#[0-9A-Fa-f]{3}|(0x|#)([0-9A-Fa-f]{2})?[0-9A-Fa-f]{6})$/)) {
         return {
             platform: 'ios',
             reference: 'systemBackgroundColor'
@@ -450,9 +450,9 @@ function colorPreferenceToComponents (pref) {
     return {
         'color-space': 'srgb',
         components: {
-            red: '0x' + red,
-            green: '0x' + green,
-            blue: '0x' + blue,
+            red: '0x' + red.toUpperCase(),
+            green: '0x' + green.toUpperCase(),
+            blue: '0x' + blue.toUpperCase(),
             alpha: alpha.toFixed(3)
         }
     };

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -413,8 +413,30 @@ describe('prepare', () => {
             }));
         });
 
+        it('should handle #fab', () => {
+            expect(colorPreferenceToComponents('#fab')).toEqual(jasmine.objectContaining({
+                components: {
+                    red: '0xFF',
+                    green: '0xAA',
+                    blue: '0xBB',
+                    alpha: '1.000'
+                }
+            }));
+        });
+
         it('should handle #FFAABB', () => {
             expect(colorPreferenceToComponents('#FFAABB')).toEqual(jasmine.objectContaining({
+                components: {
+                    red: '0xFF',
+                    green: '0xAA',
+                    blue: '0xBB',
+                    alpha: '1.000'
+                }
+            }));
+        });
+
+        it('should handle #ffaabb', () => {
+            expect(colorPreferenceToComponents('#ffaabb')).toEqual(jasmine.objectContaining({
                 components: {
                     red: '0xFF',
                     green: '0xAA',
@@ -435,6 +457,17 @@ describe('prepare', () => {
             }));
         });
 
+        it('should handle 0xffaabb', () => {
+            expect(colorPreferenceToComponents('0xffaabb')).toEqual(jasmine.objectContaining({
+                components: {
+                    red: '0xFF',
+                    green: '0xAA',
+                    blue: '0xBB',
+                    alpha: '1.000'
+                }
+            }));
+        });
+
         it('should handle #99FFAABB', () => {
             expect(colorPreferenceToComponents('#99FFAABB')).toEqual(jasmine.objectContaining({
                 components: {
@@ -446,8 +479,30 @@ describe('prepare', () => {
             }));
         });
 
+        it('should handle #99ffaabb', () => {
+            expect(colorPreferenceToComponents('#99ffaabb')).toEqual(jasmine.objectContaining({
+                components: {
+                    red: '0xFF',
+                    green: '0xAA',
+                    blue: '0xBB',
+                    alpha: '0.600'
+                }
+            }));
+        });
+
         it('should handle 0x99FFAABB', () => {
             expect(colorPreferenceToComponents('0x99FFAABB')).toEqual(jasmine.objectContaining({
+                components: {
+                    red: '0xFF',
+                    green: '0xAA',
+                    blue: '0xBB',
+                    alpha: '0.600'
+                }
+            }));
+        });
+
+        it('should handle 0x99ffaabb', () => {
+            expect(colorPreferenceToComponents('0x99ffaabb')).toEqual(jasmine.objectContaining({
                 components: {
                     red: '0xFF',
                     green: '0xAA',


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The guy who implemented this background colour parsing code forgot that lowercase letters existed when writing the regex 🙄
([aka, me](https://github.com/apache/cordova-ios/pull/896))


### Description
<!-- Describe your changes in detail -->
Adds support for lowercase hex characters in `BackgroundColor` preference parsing, along with appropriate tests.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added additional test cases with lowercase characters.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change