### PR TITLE
chore(version): bump 7.0.0-dev API.js

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -26,7 +26,7 @@
  *  This workflow would not have the `package.json` file.
  */
 // Coho updates this line
-const VERSION = '6.2.0';
+const VERSION = '7.0.0-dev';
 
 const fs = require('fs-extra');
 const path = require('path');


### PR DESCRIPTION
### Motivation, Context & Description

Bumped 7.0.0-dev in API.js.

This file was missed.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
