### PR TITLE
feat: SplashScreen Background Color preference support

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -29,6 +29,14 @@
 #import <Cordova/NSDictionary+CordovaPreferences.h>
 #import "CDVCommandDelegateImpl.h"
 
+UIColor* defaultBackgroundColor(void) {
+    if (@available(iOS 13.0, *)) {
+        return UIColor.systemBackgroundColor;
+    } else {
+        return UIColor.whiteColor;
+    }
+}
+
 @interface CDVViewController () <CDVWebViewEngineConfigurationDelegate> { }
 
 @property (nonatomic, readwrite, strong) NSXMLParser* configParser;
@@ -293,9 +301,12 @@
     }
     // /////////////////
 
-    UIColor* bgColor = [UIColor colorNamed:@"BackgroundColor"] ?: UIColor.whiteColor;
-    [self.launchView setBackgroundColor:bgColor];
+    UIColor* bgDefault = defaultBackgroundColor();
+    UIColor* bgColor = [UIColor colorNamed:@"BackgroundColor"] ?: bgDefault;
+    UIColor* bgSplash = [UIColor colorNamed:@"SplashScreenBackgroundColor"] ?: bgColor;
+
     [self.webView setBackgroundColor:bgColor];
+    [self.launchView setBackgroundColor:bgSplash];
 }
 
 -(void)viewWillAppear:(BOOL)animated

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -467,6 +467,21 @@ function getBackgroundColorDir (projectRoot, platformProjDir) {
     }
 }
 
