### PR TITLE
fix(CDVPlugin): Swift init

### DIFF
--- a/CordovaLib/Classes/Public/CDVPlugin.m
+++ b/CordovaLib/Classes/Public/CDVPlugin.m
@@ -66,7 +66,7 @@ NSString* const CDVViewWillTransitionToSizeNotification = @"CDVViewWillTransitio
 // Do not override these methods. Use pluginInitialize instead.
 - (instancetype)initWithWebViewEngine:(id <CDVWebViewEngineProtocol>)theWebViewEngine
 {
-    self = [super init];
+    self = [self init];
     if (self) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppTerminate) name:UIApplicationWillTerminateNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onMemoryWarning) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];

--- a/tests/CordovaLibTests/CDVPluginInitTests.m
+++ b/tests/CordovaLibTests/CDVPluginInitTests.m
@@ -1,0 +1,68 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import <Cordova/CDV.h>
+#import "AppDelegate.h"
+
+@interface CDVPluginInitTests : XCTestCase
+@property AppDelegate* appDelegate;
+@property CDVViewController* viewController;
+@end
+
+@implementation CDVPluginInitTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Stop tests on the first failed assertion. Having the test stop on the
+    // first exception makes it much easier to identify the source of the error.
+    // On iOS < 5 there is a bug in SenTestingKit where the exception is
+    // uncaught and the app crashes upon a failed STAssert (oh well).
+    // [self raiseAfterFailure];
+
+    self.appDelegate = [[UIApplication sharedApplication] delegate];
+    [self.appDelegate createViewController];
+    self.viewController = self.appDelegate.viewController;
+}
+
+- (void)tearDown
+{
+    // Enforce that the view controller is released between tests to ensure
+    // tests don't affect each other.
+    [self.appDelegate destroyViewController];
+    [super tearDown];
+}
+
+- (id)pluginInstance:(NSString*)pluginName
+{
+    id ret = [self.viewController getCommandInstance:pluginName];
+
+    XCTAssertNotNil(ret, @"Missing plugin %@", pluginName);
+    return ret;
+}
+
+- (void)testSwiftVariablesInitialized
+{
+    CDVPlugin* swiftPlugin = [self pluginInstance:@"SwiftInit"];
+
+    XCTAssertTrue([@"Successfully initialized" isEqualToString:[swiftPlugin performSelector:sel_getUid("getInitString")]]);
+}
+@end

--- a/tests/CordovaLibTests/CordovaLibApp/SwiftInitPlugin.swift
+++ b/tests/CordovaLibTests/CordovaLibApp/SwiftInitPlugin.swift
@@ -1,0 +1,26 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+@objc class SwiftInitPlugin : CDVPlugin {
+    let initStr : String = "Successfully initialized";
+
+    @objc func getInitString() -> String {
+        return self.initStr;
+    }
+}

--- a/tests/CordovaLibTests/CordovaLibApp/config.xml
+++ b/tests/CordovaLibTests/CordovaLibApp/config.xml
@@ -62,4 +62,7 @@
         <param name="ios-package" value="CDVGestureHandler"/>
         <param name="onload" value="true"/>
     </feature>
+    <feature name="SwiftInit">
+        <param name="ios-package" value="SwiftInitPlugin"/>
+    </feature>
 </widget>

--- a/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
+++ b/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		686357B5141002F200DF4CF2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 686357B3141002F200DF4CF2 /* InfoPlist.strings */; };
 		686357BA141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 686357B9141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m */; };
 		7EF33BD71911ABA20048544E /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7EF33BD61911ABA20048544E /* Default-568h@2x.png */; };
+		902530FB29A6DC53004AF1CF /* CDVPluginInitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 902530FA29A6DC53004AF1CF /* CDVPluginInitTests.m */; };
+		902530FC29A6DC53004AF1CF /* CDVPluginInitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 902530FA29A6DC53004AF1CF /* CDVPluginInitTests.m */; };
+		908630C829A6D003002963FA /* SwiftInitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908630C729A6D003002963FA /* SwiftInitPlugin.swift */; };
+		908630C929A6D003002963FA /* SwiftInitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908630C729A6D003002963FA /* SwiftInitPlugin.swift */; };
 		C0FA7C9B1E4BB6420077B045 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 303A4073152124BB00182201 /* main.m */; };
 		C0FA7C9C1E4BB6420077B045 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 303A4077152124BB00182201 /* AppDelegate.m */; };
 		C0FA7C9D1E4BB6420077B045 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 303A407A152124BB00182201 /* ViewController.m */; };
