### PR TITLE
chore(ci): Fix ObjC testing with latest Xcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        os: [macos-latest]
+        os: [macos-14]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "objc-tests": "npm run objc-tests-lib && npm run objc-tests-framework",
     "objc-tests-lib": "npm run xcodebuild -- -scheme CordovaLibTests",
     "objc-tests-framework": "npm run xcodebuild -- -scheme CordovaFrameworkApp",
-    "xcodebuild": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -destination \"platform=iOS Simulator,name=iPhone 8\" CONFIGURATION_BUILD_DIR=\"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
+    "xcodebuild": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -destination \"platform=iOS Simulator,name=iPhone 15\" -derivedDataPath \"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
     "preobjc-tests": "killall Simulator || true",
     "unit-tests": "jasmine --config=tests/spec/unit.json",
     "lint": "eslint . \"templates/cordova/lib/!(*.*)\""

--- a/tests/CordovaLibTests/CDVPluginInitTests.m
+++ b/tests/CordovaLibTests/CDVPluginInitTests.m
@@ -38,7 +38,7 @@
     // uncaught and the app crashes upon a failed STAssert (oh well).
     // [self raiseAfterFailure];
 
-    self.appDelegate = [[UIApplication sharedApplication] delegate];
+    self.appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
     [self.appDelegate createViewController];
     self.viewController = self.appDelegate.viewController;
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Tests would fail to run in Xcode 15 due to not having a iPhone 8 simulator with the latest runtime, and `CONFIGURATION_BUILD_DIR` was causing errors about Cordova.framework not being found and sometimes warnings about stale files.


### Description
<!-- Describe your changes in detail -->
* Move macOS CI to run on macOS 14 on Apple Silicon, using Xcode 15
* Set the tests to run with an iPhone 15 simulator
* Fix a warning about a missing cast to `AppDelegate*`
* Set `-derivedDataPath` rather than `CONFIGURATION_BUILD_DIR` so that Apple doesn't cache stale data about previous runs


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran in GitHub CI and locally with latest Xcode 15


### Checklist

- [x] I've run the tests to see all new and existing tests pass