+/**
+ * Returns the directory for the SplashScreenBackgroundColor.colorset asset, or
+ * null if no xcassets exist.
+ *
+ * @param  {string} projectRoot        The project's root directory
+ * @param  {string} platformProjDir    The platform's project directory
+ */
+function getSplashScreenBackgroundColorDir (projectRoot, platformProjDir) {
+    if (folderExists(path.join(projectRoot, platformProjDir, 'Assets.xcassets/'))) {
+        return path.join(platformProjDir, 'Assets.xcassets', 'SplashScreenBackgroundColor.colorset');
+    } else {
+        return null;
+    }
+}
+
 function colorPreferenceToComponents (pref) {
     if (!pref || !pref.match(/^(#[0-9A-Fa-f]{3}|(0x|#)([0-9A-Fa-f]{2})?[0-9A-Fa-f]{6})$/)) {
         return {
@@ -517,11 +532,12 @@ function colorPreferenceToComponents (pref) {
  * @param {Object} locations A dictionary containing useful location paths
  */
 function updateBackgroundColor (cordovaProject, locations) {
-    const pref = cordovaProject.projectConfig.getPreference('BackgroundColor', 'ios') || '';
-
     const platformProjDir = path.relative(cordovaProject.root, locations.xcodeCordovaProj);
-    const backgroundColorDir = getBackgroundColorDir(cordovaProject.root, platformProjDir);
 
+    const pref = cordovaProject.projectConfig.getPreference('BackgroundColor', 'ios') || '';
+    const splashPref = cordovaProject.projectConfig.getPreference('SplashScreenBackgroundColor', 'ios') || pref;
+
+    const backgroundColorDir = getBackgroundColorDir(cordovaProject.root, platformProjDir);
     if (backgroundColorDir) {
         const contentsJSON = {
             colors: [{
@@ -538,6 +554,24 @@ function updateBackgroundColor (cordovaProject, locations) {
         fs.writeFileSync(path.join(cordovaProject.root, backgroundColorDir, 'Contents.json'),
             JSON.stringify(contentsJSON, null, 2));
     }
+
+    const splashBackgroundColorDir = getSplashScreenBackgroundColorDir(cordovaProject.root, platformProjDir);
+    if (splashBackgroundColorDir) {
+        const contentsJSON = {
+            colors: [{
+                idiom: 'universal',
+                color: colorPreferenceToComponents(splashPref)
+            }],
+            info: {
+                author: 'Xcode',
+                version: 1
+            }
+        };
+
+        events.emit('verbose', 'Updating Splash Screen Background Color color set Contents.json');
+        fs.writeFileSync(path.join(cordovaProject.root, splashBackgroundColorDir, 'Contents.json'),
+            JSON.stringify(contentsJSON, null, 2));
+    }
 }
 
 /**
@@ -549,22 +583,29 @@ function updateBackgroundColor (cordovaProject, locations) {
  */
 function cleanBackgroundColor (projectRoot, projectConfig, locations) {
     const platformProjDir = path.relative(projectRoot, locations.xcodeCordovaProj);
+
+    const contentsJSON = {
+        colors: [{
+            idiom: 'universal',
+            color: colorPreferenceToComponents(null)
+        }],
+        info: {
+            author: 'Xcode',
+            version: 1
+        }
+    };
+
     const backgroundColorDir = getBackgroundColorDir(projectRoot, platformProjDir);
-
     if (backgroundColorDir) {
-        const contentsJSON = {
-            colors: [{
-                idiom: 'universal',
-                color: colorPreferenceToComponents(null)
-            }],
-            info: {
-                author: 'Xcode',
-                version: 1
-            }
-        };
-
         events.emit('verbose', 'Cleaning Background Color color set Contents.json');
         fs.writeFileSync(path.join(projectRoot, backgroundColorDir, 'Contents.json'),
+            JSON.stringify(contentsJSON, null, 2));
+    }
+
+    const splashBackgroundColorDir = getSplashScreenBackgroundColorDir(projectRoot, platformProjDir);
+    if (splashBackgroundColorDir) {
+        events.emit('verbose', 'Cleaning Splash Screen Background Color color set Contents.json');
+        fs.writeFileSync(path.join(projectRoot, splashBackgroundColorDir, 'Contents.json'),
             JSON.stringify(contentsJSON, null, 2));
     }
 }

--- a/templates/project/__PROJECT_NAME__/Assets.xcassets/SplashScreenBackgroundColor.colorset/Contents.json
+++ b/templates/project/__PROJECT_NAME__/Assets.xcassets/SplashScreenBackgroundColor.colorset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemBackgroundColor"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/templates/project/__PROJECT_NAME__/CDVLaunchScreen.storyboard
+++ b/templates/project/__PROJECT_NAME__/CDVLaunchScreen.storyboard
@@ -42,7 +42,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" name="BackgroundColor"/>
+                        <color key="backgroundColor" name="SplashScreenBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="2ns-9I-Qjs" secondAttribute="trailing" id="FZL-3Z-NFz"/>
                             <constraint firstItem="2ns-9I-Qjs" firstAttribute="bottom" secondItem="Ze5-6b-2t3" secondAttribute="bottom" id="L9l-pw-wXj"/>
@@ -58,7 +58,7 @@
     </scenes>
     <resources>
         <image name="LaunchStoryboard" width="1366" height="1366"/>
-        <namedColor name="BackgroundColor">
+        <namedColor name="SplashScreenBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </namedColor>
     </resources>

--- a/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Assets.xcassets/SplashScreenBackgroundColor.colorset/Contents.json
+++ b/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Assets.xcassets/SplashScreenBackgroundColor.colorset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemBackgroundColor"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1254.


### Description
<!-- Describe your changes in detail -->
Support a `SplashScreenBackgroundColor` preference that sets the background colour of the splash screen via xcassets.

If no `SplashScreenBackgroundColor` is provided, it will fall back to the `BackgroundColor` (i.e., the current behaviour). 
If neither are specified, it will fallback to the system background colour (also current behaviour).


### Testing
<!-- Please describe in detail how you tested your changes. -->
* Created a new iOS project from this branch and specified both the `BackgroundColor` and `SplashScreenBackgroundColor` preferences. Ensured both variables had correct values in Xcode and confirmed splash screen used the correct colour on device.
* Created a new iOS project from this branch and specified only the `BackgroundColor` preference. Ensured both variables had correct values in Xcode and confirmed splash screen used the correct colour on device.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
