### PR TITLE
Don't show splashscreen when using standalone CDVViewController

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.h
+++ b/CordovaLib/Classes/Public/CDVViewController.h
@@ -37,6 +37,7 @@
 }
 
 @property (nonatomic, readonly, weak) IBOutlet UIView* webView;
+@property (nonatomic, readonly, strong) UIView* launchView;
 
 @property (nonatomic, readonly, strong) NSMutableDictionary* pluginObjects;
 @property (nonatomic, readonly, strong) NSDictionary* pluginsMap;

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -521,6 +521,7 @@
     webViewBounds.origin = self.view.bounds.origin;
 
     UIView* view = [[UIView alloc] initWithFrame:webViewBounds];
+    [view setAlpha:0];
 
     NSString* launchStoryboardName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
     if (launchStoryboardName != nil) {

--- a/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.m
@@ -74,7 +74,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    // Do any additional setup after loading the view from its nib.
+    [self.launchView setAlpha:1];
 }
 
 @end


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #929 


### Description
<!-- Describe your changes in detail -->
When using CDVViewController via CordovaLib as a library, the app might already be loaded and not need to show the launch storyboard again.

Rather than unconditionally showing the splashscreen until the webview content has loaded, make it initially invisible. Then in the project template, make it visible so that it continues working as expected for apps using the Cordova CLI.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))