### PR TITLE
Remove long-unused codeSignResourceRules option

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -30,7 +30,6 @@ const projectFile = require('./projectFile');
 
 const buildConfigProperties = [
     'codeSignIdentity',
-    'codeSignResourceRules',
     'provisioningProfile',
     'developmentTeam',
     'packageType',
@@ -175,9 +174,6 @@ module.exports.run = function (buildOpts) {
             if (buildOpts.codeSignIdentity) {
                 extraConfig += `CODE_SIGN_IDENTITY = ${buildOpts.codeSignIdentity}\n`;
                 extraConfig += `CODE_SIGN_IDENTITY[sdk=iphoneos*] = ${buildOpts.codeSignIdentity}\n`;
-            }
-            if (buildOpts.codeSignResourceRules) {
-                extraConfig += `CODE_SIGN_RESOURCE_RULES_PATH = ${buildOpts.codeSignResourceRules}\n`;
             }
             if (buildOpts.provisioningProfile) {
                 if (typeof buildOpts.provisioningProfile === 'string') {


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Xcode hasn't supported specifying codesigning resource rules since pre-Mavericks, so this serves no purpose anymore.
Closes #563.


### Description
<!-- Describe your changes in detail -->
Remove support for the `--codeSignResourceRules` option.


### Testing
<!-- Please describe in detail how you tested your changes. -->
All unit tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
