### PR TITLE
Make the WebView the first responder when it loads

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -796,6 +796,10 @@
 
     [UIView animateWithDuration:fadeDuration animations:^{
         [self.launchView setAlpha:(visible ? 1 : 0)];
+
+        if (!visible) {
+            [self.webView becomeFirstResponder];
+        }
     }];
 }
 


### PR DESCRIPTION
Fixes #1132.
Maybe fixes #455.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Presently, the splashscreen becomes the focused view when the app loads, and it never moves focus back to the webview. This means that the webview does not receive events (such as keypresses) until it is explicitly focused by the user (by tapping in it). We want the webview to become the focused element when the splashscreen is hidden.


### Description
<!-- Describe your changes in detail -->
Upon hiding the splashscreen, set the webview as the first responder for event handling.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested this in iOS simulator and on macOS (with Catalyst)


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
