### PR TITLE
chore: Bump xcodebuild version check to 11

### DIFF
--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -25,7 +25,7 @@ const { CordovaError } = require('cordova-common');
 
 const SUPPORTED_OS_PLATFORMS = ['darwin'];
 
-const XCODEBUILD_MIN_VERSION = '9.0.0';
+const XCODEBUILD_MIN_VERSION = '11.0.0';
 const XCODEBUILD_NOT_FOUND_MESSAGE =
     `Please install version ${XCODEBUILD_MIN_VERSION} or greater from App Store`;
 


### PR DESCRIPTION
in cordova-ios 6 the project was updated to Xcode 11, so Xcode/xcodebuild 11 is required, but the version check was not bumped, so bumping it now.