### PR TITLE
feat(versions): print error messages, not error objects

### DIFF
--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -124,7 +124,7 @@ exports.printOrDie = versionName =>
             console.log(version);
         },
         err => {
-            console.error(err);
+            console.error(err.message);
             process.exit(2);
         }
     );

--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -49,9 +49,9 @@ exports.get_apple_xcode_version = () => {
     return spawn('xcodebuild', ['-version'])
         .then(output => {
             const versionMatch = /Xcode (.*)/.exec(output);
-
-            if (!versionMatch) return Promise.reject(output);
-
+            if (!versionMatch) {
+                throw new CordovaError('Could not determine Xcode version from output:\n' + output);
+            }
             return versionMatch[1];
         });
 };


### PR DESCRIPTION

### Description
<!-- Describe your changes in detail -->
Only log error messages instead of the whole error objects in case of failure. This improves output especially for child process errors.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing
