### PR TITLE
fix: replace of podspec variables in podfile #1125

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -51,6 +51,19 @@ function getVariableSpec (spec, options) {
     return spec.includes('$') ? options.cli_variables[spec.replace('$', '')] : spec;
 }
 
+// Replaces all pod specs available
+function replacePodSpecVariables (pod, options) {
+    const podSpecs = ['spec', 'tag', 'git', 'commit', 'branch'];
+
+    podSpecs.filter(e => pod[e])
+        .forEach(obj => {
+            const value = pod[obj];
+            pod[obj] = getVariableSpec(value, options);
+        });
+
+    return pod;
+}
+
 class Api {
     /**
      * Creates a new PlatformApi instance.
@@ -379,10 +392,8 @@ class Api {
                 // libraries
                 if (obj.libraries) {
                     Object.keys(obj.libraries).forEach(key => {
-                        const podJson = Object.assign({}, obj.libraries[key]);
-                        if (podJson.spec) {
-                            podJson.spec = getVariableSpec(podJson.spec, installOptions);
-                        }
+                        let podJson = Object.assign({}, obj.libraries[key]);
+                        podJson = replacePodSpecVariables(podJson, installOptions);
                         const val = podsjsonFile.getLibrary(key);
                         if (val) {
                             events.emit('warn', `${plugin.id} depends on ${podJson.name}, which may conflict with another plugin. ${podJson.name}@${val.spec} is already installed and was not overwritten.`);
@@ -472,10 +483,8 @@ class Api {
                 });
                 // libraries
                 Object.keys(obj.libraries).forEach(key => {
-                    const podJson = Object.assign({}, obj.libraries[key]);
-                    if (podJson.spec) {
-                        podJson.spec = getVariableSpec(podJson.spec, uninstallOptions);
-                    }
+                    let podJson = Object.assign({}, obj.libraries[key]);
+                    podJson = replacePodSpecVariables(podJson, uninstallOptions);
                     const val = podsjsonFile.getLibrary(key);
                     if (val) {
                         podsjsonFile.decrementLibrary(key);


### PR DESCRIPTION
### Platforms affected
ios


### Motivation and Context
Resolve issue #1125 



### Description
<!-- Describe your changes in detail -->
Replace variables with the variable value for all specs of pod



### Testing
<!-- Please describe in detail how you tested your changes. -->
I tested with custom plugin adding plugin with variables for all pod specs available(git, tag, branch, commit and spec)
https://guides.cocoapods.org/using/the-podfile.html


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
