### PR TITLE
refactor: cleanup create script

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -277,6 +277,3 @@ function update_cordova_subproject (argv) {
 
     utils.replaceFileContents(projectPbxprojPath, line, newLine);
 }
-
-exports.updateSubprojectHelp = updateSubprojectHelp;
-exports.update_cordova_subproject = update_cordova_subproject;

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -53,7 +53,6 @@ function copyJsAndCordovaLib (projectPath, projectName, use_shared) {
         // like it should).
         fs.symlinkSync(cordovaLibPathSrc, cordovaLibPathDest);
     } else {
-        fs.ensureDirSync(path.join(cordovaLibPathDest, 'CordovaLib.xcodeproj'));
         fs.copySync(path.join(projectAppPath, '.gitignore'), path.join(projectPath, '.gitignore'));
 
         for (const p of ['include', 'Classes', 'VERSION', 'cordova.js', 'CordovaLib.xcodeproj/project.pbxproj']) {

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -43,32 +43,31 @@ function copyJsAndCordovaLib (projectPath, projectName, use_shared, config) {
         }
     } catch (e) { }
 
-    let projectXcodePath;
-    let cordovaLibXcodePath;
+    const projectAppPath = path.join(projectPath, projectName);
+    const cordovaLibPathSrc = path.join(ROOT, 'CordovaLib');
+    const cordovaLibPathDest = path.join(projectPath, 'CordovaLib');
 
     if (use_shared) {
-        projectXcodePath = path.join(projectPath, `${projectName}.xcodeproj`);
-        cordovaLibXcodePath = path.join(ROOT, 'CordovaLib', 'CordovaLib.xcodeproj');
-
         // Symlink not used in project file, but is currently required for plugman because
         // it reads the VERSION file from it (instead of using the cordova/version script
         // like it should).
-        fs.symlinkSync(path.join(ROOT, 'CordovaLib'), path.join(projectPath, 'CordovaLib'));
+        fs.symlinkSync(cordovaLibPathSrc, cordovaLibPathDest);
     } else {
-        const r = path.join(projectPath, projectName);
-        fs.ensureDirSync(path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj'));
-        fs.copySync(path.join(r, '.gitignore'), path.join(projectPath, '.gitignore'));
-        fs.copySync(path.join(ROOT, 'CordovaLib', 'include'), path.join(projectPath, 'CordovaLib/include'));
-        fs.copySync(path.join(ROOT, 'CordovaLib', 'Classes'), path.join(projectPath, 'CordovaLib/Classes'));
-        fs.copySync(path.join(ROOT, 'CordovaLib', 'VERSION'), path.join(projectPath, 'CordovaLib/VERSION'));
-        fs.copySync(path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'CordovaLib/cordova.js'));
-        fs.copySync(path.join(ROOT, 'CordovaLib', 'CordovaLib.xcodeproj', 'project.pbxproj'), path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj', 'project.pbxproj'));
-
-        projectXcodePath = path.join(`${r}.xcodeproj`);
-        cordovaLibXcodePath = path.join(projectPath, 'CordovaLib', 'CordovaLib.xcodeproj');
+        fs.ensureDirSync(path.join(cordovaLibPathDest, 'CordovaLib.xcodeproj'));
+        fs.copySync(path.join(projectAppPath, '.gitignore'), path.join(projectPath, '.gitignore'));
+        fs.copySync(path.join(cordovaLibPathSrc, 'include'), path.join(cordovaLibPathDest, 'include'));
+        fs.copySync(path.join(cordovaLibPathSrc, 'Classes'), path.join(cordovaLibPathDest, 'Classes'));
+        fs.copySync(path.join(cordovaLibPathSrc, 'VERSION'), path.join(cordovaLibPathDest, 'VERSION'));
+        fs.copySync(path.join(cordovaLibPathSrc, 'cordova.js'), path.join(cordovaLibPathDest, 'cordova.js'));
+        fs.copySync(path.join(cordovaLibPathSrc, 'CordovaLib.xcodeproj', 'project.pbxproj'), path.join(cordovaLibPathDest, 'CordovaLib.xcodeproj', 'project.pbxproj'));
     }
 
-    updateCordovaSubproject(projectXcodePath, cordovaLibXcodePath, config);
+    const projectXcodeProjPath = `${projectAppPath}.xcodeproj`;
+    const cordovaLibXcodePath = path.join(
+        (use_shared ? cordovaLibPathSrc : cordovaLibPathDest),
+        'CordovaLib.xcodeproj'
+    );
+    updateCordovaSubproject(projectXcodeProjPath, cordovaLibXcodePath);
 }
 
 function copyScripts (projectPath, projectName) {

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -24,7 +24,7 @@ const ROOT = path.join(__dirname, '..', '..');
 const { CordovaError, events } = require('cordova-common');
 const utils = require('./utils');
 
-function copyJsAndCordovaLib (projectPath, projectName, use_shared, config) {
+function copyJsAndCordovaLib (projectPath, projectName, use_shared) {
     fs.copySync(path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'www/cordova.js'));
     fs.copySync(path.join(ROOT, 'cordova-js-src'), path.join(projectPath, 'platform_www/cordova-js-src'));
     fs.copySync(path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'platform_www/cordova.js'));
@@ -210,7 +210,7 @@ exports.createProject = (project_path, package_name, project_name, opts, config)
     fs.copySync(path.join(project_template_dir, 'pods-release.xcconfig'), path.join(project_path, 'pods-release.xcconfig'));
 
     // CordovaLib stuff
-    copyJsAndCordovaLib(project_path, project_name, use_shared, config);
+    copyJsAndCordovaLib(project_path, project_name, use_shared);
     copyScripts(project_path, project_name);
 
     events.emit('log', generateDoneMessage('create', use_shared));

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -29,23 +29,12 @@ function copyJsAndCordovaLib (projectPath, projectName, use_shared) {
     fs.copySync(path.join(ROOT, 'cordova-js-src'), path.join(projectPath, 'platform_www/cordova-js-src'));
     fs.copySync(path.join(ROOT, 'CordovaLib', 'cordova.js'), path.join(projectPath, 'platform_www/cordova.js'));
 
-    /*
-     * Check if "CordovaLib" already exists with "fs.lstatSync" and remove it.
-     * Wrapped with try/catch because lstatSync will throw an error if "CordovaLib"
-     * is missing.
-     */
-    try {
-        const stats = fs.lstatSync(path.join(projectPath, 'CordovaLib'));
-        if (stats.isSymbolicLink()) {
-            fs.unlinkSync(path.join(projectPath, 'CordovaLib'));
-        } else {
-            fs.removeSync(path.join(projectPath, 'CordovaLib'));
-        }
-    } catch (e) { }
-
     const projectAppPath = path.join(projectPath, projectName);
     const cordovaLibPathSrc = path.join(ROOT, 'CordovaLib');
     const cordovaLibPathDest = path.join(projectPath, 'CordovaLib');
+
+    // Make sure we are starting from scratch
+    fs.removeSync(cordovaLibPathDest);
 
     if (use_shared) {
         // Symlink not used in project file, but is currently required for plugman because

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -55,11 +55,10 @@ function copyJsAndCordovaLib (projectPath, projectName, use_shared) {
     } else {
         fs.ensureDirSync(path.join(cordovaLibPathDest, 'CordovaLib.xcodeproj'));
         fs.copySync(path.join(projectAppPath, '.gitignore'), path.join(projectPath, '.gitignore'));
-        fs.copySync(path.join(cordovaLibPathSrc, 'include'), path.join(cordovaLibPathDest, 'include'));
-        fs.copySync(path.join(cordovaLibPathSrc, 'Classes'), path.join(cordovaLibPathDest, 'Classes'));
-        fs.copySync(path.join(cordovaLibPathSrc, 'VERSION'), path.join(cordovaLibPathDest, 'VERSION'));
-        fs.copySync(path.join(cordovaLibPathSrc, 'cordova.js'), path.join(cordovaLibPathDest, 'cordova.js'));
-        fs.copySync(path.join(cordovaLibPathSrc, 'CordovaLib.xcodeproj', 'project.pbxproj'), path.join(cordovaLibPathDest, 'CordovaLib.xcodeproj', 'project.pbxproj'));
+
+        for (const p of ['include', 'Classes', 'VERSION', 'cordova.js', 'CordovaLib.xcodeproj/project.pbxproj']) {
+            fs.copySync(path.join(cordovaLibPathSrc, p), path.join(cordovaLibPathDest, p));
+        }
     }
 
     const projectXcodeProjPath = `${projectAppPath}.xcodeproj`;


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This takes the changes from the first four commits of #1191 and adds a few further simplifications in the affected code areas.

I pulled this out to reduce the scope of said PR and since I already reviewed this part of the changes.

### Description
<!-- Describe your changes in detail -->
From #1191:
- Remove exported `updateSubprojectHelp`
- Remove exported `update_cordova_subproject`
- Renamed internal function `update_cordova_subproject` to `updateCordovaSubproject`
  - Refactored internal function `updateCordovaSubproject` to take in two static arguments:
    - `projectXcodePath` which is the path to project's xcodeproj
    - `cordovaLibXcodePath` which is the path to the CordovaLib's xcodeproj. (Note: it maybe a symbolic link when `--link` flag is added when installing platform)
  - Improved comments
  - Removed excessive supportive internal methods
    - `AbsParentPath`
    - `AbsProjectPath`
    - `relpath`
    - `updateSubprojectHelp`

New: 
- Cleanup `copyJsAndCordovaLib`

### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm t`
