### PR TITLE
(iOS) Avoid repetitive permission prompts

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -189,6 +189,7 @@
 
     CDVWebViewUIDelegate* uiDelegate = [[CDVWebViewUIDelegate alloc] initWithViewController:self.viewController];
     uiDelegate.title = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    uiDelegate.mediaPermissionGrantType = [self parsePermissionGrantType:[settings cordovaSettingForKey:@"MediaPermissionGrantType"]];
     uiDelegate.allowNewWindows = [settings cordovaBoolSettingForKey:@"AllowNewWindows" defaultValue:NO];
     self.uiDelegate = uiDelegate;
 
@@ -451,6 +452,29 @@
 - (UIView*)webView
 {
     return self.engineWebView;
+}
+
+- (CDVWebViewPermissionGrantType)parsePermissionGrantType:(NSString*)optionString
+{
+    CDVWebViewPermissionGrantType result = CDVWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt;
+    
+    if (optionString != nil){
+        if ([optionString isEqualToString:@"prompt"]) {
+            result = CDVWebViewPermissionGrantType_Prompt;
+        } else if ([optionString isEqualToString:@"deny"]) {
+            result = CDVWebViewPermissionGrantType_Deny;
+        } else if ([optionString isEqualToString:@"grant"]) {
+            result = CDVWebViewPermissionGrantType_Grant;
+        } else if ([optionString isEqualToString:@"grantIfSameHostElsePrompt"]) {
+            result = CDVWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt;
+        } else if ([optionString isEqualToString:@"grantIfSameHostElseDeny"]) {
+            result = CDVWebViewPermissionGrantType_GrantIfSameHost_ElseDeny;
+        } else {
+            NSLog(@"Invalid \"MediaPermissionGrantType\" was detected. Fallback to default value of \"grantIfSameHostElsePrompt\"");
+        }
+    }
+    
+    return result;
 }
 
 #pragma mark WKScriptMessageHandler implementation

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
@@ -32,8 +32,17 @@ NS_ASSUME_NONNULL_BEGIN
 CDV_SWIFT_UI_ACTOR
 @interface CDVWebViewUIDelegate : NSObject <WKUIDelegate>
 
+typedef NS_ENUM(NSInteger, CDVWebViewPermissionGrantType) {
+    CDVWebViewPermissionGrantType_Prompt,
+    CDVWebViewPermissionGrantType_Deny,
+    CDVWebViewPermissionGrantType_Grant,
+    CDVWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt,
+    CDVWebViewPermissionGrantType_GrantIfSameHost_ElseDeny
+};
+
 @property (nonatomic, nullable, copy) NSString* title;
 @property (nonatomic, assign) BOOL allowNewWindows;
+@property (nonatomic, assign) CDVWebViewPermissionGrantType mediaPermissionGrantType;
 
 - (instancetype)initWithViewController:(CDVViewController*)vc;
 

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.m
@@ -159,6 +159,32 @@
     // We do not allow closing the primary WebView
 }
 
+- (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(nonnull WKSecurityOrigin *)origin initiatedByFrame:(nonnull WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(nonnull void (^)(WKPermissionDecision))decisionHandler
+  API_AVAILABLE(ios(15.0))
+{
+    WKPermissionDecision decision;
+    
+    if (_mediaPermissionGrantType == CDVWebViewPermissionGrantType_Prompt) {
+        decision = WKPermissionDecisionPrompt;
+    }
+    else if (_mediaPermissionGrantType == CDVWebViewPermissionGrantType_Deny) {
+        decision = WKPermissionDecisionDeny;
+    }
+    else if (_mediaPermissionGrantType == CDVWebViewPermissionGrantType_Grant) {
+        decision = WKPermissionDecisionGrant;
+    }
+    else {
+        if ([origin.host isEqualToString:webView.URL.host]) {
+            decision = WKPermissionDecisionGrant;
+        }
+        else {
+            decision =_mediaPermissionGrantType == CDVWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt ? WKPermissionDecisionPrompt : WKPermissionDecisionDeny;
+        }
+    }
+    
+    decisionHandler(decision);
+}
+
 #pragma mark - Utility Methods
 
 - (nullable UIViewController *)topViewController

--- a/templates/cordova/defaults.xml
+++ b/templates/cordova/defaults.xml
@@ -25,6 +25,7 @@
     <preference name="AllowInlineMediaPlayback" value="false" />
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
+    <preference name="MediaPermissionGrantType" value="grantIfSameHostElsePrompt" />
     <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="SuppressesLongPressGesture" value="false" />


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
resolves #1166 


### Description
<!-- Describe your changes in detail -->
If the app uses WebRTC, the user is initially prompted for permission twice, and then prompted again each time the app is restarted.

The solution is inspired by react:
https://github.com/react-native-webview/react-native-webview/pull/2257


### Testing
<!-- Please describe in detail how you tested your changes. -->
I tested the changes in a project that is using WebRTC camera streaming.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
