### PR TITLE
refactor(versions): DRY version binary code

### DIFF
--- a/bin/apple_ios_version
+++ b/bin/apple_ios_version
@@ -21,7 +21,4 @@
 
 var versions = require('./templates/scripts/cordova/lib/versions.js');
 
-versions.get_apple_ios_version().catch(err => {
-    console.log(err);
-    process.exit(2);
-});
+versions.printOrDie('apple_ios');

--- a/bin/apple_osx_version
+++ b/bin/apple_osx_version
@@ -21,7 +21,4 @@
 
 var versions = require('./templates/scripts/cordova/lib/versions.js');
 
-versions.get_apple_osx_version().catch(err => {
-    console.log(err);
-    process.exit(2);
-});
+versions.printOrDie('apple_osx');

--- a/bin/apple_xcode_version
+++ b/bin/apple_xcode_version
@@ -21,12 +21,4 @@
 
 var versions = require('./templates/scripts/cordova/lib/versions.js');
 
-versions.get_apple_xcode_version().then(
-    version => {
-        console.log(version);
-    },
-    err => {
-        console.error(err);
-        process.exit(2);
-    }
-);
+versions.printOrDie('apple_xcode');

--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -33,7 +33,7 @@ function fetchSdkVersionByType (sdkType) {
                 .map(line => line.match(/\d+\.\d+/)[0])
                 .sort(exports.compareVersions);
 
-            console.log(versions[0]);
+            return versions[0];
         });
 }
 
@@ -117,3 +117,14 @@ exports.compareVersions = (...args) => {
     const semverVersions = args.map(coerceToSemverIfInvalid);
     return semver.compare(...semverVersions);
 };
+
+exports.printOrDie = versionName =>
+    exports[`get_${versionName}_version`]().then(
+        version => {
+            console.log(version);
+        },
+        err => {
+            console.error(err);
+            process.exit(2);
+        }
+    );

--- a/tests/spec/unit/versions.spec.js
+++ b/tests/spec/unit/versions.spec.js
@@ -23,22 +23,18 @@ const versions = require('../../../bin/templates/scripts/cordova/lib/versions');
 // These tests can not run on windows.
 if (process.platform === 'darwin') {
     describe('versions', () => {
-        beforeEach(() => {
-            spyOn(console, 'log');
-        });
-
         describe('get_apple_ios_version method', () => {
             it('should have found ios version.', () => {
-                return versions.get_apple_ios_version().then(() => {
-                    expect(console.log).not.toHaveBeenCalledWith(undefined);
+                return versions.get_apple_ios_version().then(version => {
+                    expect(version).not.toBeUndefined();
                 });
             }, 10000);
         });
 
         describe('get_apple_osx_version method', () => {
             it('should have found osx version.', () => {
-                return versions.get_apple_osx_version().then(() => {
-                    expect(console.log).not.toHaveBeenCalledWith(undefined);
+                return versions.get_apple_osx_version().then(version => {
+                    expect(version).not.toBeUndefined();
                 });
             });
         });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This removes some minor code smells from the `versions` module and binaries.


### Description
<!-- Describe your changes in detail -->
- all version getters in `versions`  now actually return the version; previously 2 of them logged it directly
- a common helper method is used to create the legacy version binaries


### Testing
<!-- Please describe in detail how you tested your changes. -->
- automated tests pass
- version binaries still work (checked manually)

