### PR TITLE
(iOS) add undeclared dependency `underscore`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "6.2.0",
+  "version": "6.3.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "cordova-common": "^4.0.2",
     "fs-extra": "^9.1.0",
+    "underscore": "^1.9.2",
     "ios-sim": "^8.0.2",
     "nopt": "^5.0.0",
     "plist": "^3.0.1",


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation and Context

`cordova-ios` depends on `underscore` but doesn't declare it as a dependency
https://github.com/apache/cordova-ios/blob/048c1cace886d950860236adb893a860dfbd3503/bin/templates/scripts/cordova/lib/projectFile.js#L22

### Description

Added `underscore` as a dependency

### Testing

Ran `cordova prepare ios` under a strict dependency environment

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
