### PR TITLE
feat: add privacy-manifest config support

### DIFF
--- a/lib/ConfigParseriOS.js
+++ b/lib/ConfigParseriOS.js
@@ -1,0 +1,45 @@
+
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+'use strict';
+
+const et = require('elementtree');
+const fs = require('fs-extra');
+const path = require('path');
+const ConfigParser = require('cordova-common').ConfigParser;
+
+class ConfigParseriOS extends ConfigParser {
+    constructor (path) {
+        super(path);
+    }
+
+    /** getPrivacyManifest */
+    getPrivacyManifest () {
+        const platform_manifest = this.doc.find(`./platform[@name="ios"]/privacy-manifest-ios`);
+        if (platform_manifest != null) {
+            return platform_manifest;
+        }
+        const manifest = this.doc.find('privacy-manifest-ios');
+        return manifest;
+    }
+}
+
+module.exports = ConfigParseriOS;
+

--- a/lib/ConfigParseriOS.js
+++ b/lib/ConfigParseriOS.js
@@ -20,19 +20,12 @@
 
 'use strict';
 
-const et = require('elementtree');
-const fs = require('fs-extra');
-const path = require('path');
 const ConfigParser = require('cordova-common').ConfigParser;
 
 class ConfigParseriOS extends ConfigParser {
-    constructor (path) {
-        super(path);
-    }
-
     /** getPrivacyManifest */
     getPrivacyManifest () {
-        const platform_manifest = this.doc.find(`./platform[@name="ios"]/privacy-manifest-ios`);
+        const platform_manifest = this.doc.find('./platform[@name="ios"]/privacy-manifest-ios');
         if (platform_manifest != null) {
             return platform_manifest;
         }
@@ -42,4 +35,3 @@ class ConfigParseriOS extends ConfigParser {
 }
 
 module.exports = ConfigParseriOS;
-

--- a/lib/PlatformConfigParser.js
+++ b/lib/PlatformConfigParser.js
@@ -17,8 +17,6 @@
     under the License.
 */
 
-'use strict';
-
 const ConfigParser = require('cordova-common').ConfigParser;
 
 class PlatformConfigParser extends ConfigParser {

--- a/lib/PlatformConfigParser.js
+++ b/lib/PlatformConfigParser.js
@@ -22,7 +22,7 @@
 
 const ConfigParser = require('cordova-common').ConfigParser;
 
-class ConfigParseriOS extends ConfigParser {
+class PlatformConfigParser extends ConfigParser {
     /** getPrivacyManifest */
     getPrivacyManifest () {
         const platform_manifest = this.doc.find('./platform[@name="ios"]/privacy-manifest-ios');
@@ -34,4 +34,4 @@ class ConfigParseriOS extends ConfigParser {
     }
 }
 
-module.exports = ConfigParseriOS;
+module.exports = PlatformConfigParser;

--- a/lib/PlatformConfigParser.js
+++ b/lib/PlatformConfigParser.js
@@ -1,4 +1,3 @@
-
 /**
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -25,12 +24,11 @@ const ConfigParser = require('cordova-common').ConfigParser;
 class PlatformConfigParser extends ConfigParser {
     /** getPrivacyManifest */
     getPrivacyManifest () {
-        const platform_manifest = this.doc.find('./platform[@name="ios"]/privacy-manifest-ios');
+        const platform_manifest = this.doc.find('./platform[@name="ios"]/privacy-manifest');
         if (platform_manifest != null) {
             return platform_manifest;
         }
-        const manifest = this.doc.find('privacy-manifest-ios');
-        return manifest;
+        return null;
     }
 }
 

--- a/lib/PlatformConfigParser.js
+++ b/lib/PlatformConfigParser.js
@@ -22,13 +22,12 @@
 const ConfigParser = require('cordova-common').ConfigParser;
 
 class PlatformConfigParser extends ConfigParser {
-    /** getPrivacyManifest */
+    /**
+     * Returns the privacy manifest node, if available.
+     * Otherwise `null` is returned.
+     */
     getPrivacyManifest () {
-        const platform_manifest = this.doc.find('./platform[@name="ios"]/privacy-manifest');
-        if (platform_manifest != null) {
-            return platform_manifest;
-        }
-        return null;
+        return this.doc.find('./platform[@name="ios"]/privacy-manifest');
     }
 }
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -23,6 +23,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const unorm = require('unorm');
 const plist = require('plist');
+const et = require('elementtree');
 const URL = require('url');
 const events = require('cordova-common').events;
 const xmlHelpers = require('cordova-common').xmlHelpers;
@@ -35,6 +36,7 @@ const FileUpdater = require('cordova-common').FileUpdater;
 const projectFile = require('./projectFile');
 const Podfile = require('./Podfile').Podfile;
 const check_reqs = require('./check_reqs');
+const ConfigParseriOS = require('./ConfigParseriOS');
 
 // launch storyboard and related constants
 const IMAGESET_COMPACT_SIZE_CLASS = 'compact';
@@ -43,8 +45,15 @@ const CDV_ANY_SIZE_CLASS = 'any';
 module.exports.prepare = function (cordovaProject, options) {
     const platformJson = PlatformJson.load(this.locations.root, 'ios');
     const munger = new PlatformMunger('ios', this.locations.root, platformJson, new PluginInfoProvider());
-
     this._config = updateConfigFile(cordovaProject.projectConfig, munger, this.locations);
+    
+    const parser = new ConfigParseriOS(cordovaProject.projectConfig.path);
+    try {
+        const manifest = parser.getPrivacyManifest();
+        overwritePrivacyManifest(manifest, this.locations);
+    } catch (err) {
+        return Promise.reject(new CordovaError(`Could not parse PrivacyManifest in config.xml: ${err}`));
+    }
 
     // Update own www dir with project's www assets and plugins' assets and js-files
     return updateWww(cordovaProject, this.locations)
@@ -86,6 +95,34 @@ module.exports.clean = function (options) {
         cleanFileResources(projectRoot, projectConfig, this.locations);
     });
 };
+
+
+/**
+ * Overwrites the privacy manifest file with the provided manifest or sets the default manifest.
+ * @param {ElementTree} manifest - The manifest to be written to the privacy manifest file.
+ * @param {Object} locations - The locations object containing the path to the Xcode Cordova project.
+ */
+function overwritePrivacyManifest (manifest, locations) {
+    const privacyManifestDest = path.join(locations.xcodeCordovaProj, 'PrivacyInfo.xcprivacy');
+    if (manifest != null) {
+        const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>\n';
+        const DOCTYPE = '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n';
+        const plistElement = et.Element('plist');
+        plistElement.set('version', '1.0');
+        const dictElement = et.SubElement(plistElement, 'dict');
+        manifest.getchildren().forEach((child) => {
+            dictElement.append(child);
+        });
+        const etree = new et.ElementTree(plistElement);
+        const xmlString = XML_DECLARATION + DOCTYPE + etree.write({'xml_declaration': false});
+        fs.writeFileSync(privacyManifestDest, xmlString, 'utf-8');
+        return;
+    }
+    // Set default privacy manifest
+    const defaultPrivacyManifest = path.join(__dirname, '..', 'templates', 'project', '__PROJECT_NAME__', 'PrivacyInfo.xcprivacy');
+    const xmlString = fs.readFileSync(defaultPrivacyManifest, 'utf8');
+    fs.writeFileSync(privacyManifestDest, xmlString);
+}
 
 /**
  * Updates config files in project based on app's config.xml and config munge,

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -118,7 +118,7 @@ function overwritePrivacyManifest (manifest, locations) {
     // Set default privacy manifest
     const defaultPrivacyManifest = path.join(__dirname, '..', 'templates', 'project', '__PROJECT_NAME__', 'PrivacyInfo.xcprivacy');
     const xmlString = fs.readFileSync(defaultPrivacyManifest, 'utf8');
-    fs.writeFileSync(privacyManifestDest, xmlString);
+    fs.writeFileSync(privacyManifestDest, xmlString, 'utf-8');
 }
 
 /**

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -46,7 +46,7 @@ module.exports.prepare = function (cordovaProject, options) {
     const platformJson = PlatformJson.load(this.locations.root, 'ios');
     const munger = new PlatformMunger('ios', this.locations.root, platformJson, new PluginInfoProvider());
     this._config = updateConfigFile(cordovaProject.projectConfig, munger, this.locations);
-    
+
     const parser = new ConfigParseriOS(cordovaProject.projectConfig.path);
     try {
         const manifest = parser.getPrivacyManifest();
@@ -96,7 +96,6 @@ module.exports.clean = function (options) {
     });
 };
 
-
 /**
  * Overwrites the privacy manifest file with the provided manifest or sets the default manifest.
  * @param {ElementTree} manifest - The manifest to be written to the privacy manifest file.
@@ -114,7 +113,7 @@ function overwritePrivacyManifest (manifest, locations) {
             dictElement.append(child);
         });
         const etree = new et.ElementTree(plistElement);
-        const xmlString = XML_DECLARATION + DOCTYPE + etree.write({'xml_declaration': false});
+        const xmlString = XML_DECLARATION + DOCTYPE + etree.write({ xml_declaration: false });
         fs.writeFileSync(privacyManifestDest, xmlString, 'utf-8');
         return;
     }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -17,8 +17,6 @@
     under the License.
 */
 
-'use strict';
-
 const fs = require('fs-extra');
 const path = require('path');
 const unorm = require('unorm');
@@ -36,7 +34,7 @@ const FileUpdater = require('cordova-common').FileUpdater;
 const projectFile = require('./projectFile');
 const Podfile = require('./Podfile').Podfile;
 const check_reqs = require('./check_reqs');
-const ConfigParseriOS = require('./ConfigParseriOS');
+const PlatformConfigParser = require('./PlatformConfigParser');
 
 // launch storyboard and related constants
 const IMAGESET_COMPACT_SIZE_CLASS = 'compact';
@@ -47,7 +45,7 @@ module.exports.prepare = function (cordovaProject, options) {
     const munger = new PlatformMunger('ios', this.locations.root, platformJson, new PluginInfoProvider());
     this._config = updateConfigFile(cordovaProject.projectConfig, munger, this.locations);
 
-    const parser = new ConfigParseriOS(cordovaProject.projectConfig.path);
+    const parser = new PlatformConfigParser(cordovaProject.projectConfig.path);
     try {
         const manifest = parser.getPrivacyManifest();
         overwritePrivacyManifest(manifest, this.locations);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cordova-common": "^5.0.0",
+        "elementtree": "^0.1.7",
         "execa": "^5.1.1",
         "fs-extra": "^11.1.1",
         "ios-sim": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "unorm": "^1.6.0",
     "which": "^3.0.1",
     "xcode": "^3.0.1",
-    "xml-escape": "^1.1.0"
+    "xml-escape": "^1.1.0",
+    "elementtree": "^0.1.7"
   },
   "nyc": {
     "include": [

--- a/tests/spec/unit/fixtures/prepare/no-privacy-manifest.xml
+++ b/tests/spec/unit/fixtures/prepare/no-privacy-manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+</widget>

--- a/tests/spec/unit/fixtures/prepare/privacy-manifest.xml
+++ b/tests/spec/unit/fixtures/prepare/privacy-manifest.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>SampleApp</name>
+    <platform name="ios">
+        <privacy-manifest>
+            <key>NSPrivacyTracking</key>
+            <true/>
+            <key>NSPrivacyAccessedAPITypes</key>
+            <array/>
+            <key>NSPrivacyTrackingDomains</key>
+            <array/>
+            <key>NSPrivacyCollectedDataTypes</key>
+            <array>
+                <dict>
+                    <!-- The value provided by Apple for 'Device ID' data type -->
+                    <key>NSPrivacyCollectedDataType</key>
+                    <string>NSPrivacyCollectedDataTypeDeviceID</string>
+
+                    <!-- Fingerprint Identification SDK does not link the 'Device ID' with user's identity --> 
+                    <key>NSPrivacyCollectedDataTypeLinked</key>
+                    <false/>
+
+                    <!-- Fingerprint Identification SDK does not use 'Device ID' for tracking -->
+                    <key>NSPrivacyCollectedDataTypeTracking</key>
+                    <false/>
+
+                    <!-- Fingerprint Identification SDK uses 'Device ID' for App Functionality 
+                        (prevent fraud and implement security measures) -->
+                    <key>NSPrivacyCollectedDataTypePurposes</key>
+                    <array>
+                    <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                    </array>
+                </dict>
+            </array>
+        </privacy-manifest>
+    </platform>
+</widget>

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -28,7 +28,6 @@ const XcodeProject = xcode.project;
 const rewire = require('rewire');
 const prepare = rewire('../../../lib/prepare');
 const projectFile = require('../../../lib/projectFile');
-const { writeFileSync } = require('fs');
 const FileUpdater = require('cordova-common').FileUpdater;
 
 const tmpDir = path.join(__dirname, '../../../tmp');
@@ -1515,14 +1514,14 @@ describe('prepare', () => {
             const privacyManifest = my_config.getPrivacyManifest();
             const overwritePrivacyManifest = prepare.__get__('overwritePrivacyManifest');
             overwritePrivacyManifest(privacyManifest, p.locations);
-            const privacyManifestPathDest = path.join(platformProjDir, 'PrivacyInfo.xcprivacy')
+            const privacyManifestPathDest = path.join(platformProjDir, 'PrivacyInfo.xcprivacy');
             expect(writeFileSyncSpy).toHaveBeenCalledWith(privacyManifestPathDest, jasmine.any(String), 'utf-8');
             const xml = writeFileSyncSpy.calls.all()[0].args[1];
             const json = plist.parse(xml);
-            expect(json['NSPrivacyTracking']).toBeTrue();
-            expect(json['NSPrivacyAccessedAPITypes'].length).toBe(0);
-            expect(json['NSPrivacyTrackingDomains'].length).toBe(0);
-            expect(json['NSPrivacyCollectedDataTypes'].length).toBe(1);
+            expect(json.NSPrivacyTracking).toBeTrue();
+            expect(json.NSPrivacyAccessedAPITypes.length).toBe(0);
+            expect(json.NSPrivacyTrackingDomains.length).toBe(0);
+            expect(json.NSPrivacyCollectedDataTypes.length).toBe(1);
         });
         it('Test#022 : no <privacy-manifest> - should write out the privacy manifest ', () => {
             plist.parse.and.callThrough();
@@ -1534,14 +1533,14 @@ describe('prepare', () => {
             const privacyManifest = my_config.getPrivacyManifest();
             const overwritePrivacyManifest = prepare.__get__('overwritePrivacyManifest');
             overwritePrivacyManifest(privacyManifest, p.locations);
-            const privacyManifestPathDest = path.join(platformProjDir, 'PrivacyInfo.xcprivacy')
+            const privacyManifestPathDest = path.join(platformProjDir, 'PrivacyInfo.xcprivacy');
             expect(writeFileSyncSpy).toHaveBeenCalledWith(privacyManifestPathDest, jasmine.any(String), 'utf-8');
             const xml = writeFileSyncSpy.calls.all()[0].args[1];
             const json = plist.parse(xml);
-            expect(json['NSPrivacyTracking']).toBeFalse();
-            expect(json['NSPrivacyAccessedAPITypes'].length).toBe(0);
-            expect(json['NSPrivacyTrackingDomains'].length).toBe(0);
-            expect(json['NSPrivacyCollectedDataTypes'].length).toBe(0);
+            expect(json.NSPrivacyTracking).toBeFalse();
+            expect(json.NSPrivacyAccessedAPITypes.length).toBe(0);
+            expect(json.NSPrivacyTrackingDomains.length).toBe(0);
+            expect(json.NSPrivacyCollectedDataTypes.length).toBe(0);
         });
 
     });

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -28,6 +28,7 @@ const XcodeProject = xcode.project;
 const rewire = require('rewire');
 const prepare = rewire('../../../lib/prepare');
 const projectFile = require('../../../lib/projectFile');
+const { writeFileSync } = require('fs');
 const FileUpdater = require('cordova-common').FileUpdater;
 
 const tmpDir = path.join(__dirname, '../../../tmp');
@@ -1504,6 +1505,45 @@ describe('prepare', () => {
                 expect(plist.build.calls.mostRecent().args[0].CFBundleDisplayName).toEqual('MyApp');
             });
         });
+        it('Test#021 : <privacy-manifest> - should write out the privacy manifest ', () => {
+            plist.parse.and.callThrough();
+            writeFileSyncSpy.and.callThrough();
+            const projectRoot = iosProject;
+            const platformProjDir = path.join(projectRoot, 'platforms', 'ios', 'SampleApp');
+            const PlatformConfigParser = require('../../../lib/PlatformConfigParser');
+            const my_config = new PlatformConfigParser(path.join(FIXTURES, 'prepare', 'privacy-manifest.xml'));
+            const privacyManifest = my_config.getPrivacyManifest();
+            const overwritePrivacyManifest = prepare.__get__('overwritePrivacyManifest');
+            overwritePrivacyManifest(privacyManifest, p.locations);
+            const privacyManifestPathDest = path.join(platformProjDir, 'PrivacyInfo.xcprivacy')
+            expect(writeFileSyncSpy).toHaveBeenCalledWith(privacyManifestPathDest, jasmine.any(String), 'utf-8');
+            const xml = writeFileSyncSpy.calls.all()[0].args[1];
+            const json = plist.parse(xml);
+            expect(json['NSPrivacyTracking']).toBeTrue();
+            expect(json['NSPrivacyAccessedAPITypes'].length).toBe(0);
+            expect(json['NSPrivacyTrackingDomains'].length).toBe(0);
+            expect(json['NSPrivacyCollectedDataTypes'].length).toBe(1);
+        });
+        it('Test#022 : no <privacy-manifest> - should write out the privacy manifest ', () => {
+            plist.parse.and.callThrough();
+            writeFileSyncSpy.and.callThrough();
+            const projectRoot = iosProject;
+            const platformProjDir = path.join(projectRoot, 'platforms', 'ios', 'SampleApp');
+            const PlatformConfigParser = require('../../../lib/PlatformConfigParser');
+            const my_config = new PlatformConfigParser(path.join(FIXTURES, 'prepare', 'no-privacy-manifest.xml'));
+            const privacyManifest = my_config.getPrivacyManifest();
+            const overwritePrivacyManifest = prepare.__get__('overwritePrivacyManifest');
+            overwritePrivacyManifest(privacyManifest, p.locations);
+            const privacyManifestPathDest = path.join(platformProjDir, 'PrivacyInfo.xcprivacy')
+            expect(writeFileSyncSpy).toHaveBeenCalledWith(privacyManifestPathDest, jasmine.any(String), 'utf-8');
+            const xml = writeFileSyncSpy.calls.all()[0].args[1];
+            const json = plist.parse(xml);
+            expect(json['NSPrivacyTracking']).toBeFalse();
+            expect(json['NSPrivacyAccessedAPITypes'].length).toBe(0);
+            expect(json['NSPrivacyTrackingDomains'].length).toBe(0);
+            expect(json['NSPrivacyCollectedDataTypes'].length).toBe(0);
+        });
+
     });
 
     describe('<resource-file> tests', () => {

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -1542,7 +1542,6 @@ describe('prepare', () => {
             expect(json.NSPrivacyTrackingDomains.length).toBe(0);
             expect(json.NSPrivacyCollectedDataTypes.length).toBe(0);
         });
-
     });
 
     describe('<resource-file> tests', () => {


### PR DESCRIPTION
### Platforms affected
ios

### Motivation and Context
To support setting ios privacy manifest according to config.xml setting.

### Description
Introducing <privacy-manifest> tag in config.xml ios platform directive.

If user add following directive in config.xml (platform ios)
```
<privacy-manifest>
	<key>NSPrivacyTracking</key>
	<true/>
	<key>NSPrivacyCollectedDataTypes</key>
	<array/>
	<key>NSPrivacyAccessedAPITypes</key>
	<array/>
	<key>NSPrivacyTrackingDomains</key>
	<array/>
</privacy-manifest>
```
the ios project PrivacyManifest.xcprivacy is updated as config.xml.
If user does not set `<privacy-manifest>` tag in config.xml, the cordova template 
default PrivacyManifest.xcprivacy is used.

Note: This `<privacy-manifest>` tag overrides whole PrivacyManifest.xcprivacy file in project each time 
user execute cordova prepare.


### Testing
I locally checked this feature with sample project.
I locally exec `npm run coverage`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
