### PR TITLE
(ios) feat: navigationAction in shouldOverrideLoadWithRequest

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -582,6 +582,14 @@ static void * KVOContext = &KVOContext;
                 break;
             }
         }
+        SEL selector2 = NSSelectorFromString(@"shouldOverrideLoadWithRequest:navigationAction:");
+        if ([plugin respondsToSelector:selector2]) {
+            anyPluginsResponded = YES;
+            shouldAllowRequest = (((BOOL (*)(id, SEL, id, id))objc_msgSend)(plugin, selector2, navigationAction.request, navigationAction));
+            if (!shouldAllowRequest) {
+                break;
+            }
+        }
     }
 
     if (anyPluginsResponded) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently `shouldOverrideLoadWithRequest` only returns the `request` and `navigationType`, the plugin I'm working with needs to check if `navigationAction.sourceFrame` is null or not to decide whether to open the url in the browser, currently I can't do that (far as I know).

### Description
<!-- Describe your changes in detail -->

Added a new `shouldOverrideLoadWithRequest:navigationAction` selector to have full access to the `navigationAction` object.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I have kept the old implementation so that plugins that already use it are not affected, with the change both the old and the new one work correctly.

I don't know if there is a better way to implement this, since my knowledge of `Objective-C` is basic, or if it would be better to replace completely with the new one, to avoid redundancy.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
