### PR TITLE
fix: Add missing cordova versions to CDVAvailability.h

### DIFF
--- a/CordovaLib/include/Cordova/CDVAvailability.h
+++ b/CordovaLib/include/Cordova/CDVAvailability.h
@@ -78,6 +78,8 @@
 #define __CORDOVA_6_0_0 60000
 #define __CORDOVA_6_1_0 60100
 #define __CORDOVA_6_2_0 60200
+#define __CORDOVA_6_3_0 60300
+#define __CORDOVA_7_0_0 70000
 /* coho:next-version,insert-before */
 #define __CORDOVA_NA 99999      /* not available */
 
@@ -90,7 +92,7 @@
  */
 #ifndef CORDOVA_VERSION_MIN_REQUIRED
     /* coho:next-version-min-required,replace-after */
-    #define CORDOVA_VERSION_MIN_REQUIRED __CORDOVA_6_2_0
+    #define CORDOVA_VERSION_MIN_REQUIRED __CORDOVA_7_0_0
 #endif
 
 /*


### PR DESCRIPTION
This is supposedly done by coho during the release process, but looks like last two releases failed to do it, so the versions are missing.

EDIT: 
CDVAvailability.h file was moved, so the code in coho was not working, I've updated the path on coho
https://github.com/apache/cordova-coho/pull/323

