### PR TITLE
adjust build script for run on mac

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Scripts/copy-www-build-step.sh
+++ b/bin/templates/project/__PROJECT_NAME__/Scripts/copy-www-build-step.sh
@@ -26,6 +26,12 @@
 SRC_DIR="www"
 DST_DIR="$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME"
 DST_DIR_WWW="$DST_DIR/www"
+if [[ "$EFFECTIVE_PLATFORM_NAME" == "-maccatalyst" ]]; then
+  rm -rf "$DST_DIR_WWW"
+  rm -f  "$DST_DIR/config.xml"
+  DST_DIR="$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Contents/Resources"
+  DST_DIR_WWW="$DST_DIR/www"
+fi
 COPY_HIDDEN=
 ORIG_IFS=$IFS
 IFS=$(echo -en "\n\b")


### PR DESCRIPTION


<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Building an iOS app for Mac fails with our current copy script. #1158 tries to solve this with a Xcode build step instead of a custom shell script.

This is an alternative solution proposed by @pulpgrinder with a simple condition in the current script. This is probably bettter for backwards compatibility.

Addresses issue: #699

### Description
<!-- Describe your changes in detail -->

If the target platform is Mac Catalyst the correct paths are used.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Run app for:

- Mac
- Mac Rosseta
- Mac iPad
- iOS simulator

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
