### PR TITLE
chore!: Bump minimum Xcode version to 15

### DIFF
--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -25,7 +25,7 @@ const { CordovaError } = require('cordova-common');
 
 const SUPPORTED_OS_PLATFORMS = ['darwin'];
 
-const XCODEBUILD_MIN_VERSION = '11.0.0';
+const XCODEBUILD_MIN_VERSION = '14.0.0';
 const XCODEBUILD_NOT_FOUND_MESSAGE =
     `Please install version ${XCODEBUILD_MIN_VERSION} or greater from App Store`;
 

--- a/lib/check_reqs.js
+++ b/lib/check_reqs.js
@@ -25,7 +25,7 @@ const { CordovaError } = require('cordova-common');
 
 const SUPPORTED_OS_PLATFORMS = ['darwin'];
 
-const XCODEBUILD_MIN_VERSION = '14.0.0';
+const XCODEBUILD_MIN_VERSION = '15.0.0';
 const XCODEBUILD_NOT_FOUND_MESSAGE =
     `Please install version ${XCODEBUILD_MIN_VERSION} or greater from App Store`;
 


### PR DESCRIPTION
Closes https://github.com/apache/cordova-ios/issues/1367

~we could even drop Xcode 14 and go to 15 directly since Apple is going to require Xcode 15 at some point this month~