### PR TITLE
fix: Properly set the WebView config when it is provided

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -458,7 +458,7 @@ UIColor* defaultBackgroundColor(void) {
 /// @param bounds with which the webview will be initialized
 - (id _Nullable) initWebViewEngine:(nonnull Class)engineClass bounds:(CGRect)bounds {
     WKWebViewConfiguration *config = [self respondsToSelector:@selector(configuration)] ? [self configuration] : nil;
-    if (config && [engineClass respondsToSelector:@selector(initWithFrame:configuration:)]) {
+    if (config && [engineClass instancesRespondToSelector:@selector(initWithFrame:configuration:)]) {
         return [[engineClass alloc] initWithFrame:bounds configuration:config];
     } else {
         return [[engineClass alloc] initWithFrame:bounds];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes GH-1423 (based on the comment on https://github.com/apache/cordova-ios/commit/4c8136345ae9622646ee7e4eb60ba2b37ad44fbe#r142043240)


### Description
<!-- Describe your changes in detail -->
Check that the engine class instance responds to the `initWithFrame:configuration:` selector rather than the engine class itself (because it's not a static class method).


### Testing
<!-- Please describe in detail how you tested your changes. -->
All unit tests pass, but I don't think we have test coverage for this particular feature.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
