### PR TITLE
feat: add listTarget api & revert original bin file location

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -665,6 +665,11 @@ class Api {
             .then(() => require('./run').run.call(this, runOptions));
     }
 
+    listTargets (options) {
+        return check_reqs.run()
+            .then(() => require('./run').runListDevices.call(this, options));
+    }
+
     /**
      * Cleans out the build artifacts from platform's directory.
      *

--- a/lib/run.js
+++ b/lib/run.js
@@ -229,16 +229,16 @@ function listEmulators () {
         });
 }
 
-module.exports.runListDevices = async function (options) {
-    const { options: cliArgs } = options;
+module.exports.runListDevices = async function (options = {}) {
+    const { options: cliArgs = {} } = options;
 
-    if (cliArgs.device) {
-        await listDevices.call(this);
-    } else if (cliArgs.emulator) {
-        await listEmulators.call(this);
+    if (cliArgs?.device) {
+        await module.exports.listDevices.call(this);
+    } else if (cliArgs?.emulator) {
+        await module.exports.listEmulators.call(this);
     } else {
-        await listDevices.call(this);
-        await listEmulators.call(this);
+        await module.exports.listDevices.call(this);
+        await module.exports.listEmulators.call(this);
     }
 
     return true;

--- a/lib/run.js
+++ b/lib/run.js
@@ -228,3 +228,18 @@ function listEmulators () {
             });
         });
 }
+
+module.exports.runListDevices = async function (options) {
+    const { options: cliArgs } = options;
+
+    if (cliArgs.device) {
+        await listDevices.call(this);
+    } else if (cliArgs.emulator) {
+        await listEmulators.call(this);
+    } else {
+        await listDevices.call(this);
+        await listEmulators.call(this);
+    }
+
+    return true;
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "xcodebuild": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -destination \"platform=iOS Simulator,name=iPhone 8\" CONFIGURATION_BUILD_DIR=\"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
     "preobjc-tests": "killall Simulator || true",
     "unit-tests": "jasmine --config=tests/spec/unit.json",
-    "lint": "eslint . \"lib/**/!(*.*)\""
+    "lint": "eslint . \"templates/cordova/lib/!(*.*)\""
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",

--- a/templates/cordova/lib/list-devices
+++ b/templates/cordova/lib/list-devices
@@ -19,7 +19,7 @@
        under the License.
 */
 
-const { run } = require('./listDevices');
+const { run } = require('cordova-ios/lib/listDevices');
 
 run().then(devices => {
     devices.forEach(device => {

--- a/templates/cordova/lib/list-emulator-images
+++ b/templates/cordova/lib/list-emulator-images
@@ -19,7 +19,7 @@
        under the License.
 */
 
-const { run } = require('./listEmulatorImages');
+const { run } = require('cordova-ios/lib/listEmulatorImages');
 
 run().then(names => {
     names.forEach(name => {

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -92,6 +92,18 @@ describe('Platform Api', () => {
                     });
                 });
             });
+
+            describe('listTargets', () => {
+                beforeEach(() => {
+                    spyOn(check_reqs, 'run').and.returnValue(Promise.resolve());
+                });
+                it('should call into lib/run module', () => {
+                    spyOn(run_mod, 'runListDevices');
+                    return api.listTargets().then(() => {
+                        expect(run_mod.runListDevices).toHaveBeenCalled();
+                    });
+                });
+            });
         }
 
         describe('addPlugin', () => {

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -48,6 +48,27 @@ if (process.platform === 'darwin') {
                     expect(run.listEmulators).toHaveBeenCalled();
                 });
             });
+
+            it('should delegate to "listDevices" when the "runListDevices" method options param contains "options.device".', () => {
+                return run.runListDevices({ options: { device: true } }).then(() => {
+                    expect(run.listDevices).toHaveBeenCalled();
+                    expect(run.listEmulators).not.toHaveBeenCalled();
+                });
+            });
+
+            it('should delegate to "listDevices" when the "runListDevices" method options param contains "options.emulator".', () => {
+                return run.runListDevices({ options: { emulator: true } }).then(() => {
+                    expect(run.listDevices).not.toHaveBeenCalled();
+                    expect(run.listEmulators).toHaveBeenCalled();
+                });
+            });
+
+            it('should delegate to both "listEmulators" and "listDevices" when the "runListDevices" method does not contain "options.device" or "options.emulator".', () => {
+                return run.runListDevices({ options: {} }).then(() => {
+                    expect(run.listDevices).toHaveBeenCalled();
+                    expect(run.listEmulators).toHaveBeenCalled();
+                });
+            });
         });
     });
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support calling for listTarget on the PlatformAPI.
Will be used by Cordova CLI/Lib 12

Reverted the location of the binraries to the original location. Needed for older CLI versions. 

### Description
<!-- Describe your changes in detail -->

Added `listTargets` on platform api and added supporting methods in the `run.js` file

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
