### PR TITLE
Fix URL parsing for ATS in node 18

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -997,12 +997,8 @@ function processAccessAndAllowNavigationEntries (config) {
     null is returned if the URL cannot be parsed, or is to be skipped for ATS.
 */
 function parseAllowlistUrlForATS (url, options) {
-    // @todo 'url.parse' was deprecated since v11.0.0. Use 'url.URL' constructor instead.
-    const href = URL.parse(url); // eslint-disable-line
-    const retObj = {};
-    retObj.Hostname = href.hostname;
-
     // Guiding principle: we only set values in retObj if they are NOT the default
+    const retObj = {};
 
     if (url === '*') {
         retObj.Hostname = '*';
@@ -1026,25 +1022,31 @@ function parseAllowlistUrlForATS (url, options) {
         return retObj;
     }
 
-    if (!retObj.Hostname) {
-        // check origin, if it allows subdomains (wildcard in hostname), we set NSIncludesSubdomains to YES. Default is NO
-        const subdomain1 = '/*.'; // wildcard in hostname
-        const subdomain2 = '*://*.'; // wildcard in hostname and protocol
-        const subdomain3 = '*://'; // wildcard in protocol only
-        if (!href.pathname) {
-            return null;
-        } else if (href.pathname.indexOf(subdomain1) === 0) {
-            retObj.NSIncludesSubdomains = true;
-            retObj.Hostname = href.pathname.substring(subdomain1.length);
-        } else if (href.pathname.indexOf(subdomain2) === 0) {
-            retObj.NSIncludesSubdomains = true;
-            retObj.Hostname = href.pathname.substring(subdomain2.length);
-        } else if (href.pathname.indexOf(subdomain3) === 0) {
-            retObj.Hostname = href.pathname.substring(subdomain3.length);
+    let href = null;
+    try {
+        href = new URL.URL(url);
+    } catch (e) {
+        const scheme = url.split(':')[0];
+        // If there's a wildcard in the protocol, the URL will fail to parse
+        // Replace it with "http" to allow insecure loads
+        if (scheme.includes('*')) {
+            href = new URL.URL(url.replace(scheme, 'http'));
         } else {
-            // Handling "scheme:*" case to avoid creating of a blank key in NSExceptionDomains.
             return null;
         }
+    }
+
+    retObj.Hostname = href.hostname;
+
+    // Handling "scheme:*" case to avoid creating of a blank key in NSExceptionDomains.
+    if (retObj.Hostname === '') {
+        return null;
+    }
+
+    // check origin, if it allows subdomains (wildcard in hostname), we set NSIncludesSubdomains to YES. Default is NO
+    if (retObj.Hostname.startsWith('*.')) {
+        retObj.NSIncludesSubdomains = true;
+        retObj.Hostname = href.hostname.substring(2);
     }
 
     if (options.minimum_tls_version && options.minimum_tls_version !== 'TLSv1.2') { // default is TLSv1.2
@@ -1063,8 +1065,6 @@ function parseAllowlistUrlForATS (url, options) {
 
     // if the scheme is HTTP, we set NSExceptionAllowsInsecureHTTPLoads to YES. Default is NO
     if (href.protocol === 'http:') {
-        retObj.NSExceptionAllowsInsecureHTTPLoads = true;
-    } else if (!href.protocol && href.pathname.indexOf('*:/') === 0) { // wilcard in protocol
         retObj.NSExceptionAllowsInsecureHTTPLoads = true;
     }
 


### PR DESCRIPTION
### Platforms affected
iOS, with node18


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #1290: currently parsing of `access`, `allow-navigation`, and `allow-intent` directives in config.xml for Application Transport Security is broken when using node 18 due to changes to how node handles URLs.


### Description
<!-- Describe your changes in detail -->
Move URL parsing to the (non-deprecated) WHATWG URL API in node, and workaround the issues that cause URL parsing to fail or return unexpected results with that API.


### Testing
<!-- Please describe in detail how you tested your changes. -->
All unit tests pass, but I would feel more confident if people tried throwing some weirder corner cases at this to ensure it's actually behaving consistently with previous versions.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))