### PR TITLE
(ios) fix: memory leak when removing the CDVViewController

### DIFF
--- a/CordovaLib/include/Cordova/CDVURLSchemeHandler.h
+++ b/CordovaLib/include/Cordova/CDVURLSchemeHandler.h
@@ -25,7 +25,7 @@
 
 @interface CDVURLSchemeHandler : NSObject <WKURLSchemeHandler>
 
-@property (nonatomic, strong) CDVViewController* viewController;
+@property (nonatomic, weak) CDVViewController* viewController;
 
 @property (nonatomic) CDVPlugin* schemePlugin;
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
I am using Cordova inside a React Native application so I often need to destroy and re-create the CDVViewController.



### Description
Since I am using a custom scheme, it is leaking (the CDVViewController is never deallocated despite being remove from its parentViewController)



### Testing
I confirm that by changing strong to weak, the CDVViewController is deallocated as soon as it is removed from its parent view controller.



### Checklist

- [yes] I've run the tests to see all new and existing tests pass
- [no] I added automated test coverage as appropriate for this change
- [yes ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [no ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [no ] I've updated the documentation if necessary
