### PR TITLE
test(create): increase test timeout

### DIFF
--- a/tests/spec/create.spec.js
+++ b/tests/spec/create.spec.js
@@ -55,7 +55,7 @@ describe('create', () => {
     let prevTimeout;
     beforeAll(() => {
         prevTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 60 * 1000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 120 * 1000;
     });
     afterAll(() => {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = prevTimeout;


### PR DESCRIPTION
Of course, the first CI run _after_ merging #1171 had tests that timed out :unamused: So let's hope that doubling the timeout will prevent that.