### PR TITLE
feat: Add LimitsNavigationsToAppBoundDomains configuration key

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -145,6 +145,10 @@
         
     }
 
+    if (@available(iOS 14.0, *)) {
+        configuration.limitsNavigationsToAppBoundDomains = [settings cordovaBoolSettingForKey:@"LimitsNavigationsToAppBoundDomains" defaultValue:NO];
+    }
+
     return configuration;
 }
 

--- a/CordovaLib/cordova.js
+++ b/CordovaLib/cordova.js
@@ -1,5 +1,5 @@
 // Platform: ios
-// 538a985db128858c0a0eb4dd40fb9c8e5433fc94
+// cordova-js rel/6.0.0-10-g07379820
 /*
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/CordovaLib/cordova.js
+++ b/CordovaLib/cordova.js
@@ -1,5 +1,5 @@
 // Platform: ios
-// cordova-js rel/6.0.0-10-g07379820
+// 538a985db128858c0a0eb4dd40fb9c8e5433fc94
 /*
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
### Platforms affected

IOS

### Motivation and Context

Currently there is no option to set the limitsNavigationsToAppBoundDomains attribute from the `config.xml`.  If you want to use cookie authentication or browser APIs you want to set this to `YES`.

Official documentation: https://webkit.org/blog/10882/app-bound-domains/

### Description

This changeset is copied from this tutorial: https://www.ryseapp.io/blog/engineering/step-by-step-guide-to-setup-and-configure-cordova-for-ios-and-android-to-load-a-hosted-react-app

### Testing

Tested on multiple simulator instances and and physical hardware. Without it the cookie authentication for a single domain will not work. After I add this change the authentication works.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
