### PR TITLE
(iOS) Reinstate verification of main navigation in case of navigationType other

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
@@ -108,9 +108,11 @@
 
 + (BOOL)shouldOpenURLRequest:(NSURLRequest*)request navigationType:(CDVWebViewNavigationType)navigationType
 {
+    BOOL isMainNavigation = [[request.mainDocumentURL absoluteString] isEqualToString:[request.URL absoluteString]];
+
     return (
         navigationType == CDVWebViewNavigationTypeLinkClicked ||
-        navigationType == CDVWebViewNavigationTypeLinkOther
+        (navigationType == CDVWebViewNavigationTypeLinkOther && isMainNavigation)
     );
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Cordova iOS

### Motivation and Context

The PR that dropped UIWebView in favour of WKWebView (https://github.com/apache/cordova-ios/pull/773) introduced a bug that makes it so that iframe loads potentially jump out of the app and to Safari.

The current behavior is a problem for instance with Google Tag Manager. GTM might insert an iframe on the page with a source of `https://adservice.google.com`, or indeed any other country Google domain, depending on where the user is. This request would be sent out from the app and to Safari with the current implementation. Since the country domain might vary, it is impossible to approve this navigation in the `<allow-navigation />` list in order to keep it within the app.

### Description

This PR reinstates a verification that if the navigation type is `other` (for instance an iframe) we verify that the navigation is actually happening in the main URL bar and not in an iframe before allowing the URL to be forwarded out of the app.

### Testing

I have made this change in my own app and verified that the behavior is the same as with Cordova iOS 5, before this change was introduced in Cordova iOS 6.

This issue seems very similar: #988

I have not added tests for this change. This plugin has no tests covering it today.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
