### PR TITLE
refactor(create): convert main implementation to class

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -37,8 +37,6 @@ const ROOT = path.join(__dirname, '../..');
 exports.createProject = async (project_path, package_name, project_name, opts) => {
     package_name = package_name || 'my.cordova.project';
     project_name = project_name || 'CordovaExample';
-    const use_shared = !!opts.link;
-    const project_template_dir = opts.customTemplate || path.join(ROOT, 'templates', 'project');
 
     // check that project path doesn't exist
     if (fs.existsSync(project_path)) {
@@ -50,162 +48,178 @@ exports.createProject = async (project_path, package_name, project_name, opts) =
     events.emit('log', `\tPackage: ${package_name}`);
     events.emit('log', `\tName: ${project_name}`);
 
-    copyTemplateFiles(project_template_dir, project_path);
-
-    provideCordovaJs(project_path);
-
-    provideCordovaLib(project_path, use_shared);
-
-    copyScripts(project_path);
-
-    expandTokens(project_path, project_name, package_name);
+    new ProjectCreator({
+        project: {
+            path: project_path,
+            name: project_name,
+            id: package_name
+        },
+        options: {
+            templatePath: opts.customTemplate || path.join(ROOT, 'templates/project'),
+            linkLib: !!opts.link
+        }
+    }).create();
 
     events.emit('log', `iOS project created with ${pkg.name}@${pkg.version}`);
 };
 
-function copyTemplateFiles (project_template_dir, project_path) {
-    fs.copySync(project_template_dir, project_path);
+class ProjectCreator {
+    constructor (obj) {
+        Object.assign(this, obj);
+    }
 
-    // TODO: why two .gitignores?
-    const r = path.join(project_path, '__PROJECT_NAME__');
-    fs.moveSync(path.join(r, 'gitignore'), path.join(r, '.gitignore'));
-    fs.copySync(path.join(r, '.gitignore'), path.join(project_path, '.gitignore'));
-}
+    create () {
+        this.provideProjectTemplate();
+        this.provideCordovaJs();
+        this.provideCordovaLib();
+        this.provideBuildScripts();
+        this.expandTokens();
+    }
 
-function provideCordovaJs (projectPath) {
-    fs.copySync(
-        path.join(projectPath, 'www/cordova.js'),
-        path.join(projectPath, 'platform_www/cordova.js')
-    );
-}
+    provideProjectTemplate () {
+        fs.copySync(this.options.templatePath, this.project.path);
 
-function provideCordovaLib (projectPath, linkLib) {
-    copyOrLinkCordovaLib(projectPath, linkLib);
-    configureCordovaLibPath(projectPath);
-}
+        // TODO: why two .gitignores?
+        const r = this.projectPath('__PROJECT_NAME__');
+        fs.moveSync(path.join(r, 'gitignore'), path.join(r, '.gitignore'));
+        fs.copySync(path.join(r, '.gitignore'), this.projectPath('.gitignore'));
+    }
 
-function copyScripts (projectPath) {
-    const srcScriptsDir = path.join(ROOT, 'bin', 'templates', 'scripts', 'cordova');
-    const destScriptsDir = path.join(projectPath, 'cordova');
+    provideCordovaJs () {
+        fs.copySync(
+            this.projectPath('www/cordova.js'),
+            this.projectPath('platform_www/cordova.js')
+        );
+    }
 
-    // Copy in the new ones.
-    fs.copySync(srcScriptsDir, destScriptsDir);
+    provideCordovaLib () {
+        this.copyOrLinkCordovaLib();
+        this.configureCordovaLibPath();
+    }
 
-    const nodeModulesDir = path.join(ROOT, 'node_modules');
-    if (fs.existsSync(nodeModulesDir)) fs.copySync(nodeModulesDir, path.join(destScriptsDir, 'node_modules'));
-}
+    provideBuildScripts () {
+        const srcScriptsDir = path.join(ROOT, 'bin/templates/scripts/cordova');
+        const destScriptsDir = this.projectPath('cordova');
+        fs.copySync(srcScriptsDir, destScriptsDir);
 
-function expandTokens (project_path, project_name, package_name) {
-    expandTokensInFileContents(project_path, project_name, package_name);
-    expandTokensInFileNames(project_path, project_name);
-}
-
-function copyOrLinkCordovaLib (projectPath, linkLib) {
-    const cordovaLibPathSrc = path.join(ROOT, 'CordovaLib');
-    const cordovaLibPathDest = path.join(projectPath, 'CordovaLib');
-
-    if (linkLib) {
-        // Symlink not used in project file, but is currently required for plugman because
-        // it reads the VERSION file from it (instead of using the cordova/version script
-        // like it should).
-        fs.symlinkSync(cordovaLibPathSrc, cordovaLibPathDest);
-    } else {
-        for (const p of ['include', 'Classes', 'VERSION', 'CordovaLib.xcodeproj/project.pbxproj']) {
-            fs.copySync(path.join(cordovaLibPathSrc, p), path.join(cordovaLibPathDest, p));
+        const nodeModulesDir = path.join(ROOT, 'node_modules');
+        if (fs.existsSync(nodeModulesDir)) {
+            fs.copySync(nodeModulesDir, path.join(destScriptsDir, 'node_modules'));
         }
     }
-}
 
-/**
- * Updates xcodeproj's Sub Projects
- *
- * @param {string} project_path absolute path to the project's `platforms/ios` directory
- */
-function configureCordovaLibPath (project_path) {
-    // CordovaLib could be a symlink, so we resolve it
-    const cdvLibRealPath = fs.realpathSync(path.join(project_path, 'CordovaLib'));
-
-    const cdvLibXcodeAbsPath = path.join(cdvLibRealPath, 'CordovaLib.xcodeproj');
-    const cdvLibXcodePath = path.relative(project_path, cdvLibXcodeAbsPath);
-    const pbxprojPath = path.join(project_path, '__PROJECT_NAME__.xcodeproj/project.pbxproj');
-
-    // Replace magic line in project.pbxproj
-    transformFileContents(pbxprojPath, contents => {
-        const regex = /(.+CordovaLib.xcodeproj.+PBXFileReference.+wrapper.pb-project.+)(path = .+?;)(.*)(sourceTree.+;)(.+)/;
-        const line = contents.split(/\r?\n/)
-            .find(l => regex.test(l));
-
-        if (!line) {
-            throw new Error(`Entry not found in project file for sub-project: ${cdvLibXcodePath}`);
-        }
-
-        let newLine = line
-            .replace(/path = .+?;/, `path = ${cdvLibXcodePath};`)
-            .replace(/sourceTree.+?;/, 'sourceTree = "<group>";');
-
-        if (!newLine.match('name')) {
-            newLine = newLine.replace('path = ', 'name = CordovaLib.xcodeproj; path = ');
-        }
-
-        return contents.replace(line, newLine);
-    });
-}
-
-function expandTokensInFileContents (project_path, project_name, package_name) {
-    // Expand __PROJECT_ID__ token in file contents
-    transformFileContents(
-        path.join(project_path, '__PROJECT_NAME__.xcodeproj/project.pbxproj'),
-        contents => contents.replace(/__PROJECT_ID__/g, package_name)
-    );
-
-    // Expand __PROJECT_NAME__ token in file contents
-    for (const p of [
-        'cordova/build-debug.xcconfig',
-        'cordova/build-release.xcconfig',
-        '__PROJECT_NAME__.xcworkspace/contents.xcworkspacedata',
-        '__PROJECT_NAME__.xcworkspace/xcshareddata/xcschemes/__PROJECT_NAME__.xcscheme',
-        '__PROJECT_NAME__.xcodeproj/project.pbxproj',
-        '__PROJECT_NAME__/Classes/AppDelegate.h',
-        '__PROJECT_NAME__/Classes/AppDelegate.m',
-        '__PROJECT_NAME__/Classes/MainViewController.h',
-        '__PROJECT_NAME__/Classes/MainViewController.m',
-        '__PROJECT_NAME__/main.m',
-        '__PROJECT_NAME__/__PROJECT_NAME__-Info.plist',
-        '__PROJECT_NAME__/__PROJECT_NAME__-Prefix.pch'
-    ]) {
-        expandProjectNameInFileContents(path.join(project_path, p), project_name);
+    expandTokens () {
+        this.expandTokensInFileContents();
+        this.expandTokensInFileNames();
     }
-}
 
-function expandTokensInFileNames (project_path, project_name) {
-    // Expand __PROJECT_NAME__ token in file & folder names
-    for (const p of [
-        '__PROJECT_NAME__.xcworkspace/xcshareddata/xcschemes/__PROJECT_NAME__.xcscheme',
-        '__PROJECT_NAME__.xcworkspace',
-        '__PROJECT_NAME__.xcodeproj',
-        '__PROJECT_NAME__/__PROJECT_NAME__-Info.plist',
-        '__PROJECT_NAME__/__PROJECT_NAME__-Prefix.pch',
-        '__PROJECT_NAME__'
-    ]) {
-        expandProjectNameInBaseName(path.join(project_path, p), project_name);
+    copyOrLinkCordovaLib () {
+        const cordovaLibPathSrc = path.join(ROOT, 'CordovaLib');
+        const cordovaLibPathDest = this.projectPath('CordovaLib');
+
+        if (this.options.linkLib) {
+            // Symlink not used in project file, but is currently required for plugman because
+            // it reads the VERSION file from it (instead of using the cordova/version script
+            // like it should).
+            fs.symlinkSync(cordovaLibPathSrc, cordovaLibPathDest);
+        } else {
+            for (const p of ['include', 'Classes', 'VERSION', 'CordovaLib.xcodeproj/project.pbxproj']) {
+                fs.copySync(path.join(cordovaLibPathSrc, p), path.join(cordovaLibPathDest, p));
+            }
+        }
     }
-}
 
-function expandProjectNameInBaseName (f, projectName) {
-    const { dir, base } = path.parse(f);
-    const newBase = base.replace('__PROJECT_NAME__', projectName);
-    return fs.moveSync(f, path.join(dir, newBase));
-}
+    configureCordovaLibPath () {
+        // CordovaLib could be a symlink, so we resolve it
+        const cdvLibRealPath = fs.realpathSync(this.projectPath('CordovaLib'));
 
-function expandProjectNameInFileContents (f, projectName) {
-    // https://issues.apache.org/jira/browse/CB-12402 - Encode XML characters properly
-    const xmlExtensions = new Set(['.xcworkspacedata', '.xcscheme']);
-    const escape = xmlExtensions.has(path.extname(f))
-        ? xmlescape
-        : s => s.replace(/&/g, '\\&');
-    transformFileContents(f, contents =>
-        contents.replace(/__PROJECT_NAME__/g, escape(projectName))
-    );
+        const cdvLibXcodeAbsPath = path.join(cdvLibRealPath, 'CordovaLib.xcodeproj');
+        const cdvLibXcodePath = path.relative(this.project.path, cdvLibXcodeAbsPath);
+
+        // Replace magic line in project.pbxproj
+        const pbxprojPath = this.projectPath('__PROJECT_NAME__.xcodeproj/project.pbxproj');
+        transformFileContents(pbxprojPath, contents => {
+            const regex = /(.+CordovaLib.xcodeproj.+PBXFileReference.+wrapper.pb-project.+)(path = .+?;)(.*)(sourceTree.+;)(.+)/;
+            const line = contents.split(/\r?\n/)
+                .find(l => regex.test(l));
+
+            if (!line) {
+                throw new Error(`Entry not found in project file for sub-project: ${cdvLibXcodePath}`);
+            }
+
+            let newLine = line
+                .replace(/path = .+?;/, `path = ${cdvLibXcodePath};`)
+                .replace(/sourceTree.+?;/, 'sourceTree = "<group>";');
+
+            if (!newLine.match('name')) {
+                newLine = newLine.replace('path = ', 'name = CordovaLib.xcodeproj; path = ');
+            }
+
+            return contents.replace(line, newLine);
+        });
+    }
+
+    expandTokensInFileContents () {
+        // Expand __PROJECT_ID__ token in file contents
+        transformFileContents(
+            this.projectPath('__PROJECT_NAME__.xcodeproj/project.pbxproj'),
+            contents => contents.replace(/__PROJECT_ID__/g, this.project.id)
+        );
+
+        // Expand __PROJECT_NAME__ token in file contents
+        for (const p of [
+            'cordova/build-debug.xcconfig',
+            'cordova/build-release.xcconfig',
+            '__PROJECT_NAME__.xcworkspace/contents.xcworkspacedata',
+            '__PROJECT_NAME__.xcworkspace/xcshareddata/xcschemes/__PROJECT_NAME__.xcscheme',
+            '__PROJECT_NAME__.xcodeproj/project.pbxproj',
+            '__PROJECT_NAME__/Classes/AppDelegate.h',
+            '__PROJECT_NAME__/Classes/AppDelegate.m',
+            '__PROJECT_NAME__/Classes/MainViewController.h',
+            '__PROJECT_NAME__/Classes/MainViewController.m',
+            '__PROJECT_NAME__/main.m',
+            '__PROJECT_NAME__/__PROJECT_NAME__-Info.plist',
+            '__PROJECT_NAME__/__PROJECT_NAME__-Prefix.pch'
+        ]) {
+            this.expandProjectNameInFileContents(this.projectPath(p));
+        }
+    }
+
+    expandTokensInFileNames () {
+        // Expand __PROJECT_NAME__ token in file & folder names
+        for (const p of [
+            '__PROJECT_NAME__.xcworkspace/xcshareddata/xcschemes/__PROJECT_NAME__.xcscheme',
+            '__PROJECT_NAME__.xcworkspace',
+            '__PROJECT_NAME__.xcodeproj',
+            '__PROJECT_NAME__/__PROJECT_NAME__-Info.plist',
+            '__PROJECT_NAME__/__PROJECT_NAME__-Prefix.pch',
+            '__PROJECT_NAME__'
+        ]) {
+            this.expandProjectNameInBaseName(this.projectPath(p));
+        }
+    }
+
+    expandProjectNameInBaseName (f) {
+        const { dir, base } = path.parse(f);
+        const newBase = base.replace('__PROJECT_NAME__', this.project.name);
+        return fs.moveSync(f, path.join(dir, newBase));
+    }
+
+    expandProjectNameInFileContents (f) {
+        // https://issues.apache.org/jira/browse/CB-12402 - Encode XML characters properly
+        const xmlExtensions = new Set(['.xcworkspacedata', '.xcscheme']);
+        const escape = xmlExtensions.has(path.extname(f))
+            ? xmlescape
+            : s => s.replace(/&/g, '\\&');
+
+        transformFileContents(f, contents =>
+            contents.replace(/__PROJECT_NAME__/g, escape(this.project.name))
+        );
+    }
+
+    projectPath (projectRelativePath) {
+        return path.join(this.project.path, projectRelativePath);
+    }
 }
 
 function transformFileContents (file, transform) {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Last PR of @erisu's and my `create` cleanup effort.

Note: Ignore whitespace when viewing the diff.

### Description
<!-- Describe your changes in detail -->
This converts the create implementation to a class, so we can avoid excessive argument passing.


### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm t`
