### PR TITLE
test(create): waste less time on name variants

### DIFF
--- a/tests/spec/create.spec.js
+++ b/tests/spec/create.spec.js
@@ -52,15 +52,6 @@ function createAndBuild (projectname, projectid) {
 }
 
 describe('create', () => {
-    let prevTimeout;
-    beforeAll(() => {
-        prevTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 120 * 1000;
-    });
-    afterAll(() => {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = prevTimeout;
-    });
-
     it('Test#001 : create project with ascii name, no spaces', () => {
         const projectname = 'testcreate';
         const projectid = 'com.test.app1';
@@ -68,52 +59,10 @@ describe('create', () => {
         return createAndBuild(projectname, projectid);
     }, 240 * 1000); // first build takes longer (probably cold caches)
 
-    it('Test#002 : create project with ascii name, and spaces', () => {
-        const projectname = 'test create';
+    it('Test#002 : create project with complicated name', () => {
+        const projectname = '応応応応 hello & إثرا 用用用用';
         const projectid = 'com.test.app2';
 
         return createAndBuild(projectname, projectid);
-    });
-
-    it('Test#003 : create project with unicode name, no spaces', () => {
-        const projectname = '応応応応用用用用';
-        const projectid = 'com.test.app3';
-
-        return createAndBuild(projectname, projectid);
-    });
-
-    it('Test#004 : create project with unicode name 2, no spaces', () => {
-        const projectname = 'إثرا';
-        const projectid = 'com.test.app3.2';
-
-        return createAndBuild(projectname, projectid);
-    });
-
-    it('Test#005 : create project with unicode name, and spaces', () => {
-        const projectname = '応応応応 用用用用';
-        const projectid = 'com.test.app4';
-
-        return createAndBuild(projectname, projectid);
-    });
-
-    it('Test#006 : create project with ascii+unicode name, no spaces', () => {
-        const projectname = '応応応応hello用用用用';
-        const projectid = 'com.test.app5';
-
-        return createAndBuild(projectname, projectid);
-    });
-
-    it('Test#007 : create project with ascii+unicode name, and spaces', () => {
-        const projectname = '応応応応 hello 用用用用';
-        const projectid = 'com.test.app6';
-
-        return createAndBuild(projectname, projectid);
-    });
-
-    it('Test#008 : create project with ascii name, and spaces, ampersand(&)', () => {
-        const projectname = 'hello & world';
-        const projectid = 'com.test.app7';
-
-        return createAndBuild(projectname, projectid);
-    });
+    }, 120 * 1000);
 });


### PR DESCRIPTION
This should speed up the create tests by a few minutes while still allowing us to notice if any part of the build had issues regarding special characters.