### PR TITLE
GH-1059: Add VALIDATE_WORKSPACE setting to XcodeProj

### DIFF
--- a/bin/templates/project/__TEMP__.xcodeproj/project.pbxproj
+++ b/bin/templates/project/__TEMP__.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "__PROJECT_ID__";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = NO;
 			};
 			name = Debug;
 		};
@@ -350,6 +351,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "__PROJECT_ID__";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = NO;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1059


### Description
<!-- Describe your changes in detail -->
In Xcode 12, if an app is linked against .framework files with multiple architectures, it will generate an error about embedded framework mismatches. Declaring this property (even with its default value of `NO`) resolves the issue.


### Testing
<!-- Please describe in detail how you tested your changes. -->
CI passing


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
