### PR TITLE
Hide splash sceen without `SplashScreenDelay` on .hide()

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -767,7 +767,18 @@
     self.webView.hidden = NO;
 
     if ([self.settings cordovaBoolSettingForKey:@"AutoHideSplashScreen" defaultValue:YES]) {
-       [self showLaunchScreen:NO];
+        CGFloat splashScreenDelaySetting = [self.settings cordovaFloatSettingForKey:@"SplashScreenDelay" defaultValue:0];
+
+        if (splashScreenDelaySetting == 0) {
+            [self showLaunchScreen:NO];
+        } else {
+            // Divide by 1000 because config returns milliseconds and NSTimer takes seconds
+            CGFloat splashScreenDelay = splashScreenDelaySetting / 1000;
+
+            [NSTimer scheduledTimerWithTimeInterval:splashScreenDelay repeats:NO block:^(NSTimer * _Nonnull timer) {
+                [self showLaunchScreen:NO];
+            }];
+        }
     }
 }
 
@@ -776,22 +787,16 @@
  */
 - (void)showLaunchScreen:(BOOL)visible
 {
-    CGFloat splashScreenDelay = [self.settings cordovaFloatSettingForKey:@"SplashScreenDelay" defaultValue:0];
-
-    // AnimateWithDuration takes seconds but cordova documentation specifies milliseconds
     CGFloat fadeSplashScreenDuration = [self.settings cordovaFloatSettingForKey:@"FadeSplashScreenDuration" defaultValue:250];
 
     // Setting minimum value for fade to 0.25 seconds
     fadeSplashScreenDuration = fadeSplashScreenDuration < 250 ? 250 : fadeSplashScreenDuration;
 
-    // Divide by 1000 because config returns milliseconds and NSTimer takes seconds
-    CGFloat delayToFade = (MAX(splashScreenDelay, fadeSplashScreenDuration) - fadeSplashScreenDuration)/1000;
+    // AnimateWithDuration takes seconds but cordova documentation specifies milliseconds
     CGFloat fadeDuration = fadeSplashScreenDuration/1000;
 
-    [NSTimer scheduledTimerWithTimeInterval:delayToFade repeats:NO block:^(NSTimer * _Nonnull timer) {
-        [UIView animateWithDuration:fadeDuration animations:^{
-            [self.launchView setAlpha:(visible ? 1 : 0)];
-        }];
+    [UIView animateWithDuration:fadeDuration animations:^{
+        [self.launchView setAlpha:(visible ? 1 : 0)];
     }];
 }
 


### PR DESCRIPTION
Fixes #991

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
The `cordova-plugin-splash-screen` allowed to hide the splash screen as a race between the timeout specified in the `SplashScreenDelay` preference and the call to `navigator.splashscreen.hide()` in JS code. This was very desirable, it allowed to show the splash screen for a long time if the application took a long time to boot but not too long so that users wouldn't think that the application is hanging.

Since the reimplementation of this functionality here, the behavior has changed. Now, the `SplashScreenDelay` preference applies to calls made by `navigator.splashscreen.hide()`, defeating the behavior described above.



### Description
Make hiding of splash screen again a race between the timeout specified in `SplashScreenDelay` setting and `navigator.splashscreen.hide()` call.




### Testing
Manual tests in simulator and real device (iPhone X).



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] ~I added automated test coverage as appropriate for this change~ - no idea, how
- [ ] ~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~ - doesn't make sense, this is a cordova-ios repo, it can only be ios-related
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
