### PR TITLE
chore: make code compile on Xcode 11

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -158,9 +158,11 @@
         
     }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
     if (@available(iOS 14.0, *)) {
         configuration.limitsNavigationsToAppBoundDomains = [settings cordovaBoolSettingForKey:@"LimitsNavigationsToAppBoundDomains" defaultValue:NO];
     }
+#endif
 
     return configuration;
 }


### PR DESCRIPTION
Cordova still supports Xcode 11 technically since we have not officially dropped support for it, but this code doesn't compile on Xcode 11, making paramedic to fail.
The PR puts the code inside a `__IPHONE_OS_VERSION_MAX_ALLOWED` version check so it compiles.