@@ -99,6 +103,8 @@
 		686357B4141002F200DF4CF2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		686357B9141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVPluginResultJSONSerializationTests.m; sourceTree = "<group>"; };
 		7EF33BD61911ABA20048544E /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		902530FA29A6DC53004AF1CF /* CDVPluginInitTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVPluginInitTests.m; sourceTree = "<group>"; };
+		908630C729A6D003002963FA /* SwiftInitPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftInitPlugin.swift; sourceTree = "<group>"; };
 		C0FA7CAA1E4BB6420077B045 /* CordovaFrameworkApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CordovaFrameworkApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0FA7CAC1E4BB6B30077B045 /* Cordova.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cordova.framework; path = "../Debug-iphonesimulator/Cordova.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0FA7CC71E4BBBBE0077B045 /* CordovaFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CordovaFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -187,6 +193,7 @@
 				303A4079152124BB00182201 /* ViewController.h */,
 				303A407A152124BB00182201 /* ViewController.m */,
 				303A406E152124BB00182201 /* Supporting Files */,
+				908630C729A6D003002963FA /* SwiftInitPlugin.swift */,
 			);
 			path = CordovaLibApp;
 			sourceTree = "<group>";
@@ -214,6 +221,7 @@
 		EB3B34F4161B585D003DBE7D /* CordovaLibTests */ = {
 			isa = PBXGroup;
 			children = (
+				902530FA29A6DC53004AF1CF /* CDVPluginInitTests.m */,
 				4E23F90123E175AD006CD852 /* CDVWebViewEngineTest.m */,
 				30D1B08B15A2B36D0060C291 /* CDVBase64Tests.m */,
 				30610C9119AD9B95000B3781 /* CDVCommandDelegateTests.m */,
@@ -424,6 +432,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				908630C829A6D003002963FA /* SwiftInitPlugin.swift in Sources */,
 				303A4074152124BB00182201 /* main.m in Sources */,
 				303A4078152124BB00182201 /* AppDelegate.m in Sources */,
 				303A407B152124BB00182201 /* ViewController.m in Sources */,
@@ -436,6 +445,7 @@
 			files = (
 				3035621714104C34006C2D43 /* CDVAllowListTests.m in Sources */,
 				686357BA141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m in Sources */,
+				902530FB29A6DC53004AF1CF /* CDVPluginInitTests.m in Sources */,
 				30D1B08C15A2B36D0060C291 /* CDVBase64Tests.m in Sources */,
 				EBA3554615A731F100F4DE24 /* CDVFakeFileManager.m in Sources */,
 				4E23F90223E175AD006CD852 /* CDVWebViewEngineTest.m in Sources */,
@@ -449,6 +459,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				908630C929A6D003002963FA /* SwiftInitPlugin.swift in Sources */,
 				C0FA7C9B1E4BB6420077B045 /* main.m in Sources */,
 				C0FA7C9C1E4BB6420077B045 /* AppDelegate.m in Sources */,
 				C0FA7C9D1E4BB6420077B045 /* ViewController.m in Sources */,
@@ -461,6 +472,7 @@
 			files = (
 				C0FA7CB51E4BBBBE0077B045 /* CDVAllowListTests.m in Sources */,
 				C0FA7CB61E4BBBBE0077B045 /* CDVPluginResultJSONSerializationTests.m in Sources */,
+				902530FC29A6DC53004AF1CF /* CDVPluginInitTests.m in Sources */,
 				C0FA7CB91E4BBBBE0077B045 /* CDVBase64Tests.m in Sources */,
 				C0FA7CBA1E4BBBBE0077B045 /* CDVFakeFileManager.m in Sources */,
 				C0FA7CBB1E4BBBBE0077B045 /* CDVViewControllerTest.m in Sources */,
@@ -551,7 +563,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = include/Cordova;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "__PROJECT_NAME__/Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "CordovaLibApp/Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = (
 					"Classes/**",
@@ -604,7 +616,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = include/Cordova;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "__PROJECT_NAME__/Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "CordovaLibApp/Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = (
 					"Classes/**",
@@ -636,6 +648,7 @@
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.cordovalibapptests.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../CordovaLib/Classes/Private/**";
 				WRAPPER_EXTENSION = app;
@@ -661,6 +674,7 @@
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.cordovalibapptests.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../CordovaLib/Classes/Private/**";
 				VALIDATE_PRODUCT = YES;
@@ -761,6 +775,7 @@
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.cordovalibapptests.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../CordovaLib/Classes/Private/**";
 				WRAPPER_EXTENSION = app;
@@ -790,6 +805,7 @@
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.cordovalibapptests.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../CordovaLib/Classes/Private/**";
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1288 


### Description
<!-- Describe your changes in detail -->
This ensures that the default `init` method is called for CDVPlugin subclasses, to allow Swift initializers to run as expected.


Aside: I still feel like `NS_DESIGNATED_INITIALIZER` would be the theoretically correct way to solve this, but that doesn't work when our designated initializer with the webview is part of private implementation details (your designated initializer must be part of your public API surface).
The risk is that someone could (in their own code) do `[[MyCordovaPlugin alloc] init]` and try to construct a plugin instance without providing the webview engine, and lead to all sorts of weird issues.

However, that problem already existed and people don't seem to be shooting themselves in the foot with it (or at least, not complaining here when they do), so it's probably better to fix the issue that is impacting people even if the solution isn't theoretically perfect.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Added a unit test which ensures that an init-time property in a Swift plugin is correctly set after the plugin has been initialized. This test case fails without the changes to CDVPlugin.m.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
