### PR TITLE
refactor: hide implementations of build & run

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -87,6 +87,7 @@ function getDefaultSimulatorTarget () {
         });
 }
 
+/** @returns {Promise<void>} */
 module.exports.run = buildOpts => {
     let emulatorTarget = '';
     const projectPath = path.join(__dirname, '..', '..');
@@ -263,7 +264,8 @@ module.exports.run = buildOpts => {
             return fs.writeFile(exportOptionsPath, exportOptionsPlist, 'utf-8')
                 .then(checkSystemRuby)
                 .then(packageArchive);
-        });
+        })
+        .then(() => {}); // resolve to undefined
 };
 
 /**

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -30,6 +30,7 @@ const fs = require('fs-extra');
 const cordovaPath = path.join(__dirname, '..');
 const projectPath = path.join(__dirname, '..', '..');
 
+/** @returns {Promise<void>} */
 module.exports.run = runOptions => {
     // Validate args
     if (runOptions.device && runOptions.emulator) {
@@ -108,7 +109,8 @@ module.exports.run = runOptions => {
             } else {
                 return module.exports.deployToSim(appPath, runOptions.target);
             }
-        });
+        })
+        .then(() => {}); // resolve to undefined
 };
 
 module.exports.filterSupportedArgs = filterSupportedArgs;


### PR DESCRIPTION
This makes build and run modules more closed by avoiding to expose
internals via the resolved promise value. Both modules' main exports
previously returned a promise that resolved to a subrocess spawn result.
Now these promises resolve to undefined.

The public API methods that return these promises did not document a
specific promise return value, just when the promise would resolve or
reject. Thus, this change is not breaking.