### PR TITLE
`(ios)` Removed verbose logging

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -380,7 +380,7 @@ function updateIcons (cordovaProject, locations) {
     const resourceMap = mapIconResources(icons, iconsDir);
     events.emit('verbose', `Updating icons at ${iconsDir}`);
     FileUpdater.updatePaths(
-        resourceMap, { rootDir: cordovaProject.root }, logFileOp);
+        resourceMap, { rootDir: cordovaProject.root });
 }
 
 function cleanIcons (projectRoot, projectConfig, locations) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

cordova-ios@6.2.0

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When an icon tag references a missing source path, a warning or error should be displayed so that the user knows to fix it.
#1106 

### Description
<!-- Describe your changes in detail -->

I removed the verbose logging tag submitted to cordova-common. When a source path error occurs, it is not displayed on the command line. 

### Testing
<!-- Please describe in detail how you tested your changes. -->

I rebuilt my own app using a local, modified copy of the cordova-ios repo. I successfully triggered this error and saw the logs populate correctly. 

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
