### PR TITLE
fix(ios): split xcode project location by env separator

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -258,7 +258,7 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
                 const bridgingHeaders = headerTags.filter(obj => obj.type === 'BridgingHeader');
                 if (bridgingHeaders.length > 0) {
                     const project_dir = this.locations.root;
-                    const project_name = this.locations.xcodeCordovaProj.split('/').pop();
+                    const project_name = this.locations.xcodeCordovaProj.split(path.sep).pop();
                     const BridgingHeader = require('./lib/BridgingHeader').BridgingHeader;
                     const bridgingHeaderFile = new BridgingHeader(path.join(project_dir, project_name, 'Bridging-Header.h'));
                     events.emit('verbose', 'Adding Bridging-Headers since the plugin contained <header-file> with type="BridgingHeader"');
@@ -306,7 +306,7 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
                 const bridgingHeaders = headerTags.filter(obj => obj.type === 'BridgingHeader');
                 if (bridgingHeaders.length > 0) {
                     const project_dir = this.locations.root;
-                    const project_name = this.locations.xcodeCordovaProj.split('/').pop();
+                    const project_name = this.locations.xcodeCordovaProj.split(path.sep).pop();
                     const BridgingHeader = require('./lib/BridgingHeader').BridgingHeader;
                     const bridgingHeaderFile = new BridgingHeader(path.join(project_dir, project_name, 'Bridging-Header.h'));
                     events.emit('verbose', 'Removing Bridging-Headers since the plugin contained <header-file> with type="BridgingHeader"');
@@ -342,7 +342,7 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
 
 Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods, installOptions) {
     const project_dir = this.locations.root;
-    const project_name = this.locations.xcodeCordovaProj.split('/').pop();
+    const project_name = this.locations.xcodeCordovaProj.split(path.sep).pop();
     const minDeploymentTarget = this.getPlatformInfo().projectConfig.getPreference('deployment-target', 'ios');
 
     const Podfile = require('./lib/Podfile').Podfile;
@@ -469,7 +469,7 @@ Api.prototype.addPodSpecs = function (plugin, podSpecs, frameworkPods, installOp
 
 Api.prototype.removePodSpecs = function (plugin, podSpecs, frameworkPods, uninstallOptions) {
     const project_dir = this.locations.root;
-    const project_name = this.locations.xcodeCordovaProj.split('/').pop();
+    const project_name = this.locations.xcodeCordovaProj.split(path.sep).pop();
 
     const Podfile = require('./lib/Podfile').Podfile;
     const PodsJson = require('./lib/PodsJson').PodsJson;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
ios


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/apache/cordova-ios/issues/1139


### Description
<!-- Describe your changes in detail -->
replaced the delimiter string with the environment delimiter


### Testing
<!-- Please describe in detail how you tested your changes. -->
I've tested this code on install cordova plugin like `scandit-cordova-datacapture-core`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
