### PR TITLE
fix!: Deprecate(/Remove) scrollView category extension on UIView

### DIFF
--- a/CordovaLib/include/Cordova/CDVPlugin.h
+++ b/CordovaLib/include/Cordova/CDVPlugin.h
@@ -27,11 +27,15 @@
 #import <Cordova/CDVViewController.h>
 #import <Cordova/CDVWebViewEngineProtocol.h>
 
+#ifndef __swift__
+// This global extension to the UIView class causes issues for Swift subclasses
+// of UIView with their own scrollView properties, so we're removing it from
+// the exposed Swift API and marking it as deprecated
+// TODO: Remove in Cordova 9
 @interface UIView (org_apache_cordova_UIView_Extension)
-
-@property (nonatomic, weak) UIScrollView* scrollView;
-
+@property (nonatomic, weak) UIScrollView* scrollView CDV_DEPRECATED(8, "Check for a scrollView property on the view object at runtime and invoke it dynamically.");
 @end
+#endif
 
 extern NSString* const CDVPageDidLoadNotification;
 extern NSString* const CDVPluginHandleOpenURLNotification;


### PR DESCRIPTION


### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As mentioned in #1399, this API was added as a compatibility shim at the time we supported both UIWebView and WKWebView, when WKWebView did not expose a public `scrollView` property. That property was made available in iOS 8, and this extension now risks causing problems due to being applied globally to all UIView subclasses.

Closes #1399.

### Description
<!-- Describe your changes in detail -->
Deprecate the category extension to expose a `scrollView` property on all UIView object instances, and remove it entirely from visibility to Swift.


### Testing
<!-- Please describe in detail how you tested your changes. -->
* Existing tests pass.
* Tested against all core Apache plugins.
* Manually tested that this resolves the issue in #1399 where a Swift UIView subclass defines a `scrollView` property


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
