### PR TITLE
refactor: replace superspawn with execa

### DIFF
--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -19,11 +19,8 @@
 
 const path = require('path');
 const which = require('which');
-const {
-    CordovaError,
-    events,
-    superspawn: { spawn }
-} = require('cordova-common');
+const execa = require('execa');
+const { CordovaError, events } = require('cordova-common');
 const fs = require('fs-extra');
 const plist = require('plist');
 const util = require('util');
@@ -210,7 +207,7 @@ module.exports.run = buildOpts => {
             fs.removeSync(buildOutputDir);
 
             const xcodebuildArgs = getXcodeBuildArgs(projectName, projectPath, configuration, buildOpts.device, buildOpts.buildFlag, emulatorTarget, buildOpts.automaticProvisioning);
-            return spawn('xcodebuild', xcodebuildArgs, { cwd: projectPath, printCommand: true, stdio: 'inherit' });
+            return execa('xcodebuild', xcodebuildArgs, { cwd: projectPath, stdio: 'inherit' });
         }).then(() => {
             if (!buildOpts.device || buildOpts.noSign) {
                 return;
@@ -258,7 +255,7 @@ module.exports.run = buildOpts => {
 
             function packageArchive () {
                 const xcodearchiveArgs = getXcodeArchiveArgs(projectName, projectPath, buildOutputDir, exportOptionsPath, buildOpts.automaticProvisioning);
-                return spawn('xcodebuild', xcodearchiveArgs, { cwd: projectPath, printCommand: true, stdio: 'inherit' });
+                return execa('xcodebuild', xcodearchiveArgs, { cwd: projectPath, stdio: 'inherit' });
             }
 
             return fs.writeFile(exportOptionsPath, exportOptionsPlist, 'utf-8')

--- a/bin/templates/scripts/cordova/lib/clean.js
+++ b/bin/templates/scripts/cordova/lib/clean.js
@@ -19,10 +19,8 @@
 
 const path = require('path');
 const fs = require('fs-extra');
-const {
-    CordovaError,
-    superspawn: { spawn }
-} = require('cordova-common');
+const execa = require('execa');
+const { CordovaError } = require('cordova-common');
 
 const projectPath = path.join(__dirname, '..', '..');
 
@@ -34,10 +32,10 @@ module.exports.run = () => {
     }
 
     const xcodebuildClean = configName => {
-        return spawn(
+        return execa(
             'xcodebuild',
             ['-project', projectName, '-configuration', configName, '-alltargets', 'clean'],
-            { cwd: projectPath, printCommand: true, stdio: 'inherit' }
+            { cwd: projectPath, stdio: 'inherit' }
         );
     };
 

--- a/bin/templates/scripts/cordova/lib/listDevices.js
+++ b/bin/templates/scripts/cordova/lib/listDevices.js
@@ -17,7 +17,7 @@
        under the License.
 */
 
-const { superspawn: { spawn } } = require('cordova-common');
+const execa = require('execa');
 
 const DEVICE_REGEX = /-o (iPhone|iPad|iPod)@.*?"USB Serial Number" = "([^"]*)"/gs;
 
@@ -26,9 +26,9 @@ const DEVICE_REGEX = /-o (iPhone|iPad|iPod)@.*?"USB Serial Number" = "([^"]*)"/g
  * @return {Promise} Promise fulfilled with list of available iOS devices
  */
 function listDevices () {
-    return spawn('ioreg', ['-p', 'IOUSB', '-l'])
-        .then(output => {
-            return [...matchAll(output, DEVICE_REGEX)]
+    return execa('ioreg', ['-p', 'IOUSB', '-l'])
+        .then(({ stdout }) => {
+            return [...matchAll(stdout, DEVICE_REGEX)]
                 .map(m => m.slice(1).reverse().join(' '));
         });
 }

--- a/bin/templates/scripts/cordova/lib/listEmulatorBuildTargets.js
+++ b/bin/templates/scripts/cordova/lib/listEmulatorBuildTargets.js
@@ -17,7 +17,8 @@
        under the License.
 */
 
-const { superspawn: { spawn }, events } = require('cordova-common');
+const execa = require('execa');
+const { events } = require('cordova-common');
 
 /**
  * Returns a list of available simulator build targets of the form
@@ -32,8 +33,8 @@ const { superspawn: { spawn }, events } = require('cordova-common');
  */
 function listEmulatorBuildTargets () {
     events.emit('log', 'List simulator targets');
-    return spawn('xcrun', ['simctl', 'list', '--json'], { printCommand: true })
-        .then(output => JSON.parse(output))
+    return execa('xcrun', ['simctl', 'list', '--json'])
+        .then(({ stdout }) => JSON.parse(stdout))
         .then(function (simInfo) {
             const devices = simInfo.devices;
             const deviceTypes = simInfo.devicetypes;

--- a/bin/templates/scripts/cordova/lib/versions.js
+++ b/bin/templates/scripts/cordova/lib/versions.js
@@ -17,18 +17,16 @@
     under the License.
 */
 
-const {
-    CordovaError,
-    superspawn: { spawn }
-} = require('cordova-common');
+const execa = require('execa');
 const semver = require('semver');
+const { CordovaError } = require('cordova-common');
 
 function fetchSdkVersionByType (sdkType) {
-    return spawn('xcodebuild', ['-showsdks'])
-        .then(output => {
+    return execa('xcodebuild', ['-showsdks'])
+        .then(({ stdout }) => {
             const regexSdk = new RegExp(`^${sdkType} \\d`);
 
-            const versions = output.split('\n')
+            const versions = stdout.split('\n')
                 .filter(line => line.trim().match(regexSdk))
                 .map(line => line.match(/\d+\.\d+/)[0])
                 .sort(exports.compareVersions);
@@ -46,11 +44,11 @@ exports.get_apple_osx_version = () => {
 };
 
 exports.get_apple_xcode_version = () => {
-    return spawn('xcodebuild', ['-version'])
-        .then(output => {
-            const versionMatch = /Xcode (.*)/.exec(output);
+    return execa('xcodebuild', ['-version'])
+        .then(({ stdout }) => {
+            const versionMatch = /Xcode (.*)/.exec(stdout);
             if (!versionMatch) {
-                throw new CordovaError('Could not determine Xcode version from output:\n' + output);
+                throw new CordovaError('Could not determine Xcode version from output:\n' + stdout);
             }
             return versionMatch[1];
         });
@@ -62,7 +60,8 @@ exports.get_apple_xcode_version = () => {
  *                           or rejected in case of error
  */
 exports.get_ios_deploy_version = () => {
-    return spawn('ios-deploy', ['--version']);
+    return execa('ios-deploy', ['--version'])
+        .then(({ stdout }) => stdout);
 };
 
 /**
@@ -71,7 +70,8 @@ exports.get_ios_deploy_version = () => {
  *                           or rejected in case of error
  */
 exports.get_cocoapods_version = () => {
-    return spawn('pod', ['--version']);
+    return execa('pod', ['--version'])
+        .then(({ stdout }) => stdout);
 };
 
 /**
@@ -80,7 +80,8 @@ exports.get_cocoapods_version = () => {
  *                           or rejected in case of error
  */
 exports.get_ios_sim_version = () => {
-    return spawn('ios-sim', ['--version']);
+    return execa('ios-sim', ['--version'])
+        .then(({ stdout }) => stdout);
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cordova-common": "^4.0.2",
+        "execa": "^5.1.1",
         "fs-extra": "^10.0.0",
         "ios-sim": "^8.0.2",
         "nopt": "^5.0.0",
@@ -1786,6 +1787,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -2147,6 +2170,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -2300,6 +2334,14 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "engines": {
+        "node": ">=10.17.0"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -2603,7 +2645,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -2958,6 +2999,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2982,7 +3028,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3070,6 +3115,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc": {
@@ -3262,7 +3318,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -4233,8 +4288,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
-      "dev": true
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
     },
     "node_modules/simctl": {
       "version": "2.0.0",
@@ -4381,6 +4435,14 @@
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -6236,6 +6298,22 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -6508,6 +6586,11 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+    },
     "get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -6612,6 +6695,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -6823,8 +6911,7 @@
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-string": {
       "version": "1.0.7",
@@ -7096,6 +7183,11 @@
         }
       }
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7113,8 +7205,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7184,6 +7275,14 @@
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "requires": {
         "abbrev": "1"
+      }
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "requires": {
+        "path-key": "^3.0.0"
       }
     },
     "nyc": {
@@ -7330,7 +7429,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -8032,8 +8130,7 @@
     "signal-exit": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
-      "dev": true
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
     },
     "simctl": {
       "version": "2.0.0",
@@ -8150,6 +8247,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "cordova-common": "^4.0.2",
+    "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
     "ios-sim": "^8.0.2",
     "nopt": "^5.0.0",

--- a/tests/spec/unit/lib/list-devices.spec.js
+++ b/tests/spec/unit/lib/list-devices.spec.js
@@ -27,17 +27,17 @@ const sampleData = fs.readFileSync(path.resolve(__dirname, '../fixtures/sample-i
 
 describe('cordova/lib/listDevices', () => {
     describe('run method', () => {
-        let spawnSpy;
+        let execaSpy;
 
         beforeEach(() => {
-            spawnSpy = jasmine.createSpy('spawn').and.returnValue(Promise.resolve(sampleData));
-            list_devices.__set__('spawn', spawnSpy);
+            execaSpy = jasmine.createSpy('execa').and.resolveTo({ stdout: sampleData });
+            list_devices.__set__('execa', execaSpy);
         });
 
         it('should trim and split standard output and return as array', () => {
             return list_devices.run()
                 .then(results => {
-                    expect(spawnSpy).toHaveBeenCalledWith('ioreg', ['-p', 'IOUSB', '-l']);
+                    expect(execaSpy).toHaveBeenCalledWith('ioreg', ['-p', 'IOUSB', '-l']);
                     expect(results).toEqual([
                         'THE_IPHONE_SERIAL iPhone',
                         'THE_IPAD_SERIAL iPad'


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Progresses https://github.com/apache/cordova/issues/16 and https://github.com/apache/cordova/issues/7


### Description
<!-- Describe your changes in detail -->
Use `execa` for any subprocess spawning.

#### A few notes
`execa` has no equivalent of `superspawn`'s `printCommand` option (if set to `true`, it emits a verbose log of the command being executed). In the current state of this PR, those verbose logs are removed without a substitute.

`superspawn` promises resolve to the captured stdout, while `execa` resolves to an object with more properties. In many of the cases where we spawn subprocesses, this does not matter, since we we only care about promise fulfillment.

`superspawn` allowed to subscribe to a running process' output by means of Q's `progress` method. This basically directly translates to subscribing to `data` events on the backing streams. So that is what we used to replace these calls. However, the existing code seems to assume that the data emitted are whole lines of output only. This is by no means guaranteed, so we added `FIXME` comments to the code.


### Testing
<!-- Please describe in detail how you tested your changes. -->
- Existing tests pass
- It would be great if someone could do some manual tests with the platform (I own no Apple computer)

