### PR TITLE
chore: Remove unused imports from template

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.h
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/MainViewController.h
@@ -26,8 +26,6 @@
 //
 
 #import <Cordova/CDVViewController.h>
-#import <Cordova/CDVCommandDelegateImpl.h>
-#import <Cordova/CDVCommandQueue.h>
 
 @interface MainViewController : CDVViewController
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
This work was missed in https://github.com/apache/cordova-ios/pull/1161 and is now causing errors.


### Description
Removed unused headers from the project template.


### Testing
Unit tests pass (although they also didn't catch this being an error last time)


### Checklist

- [x] I've run the tests to see all new and existing tests pass