### PR TITLE
Fix #1232: Reload issue resulting in white screen

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -283,7 +283,9 @@ static void * KVOContext = &KVOContext;
 - (void) onAppWillEnterForeground:(NSNotification*)notification {
     if ([self shouldReloadWebView]) {
         NSLog(@"%@", @"CDVWebViewEngine reloading!");
-        [(WKWebView*)_engineWebView reload];
+        NSURL* url = [((CDVViewController*) self.viewController) appUrl];
+        NSURLRequest* appReq = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:20.0];
+        [self loadRequest:appReq];
     }
 }
 
@@ -529,7 +531,11 @@ static void * KVOContext = &KVOContext;
 
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
 {
-    [webView reload];
+    CDVViewController *vc = (CDVViewController *)self.viewController;
+    [vc showLaunchScreen:true];
+    NSURL* url = [vc appUrl];
+    NSURLRequest* appReq = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:20.0];
+    [self loadRequest:appReq];
 }
 
 - (BOOL)defaultResourcePolicyForURL:(NSURL*)url

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -83,6 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSString*)appURLScheme;
 - (nullable NSURL*)errorURL;
+- (NSURL*)appUrl;
 
 - (NSArray*)parseInterfaceOrientations:(NSArray*)orientations;
 - (BOOL)supportsOrientation:(UIInterfaceOrientation)orientation;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

Fixes #1232
Fixes meteor/meteor#11811

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If the iOS system kills the WKWebView processes due to e.g. memory issues, the Cordova app tries to reload the current URL on becoming foreground here:

https://github.com/apache/cordova-ios/blob/67b0bb2cfceb3f04fcd25a09222e86404805c594/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m#L530-L533

Due to client side routing, the current page may not be the correct initial URL (which includes an access token e.g.). Hence, some apps show a blank screen due to failure of reloading.

See https://github.com/apache/cordova-ios/issues/1232 and https://github.com/meteor/meteor/issues/11811 for an in-depth analysis of the problem and a feasible replication.

https://github.com/apache/cordova-ios/issues/1232 also indicates that the logic behind `shouldReloadWebView` could be an additional problem. @gouteru describes a further fix in https://github.com/apache/cordova-ios/issues/1232#issuecomment-1112812092 where they change this logic. As I found that the tests in

https://github.com/apache/cordova-ios/blob/67b0bb2cfceb3f04fcd25a09222e86404805c594/tests/CordovaLibTests/CDVWebViewEngineTest.m#L191-L193

explicitly state that an empty title should not result in a reload, I decided to not include they fix. But it could also be possible that the fix is required, as a result, the tests would have to be changed accordingly. If checking the title for 0 lengthiness is strictly required for your use case, please correct me @gouteru.

### Description
<!-- Describe your changes in detail -->
Since a reload is not sufficient, `CDVWebViewEngine.m` gets the initial app URL via `CDVViewController` (by making `appUrl` a public method) and initiates a new request with the initial app URL. The splashscreen is shown before the new request to hide a temporary white screen from the user.

### Testing
<!-- Please describe in detail how you tested your changes. -->
I used the changes with my Meteor/Cordova app on different iOS devices and I could not detect any white screen.

### Checklist
- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
