### PR TITLE
(iOS) Skip Cocoapods checkTool on non-darwin platform

### DIFF
--- a/bin/templates/scripts/cordova/lib/check_reqs.js
+++ b/bin/templates/scripts/cordova/lib/check_reqs.js
@@ -68,7 +68,14 @@ function os_platform_is_supported () {
  * @return {Promise} Returns a promise either resolved or rejected
  */
 module.exports.check_cocoapods = toolChecker => {
-    return checkTool('pod', COCOAPODS_MIN_VERSION, COCOAPODS_NOT_FOUND_MESSAGE, 'CocoaPods');
+    if (os_platform_is_supported()) {
+        return checkTool('pod', COCOAPODS_MIN_VERSION, COCOAPODS_NOT_FOUND_MESSAGE, 'CocoaPods');
+    }
+
+    return Promise.resolve({
+        ignore: true,
+        ignoreMessage: `CocoaPods check and installation ignored on ${process.platform}`
+    });
 };
 
 /**


### PR DESCRIPTION
### Platforms affected
- host environment
- iOS xcode project generation

### What does this PR do?
Ignore CocoaPods check and installation on non-darwin (macOS) platforms.

### What testing has been done on this change?
Manual tests:
- cordova plugin add cordova-plugin-firebase-crashlytics
- cordova plugin rm cordova-plugin-firebase-crashlytics

Tested on docker-linux: "Debian GNU/Linux 9 (stretch)"

Tested on Mac OS X:
- ProductVersion: 10.15.7
- BuildVersion: 19H2

cordova-ios: npm test - the results are below

### Description
On Linux: try to add a plugin with Cocoapods dependency, e.g.:
- cordova plugin add cordova-plugin-firebase-crashlytics

Cordova throws an error instead of skipping the pod version check.
With this patch, Cordova ignores checking and installing CocoaPods on non-darwin (macOS) platforms.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
