### PR TITLE
fix: WASM MIME type error by specifying it in Info.plist template

### DIFF
--- a/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
+++ b/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
@@ -45,5 +45,25 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>WebAssembly</string>
+			<key>UTTypeIdentifier</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<string>wasm</string>
+				<key>public.mime-type</key>
+				<string>application/wasm</string>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
+++ b/templates/project/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist
@@ -45,7 +45,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UTExportedTypeDeclarations</key>
+	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>
 			<key>UTTypeConformsTo</key>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1370 where WebAssembly cannot be loaded in iOS production build due to the error `"Unexpected response MIME type. Expected 'application/wasm'"`. The error causes a blank app screen and prevents any user interaction.

### Description
<!-- Describe your changes in detail -->

I added `UTExportedTypeDeclarations` to the Info.plist template file, specifying the expected MIME type for loading WASM files.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I modified my project's Info.plist file by adding the `UTExportedTypeDeclarations` key and value as shown in the commit, built and ran my project on the device, and verified that the app loads and is displayed as expected.

The automated tests don't run on my macOS version as it does not match CordovaLibTests’s deployment target. I don't know how to get the tests running.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary