### PR TITLE
fix(bin/create): set failing exit code on failure

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -68,4 +68,7 @@ var options = {
 
 require('./templates/scripts/cordova/loggingHelper').adjustLoggerLevel(argv);
 
-Api.createPlatform(projectPath, config, options);
+Api.createPlatform(projectPath, config, options).catch(err => {
+    console.error(err);
+    process.exit(2);
+});


### PR DESCRIPTION
Set failing exit code on failure for `bin/create`, like we do for the other binaries.