### PR TITLE
feat: support extending export options

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -215,7 +215,7 @@ module.exports.run = function (buildOpts) {
 
             const project = createProjectObject(projectPath, projectName);
             const bundleIdentifier = project.getPackageName();
-            const exportOptions = { compileBitcode: false, method: 'development' };
+            const exportOptions = { ...buildOpts.exportOptions, compileBitcode: false, method: 'development' };
 
             if (buildOpts.packageType) {
                 exportOptions.method = buildOpts.packageType;


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support extending the `exportOptions` through the `buildOpts`.

Resolves #1209 

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
