### PR TITLE
refactor: do not infer project root from script location

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -73,7 +73,7 @@ class Api {
     constructor (platform, platformRootDir, events) {
         // 'platform' property is required as per PlatformApi spec
         this.platform = platform || 'ios';
-        this.root = platformRootDir || path.resolve(__dirname, '..');
+        this.root = platformRootDir;
 
         setupEvents(events);
 
@@ -680,7 +680,7 @@ class Api {
      */
     clean (cleanOptions) {
         return check_reqs.run()
-            .then(() => require('./lib/clean').run.call(this, cleanOptions))
+            .then(() => require('./lib/clean').run(this.root))
             .then(() => require('./lib/prepare').clean.call(this, cleanOptions));
     }
 

--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -680,7 +680,7 @@ class Api {
      */
     clean (cleanOptions) {
         return check_reqs.run()
-            .then(() => require('./lib/clean').run(this.root))
+            .then(() => require('./lib/clean').run.call(this, cleanOptions))
             .then(() => require('./lib/prepare').clean.call(this, cleanOptions));
     }
 

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -85,9 +85,9 @@ function getDefaultSimulatorTarget () {
 }
 
 /** @returns {Promise<void>} */
-module.exports.run = buildOpts => {
+module.exports.run = function (buildOpts) {
+    const projectPath = this.root;
     let emulatorTarget = '';
-    const projectPath = path.join(__dirname, '..', '..');
     let projectName = '';
 
     buildOpts = buildOpts || {};
@@ -192,7 +192,7 @@ module.exports.run = buildOpts => {
                 writeCodeSignStyle('Automatic');
             }
 
-            return fs.writeFile(path.join(__dirname, '..', 'build-extras.xcconfig'), extraConfig, 'utf-8');
+            return fs.writeFile(path.join(projectPath, 'cordova/build-extras.xcconfig'), extraConfig, 'utf-8');
         }).then(() => {
             const configuration = buildOpts.release ? 'Release' : 'Debug';
 

--- a/bin/templates/scripts/cordova/lib/clean.js
+++ b/bin/templates/scripts/cordova/lib/clean.js
@@ -22,9 +22,7 @@ const fs = require('fs-extra');
 const execa = require('execa');
 const { CordovaError } = require('cordova-common');
 
-const projectPath = path.join(__dirname, '..', '..');
-
-module.exports.run = () => {
+module.exports.run = function (projectPath) {
     const projectName = fs.readdirSync(projectPath).filter(name => path.extname(name) === '.xcodeproj');
 
     if (!projectName) {

--- a/bin/templates/scripts/cordova/lib/clean.js
+++ b/bin/templates/scripts/cordova/lib/clean.js
@@ -22,7 +22,8 @@ const fs = require('fs-extra');
 const execa = require('execa');
 const { CordovaError } = require('cordova-common');
 
-module.exports.run = function (projectPath) {
+module.exports.run = function () {
+    const projectPath = this.root;
     const projectName = fs.readdirSync(projectPath).filter(name => path.extname(name) === '.xcodeproj');
 
     if (!projectName) {

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -63,6 +63,10 @@ module.exports.prepare = function (cordovaProject, options) {
 };
 
 module.exports.clean = function (options) {
+    // A cordovaProject isn't passed into the clean() function, because it might have
+    // been called from the platform shell script rather than the CLI. Check for the
+    // noPrepare option passed in by the non-CLI clean script. If that's present, or if
+    // there's no config.xml found at the project root, then don't clean prepared files.
     const projectRoot = path.resolve(this.root, '../..');
     const projectConfigFile = path.join(projectRoot, 'config.xml');
     if ((options && options.noPrepare) || !fs.existsSync(projectConfigFile) ||

--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -63,10 +63,6 @@ module.exports.prepare = function (cordovaProject, options) {
 };
 
 module.exports.clean = function (options) {
-    // A cordovaProject isn't passed into the clean() function, because it might have
-    // been called from the platform shell script rather than the CLI. Check for the
-    // noPrepare option passed in by the non-CLI clean script. If that's present, or if
-    // there's no config.xml found at the project root, then don't clean prepared files.
     const projectRoot = path.resolve(this.root, '../..');
     const projectConfigFile = path.join(projectRoot, 'config.xml');
     if ((options && options.noPrepare) || !fs.existsSync(projectConfigFile) ||

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -184,7 +184,7 @@ async function deployToSim (projectPath, appPath, target) {
 }
 
 function startSim (projectPath, appPath, target) {
-    const logPath = path.join(projectPath, 'console.log');
+    const logPath = path.join(projectPath, 'cordova/console.log');
     const deviceTypeId = `com.apple.CoreSimulator.SimDeviceType.${target}`;
 
     const subprocess = execa(

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -24,11 +24,10 @@ const { CordovaError, events } = require('cordova-common');
 const check_reqs = require('./check_reqs');
 const fs = require('fs-extra');
 
-const cordovaPath = path.join(__dirname, '..');
-const projectPath = path.join(__dirname, '..', '..');
-
 /** @returns {Promise<void>} */
-module.exports.run = runOptions => {
+module.exports.run = function (runOptions) {
+    const projectPath = this.root;
+
     // Validate args
     if (runOptions.device && runOptions.emulator) {
         return Promise.reject(new CordovaError('Only one of "device"/"emulator" options should be specified'));
@@ -101,10 +100,10 @@ module.exports.run = runOptions => {
                             return module.exports.deployToDevice(appPath, runOptions.target, extraArgs);
                         },
                         // if device connection check failed use emulator then
-                        () => module.exports.deployToSim(appPath, runOptions.target)
+                        () => module.exports.deployToSim(projectPath, appPath, runOptions.target)
                     );
             } else {
-                return module.exports.deployToSim(appPath, runOptions.target);
+                return module.exports.deployToSim(projectPath, appPath, runOptions.target);
             }
         })
         .then(() => {}); // resolve to undefined
@@ -170,7 +169,7 @@ function deployToDevice (appPath, target, extraArgs) {
  * @param  {String} target  Target device type
  * @return {Promise}        Resolves when deploy succeeds otherwise rejects
  */
-async function deployToSim (appPath, target) {
+async function deployToSim (projectPath, appPath, target) {
     events.emit('log', 'Deploying to simulator');
 
     if (!target) {
@@ -181,11 +180,11 @@ async function deployToSim (appPath, target) {
         events.emit('log', `No target specified for emulator. Deploying to "${target}" simulator.`);
     }
 
-    return startSim(appPath, target);
+    return startSim(projectPath, appPath, target);
 }
 
-function startSim (appPath, target) {
-    const logPath = path.join(cordovaPath, 'console.log');
+function startSim (projectPath, appPath, target) {
+    const logPath = path.join(projectPath, 'console.log');
     const deviceTypeId = `com.apple.CoreSimulator.SimDeviceType.${target}`;
 
     const subprocess = execa(

--- a/bin/templates/scripts/cordova/lib/run.js
+++ b/bin/templates/scripts/cordova/lib/run.js
@@ -100,10 +100,10 @@ module.exports.run = function (runOptions) {
                             return module.exports.deployToDevice(appPath, runOptions.target, extraArgs);
                         },
                         // if device connection check failed use emulator then
-                        () => module.exports.deployToSim(projectPath, appPath, runOptions.target)
+                        () => module.exports.deployToSim(appPath, runOptions.target)
                     );
             } else {
-                return module.exports.deployToSim(projectPath, appPath, runOptions.target);
+                return module.exports.deployToSim(appPath, runOptions.target);
             }
         })
         .then(() => {}); // resolve to undefined
@@ -169,7 +169,7 @@ function deployToDevice (appPath, target, extraArgs) {
  * @param  {String} target  Target device type
  * @return {Promise}        Resolves when deploy succeeds otherwise rejects
  */
-async function deployToSim (projectPath, appPath, target) {
+async function deployToSim (appPath, target) {
     events.emit('log', 'Deploying to simulator');
 
     if (!target) {
@@ -180,10 +180,11 @@ async function deployToSim (projectPath, appPath, target) {
         events.emit('log', `No target specified for emulator. Deploying to "${target}" simulator.`);
     }
 
-    return startSim(projectPath, appPath, target);
+    return startSim(appPath, target);
 }
 
-function startSim (projectPath, appPath, target) {
+function startSim (appPath, target) {
+    const projectPath = path.join(path.dirname(appPath), '../..');
     const logPath = path.join(projectPath, 'cordova/console.log');
     const deviceTypeId = `com.apple.CoreSimulator.SimDeviceType.${target}`;
 

--- a/tests/spec/create.spec.js
+++ b/tests/spec/create.spec.js
@@ -66,7 +66,7 @@ function verifyProjectBundleIdentifier (tmpDir, projectName, expectedBundleIdent
 function verifyBuild (tmpDir) {
     const Api = require(path.join(tmpDir, 'cordova/Api.js'));
 
-    return expectAsync(new Api().build({ emulator: true }))
+    return expectAsync(new Api('ios', tmpDir).build({ emulator: true }))
         .toBeResolved();
 }
 


### PR DESCRIPTION
### Motivation and Context

The goal of this PR is to eliminate all areas where our JS library expects to be located inside the project directory.

This is to prepare for a change that will keep the library in `node_modules` and not copy it to the platform project.

### Description

Basically this passes the project root that has been passed to `Api` to all places that need it but do not yet have it.

~~This also extends the E2E tests to check that we do not have to require the Api from the platform project folder.~~

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
