### PR TITLE
refactor(create)!: move apple_* binaries & cleanup copyScripts

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -74,26 +74,10 @@ function copyScripts (projectPath, projectName) {
     fs.removeSync(destScriptsDir);
 
     // Copy in the new ones.
-    const binDir = path.join(ROOT, 'bin');
     fs.copySync(srcScriptsDir, destScriptsDir);
 
     const nodeModulesDir = path.join(ROOT, 'node_modules');
     if (fs.existsSync(nodeModulesDir)) fs.copySync(nodeModulesDir, path.join(destScriptsDir, 'node_modules'));
-
-    // Copy the version scripts
-    fs.copySync(path.join(binDir, 'apple_ios_version'), path.join(destScriptsDir, 'apple_ios_version'));
-    fs.copySync(path.join(binDir, 'apple_osx_version'), path.join(destScriptsDir, 'apple_osx_version'));
-    fs.copySync(path.join(binDir, 'apple_xcode_version'), path.join(destScriptsDir, 'apple_xcode_version'));
-
-    // TODO: the two files being edited on-the-fly here are shared between
-    // platform and project-level commands. the below `sed` is updating the
-    // `require` path for the two libraries. if there's a better way to share
-    // modules across both the repo and generated projects, we should make sure
-    // to remove/update this.
-    const path_regex = /templates\/scripts\/cordova\//;
-    utils.replaceFileContents(path.join(destScriptsDir, 'apple_ios_version'), path_regex, '');
-    utils.replaceFileContents(path.join(destScriptsDir, 'apple_osx_version'), path_regex, '');
-    utils.replaceFileContents(path.join(destScriptsDir, 'apple_xcode_version'), path_regex, '');
 
     // CB-11792 do a token replace for __PROJECT_NAME__ in .xcconfig
     const project_name_esc = projectName.replace(/&/g, '\\&');

--- a/bin/templates/scripts/cordova/apple_ios_version
+++ b/bin/templates/scripts/cordova/apple_ios_version
@@ -2,23 +2,23 @@
 
 /*
     Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements. See the NOTICE file
+    or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
-    regarding copyright ownership. The ASF licenses this file
+    regarding copyright ownership.  The ASF licenses this file
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
-    with the License. You may obtain a copy of the License at
+    with the License.  You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied. See the License for the
+    KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
 */
 
-const versions = require('./templates/scripts/cordova/lib/versions.js');
+const versions = require('./lib/versions.js');
 
-versions.printOrDie('apple_osx');
+versions.printOrDie('apple_ios');

--- a/bin/templates/scripts/cordova/apple_osx_version
+++ b/bin/templates/scripts/cordova/apple_osx_version
@@ -2,23 +2,23 @@
 
 /*
     Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
+    or more contributor license agreements. See the NOTICE file
     distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
+    regarding copyright ownership. The ASF licenses this file
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+    with the License. You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
+    KIND, either express or implied. See the License for the
     specific language governing permissions and limitations
     under the License.
 */
 
-const versions = require('./templates/scripts/cordova/lib/versions.js');
+const versions = require('./lib/versions.js');
 
-versions.printOrDie('apple_xcode');
+versions.printOrDie('apple_osx');

--- a/bin/templates/scripts/cordova/apple_xcode_version
+++ b/bin/templates/scripts/cordova/apple_xcode_version
@@ -19,6 +19,6 @@
     under the License.
 */
 
-const versions = require('./templates/scripts/cordova/lib/versions.js');
+const versions = require('./lib/versions.js');
 
-versions.printOrDie('apple_ios');
+versions.printOrDie('apple_xcode');


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is a replacement for commit https://github.com/apache/cordova-ios/pull/1191/commits/daac0c1789231a2810519be2a0961ebeae9b6347 from #1191 which is broken in my opinion.


### Description
<!-- Describe your changes in detail -->
In contrast to the original commit, this moves the binaries to the current script template location `bin/templates/scripts/cordova`. This folder and its contents can be restructured and moved in a later PR.


### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm t`
