### PR TITLE
chore: Remove unused BackupWebStorage preference

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -278,14 +278,6 @@
     // Load settings
     [self loadSettings];
 
-    NSString* backupWebStorageType = @"cloud"; // default value
-
-    id backupWebStorage = [self.settings cordovaSettingForKey:@"BackupWebStorage"];
-    if ([backupWebStorage isKindOfClass:[NSString class]]) {
-        backupWebStorageType = backupWebStorage;
-    }
-    [self.settings setCordovaSetting:backupWebStorageType forKey:@"BackupWebStorage"];
-
     // // Instantiate the Launch screen /////////
 
     if (!self.launchView) {

--- a/templates/cordova/defaults.xml
+++ b/templates/cordova/defaults.xml
@@ -23,7 +23,6 @@
 
     <!-- Preferences for iOS -->
     <preference name="AllowInlineMediaPlayback" value="false" />
-    <preference name="BackupWebStorage" value="cloud" />
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />

--- a/templates/project/__PROJECT_NAME__/config.xml
+++ b/templates/project/__PROJECT_NAME__/config.xml
@@ -49,7 +49,6 @@
 
     <!-- Preferences for iOS -->
     <preference name="AllowInlineMediaPlayback" value="false" />
-    <preference name="BackupWebStorage" value="cloud" />
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />

--- a/tests/CordovaLibTests/CordovaLibApp/config.xml
+++ b/tests/CordovaLibTests/CordovaLibApp/config.xml
@@ -37,7 +37,6 @@
 
     <!-- Preferences for iOS -->
     <preference name="AllowInlineMediaPlayback" value="false" />
-    <preference name="BackupWebStorage" value="cloud" />
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />

--- a/tests/spec/unit/fixtures/ios-config-xml/SampleApp/config.xml
+++ b/tests/spec/unit/fixtures/ios-config-xml/SampleApp/config.xml
@@ -33,7 +33,6 @@
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
     <preference name="AllowInlineMediaPlayback" value="false" />
-    <preference name="BackupWebStorage" value="cloud" />
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="MediaTypesRequiringUserActionForPlayback" value="false" />

--- a/tests/spec/unit/fixtures/ios-config-xml/cordova/defaults.xml
+++ b/tests/spec/unit/fixtures/ios-config-xml/cordova/defaults.xml
@@ -23,7 +23,6 @@
 
     <!-- Preferences for iOS -->
     <preference name="AllowInlineMediaPlayback" value="false" />
-    <preference name="BackupWebStorage" value="cloud" />
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />


### PR DESCRIPTION
Fixes #1332.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This preference is unused (since at least the move from UIWebView to WKWebView)


### Description
<!-- Describe your changes in detail -->
Remove some special handling that was being done in CDVViewController for an unused BackupWebStorage preference.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Unit tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))