### PR TITLE
fix: alerts could freeze the application

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -192,7 +192,8 @@
         self.CDV_ASSETS_URL = [NSString stringWithFormat:@"%@://%@", scheme, hostname];
     }
 
-    CDVWebViewUIDelegate* uiDelegate = [[CDVWebViewUIDelegate alloc] initWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]];
+    CDVWebViewUIDelegate* uiDelegate = [[CDVWebViewUIDelegate alloc] initWithViewController:vc];
+    uiDelegate.title = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     uiDelegate.allowNewWindows = [settings cordovaBoolSettingForKey:@"AllowNewWindows" defaultValue:NO];
     self.uiDelegate = uiDelegate;
 

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
@@ -19,14 +19,24 @@
 
 #import <WebKit/WebKit.h>
 
-@interface CDVWebViewUIDelegate : NSObject <WKUIDelegate>
-{
-    NSMutableArray<UIViewController*>* windows;
-}
+#ifdef NS_SWIFT_UI_ACTOR
+#define CDV_SWIFT_UI_ACTOR NS_SWIFT_UI_ACTOR
+#else
+#define CDV_SWIFT_UI_ACTOR
+#endif
 
-@property (nonatomic, copy) NSString* title;
+@class CDVViewController;
+
+NS_ASSUME_NONNULL_BEGIN
+
+CDV_SWIFT_UI_ACTOR
+@interface CDVWebViewUIDelegate : NSObject <WKUIDelegate>
+
+@property (nonatomic, nullable, copy) NSString* title;
 @property (nonatomic, assign) BOOL allowNewWindows;
 
-- (instancetype)initWithTitle:(NSString*)title;
+- (instancetype)initWithViewController:(CDVViewController*)vc;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.m
@@ -18,22 +18,32 @@
  */
 
 #import "CDVWebViewUIDelegate.h"
+#import <Cordova/CDVViewController.h>
+
+@interface CDVWebViewUIDelegate ()
+
+@property (nonatomic, weak) CDVViewController *viewController;
+
+@end
 
 @implementation CDVWebViewUIDelegate
+{
+    NSMutableArray<UIViewController *> *windows;
+}
 
-- (instancetype)initWithTitle:(NSString*)title
+- (instancetype)initWithViewController:(CDVViewController *)vc
 {
     self = [super init];
+
     if (self) {
-        self.title = title;
+        self.viewController = vc;
+        self.title = vc.title;
         windows = [[NSMutableArray alloc] init];
     }
-
     return self;
 }
 
-- (void)     webView:(WKWebView*)webView runJavaScriptAlertPanelWithMessage:(NSString*)message
-    initiatedByFrame:(WKFrameInfo*)frame completionHandler:(void (^)(void))completionHandler
+- (void)webView:(WKWebView*)webView runJavaScriptAlertPanelWithMessage:(NSString*)message initiatedByFrame:(WKFrameInfo*)frame completionHandler:(CDV_SWIFT_UI_ACTOR void (^)(void))completionHandler
 {
     UIAlertController* alert = [UIAlertController alertControllerWithTitle:self.title
                                                                    message:message
@@ -49,13 +59,10 @@
 
     [alert addAction:ok];
 
-    UIViewController* rootController = [UIApplication sharedApplication].delegate.window.rootViewController;
-
-    [rootController presentViewController:alert animated:YES completion:nil];
+    [[self topViewController] presentViewController:alert animated:YES completion:nil];
 }
 
-- (void)     webView:(WKWebView*)webView runJavaScriptConfirmPanelWithMessage:(NSString*)message
-    initiatedByFrame:(WKFrameInfo*)frame completionHandler:(void (^)(BOOL result))completionHandler
+- (void)webView:(WKWebView*)webView runJavaScriptConfirmPanelWithMessage:(NSString*)message initiatedByFrame:(WKFrameInfo*)frame completionHandler:(CDV_SWIFT_UI_ACTOR void (^)(BOOL result))completionHandler
 {
     UIAlertController* alert = [UIAlertController alertControllerWithTitle:self.title
                                                                    message:message
@@ -80,14 +87,10 @@
         }];
     [alert addAction:cancel];
 
-    UIViewController* rootController = [UIApplication sharedApplication].delegate.window.rootViewController;
-
-    [rootController presentViewController:alert animated:YES completion:nil];
+    [[self topViewController] presentViewController:alert animated:YES completion:nil];
 }
 
-- (void)      webView:(WKWebView*)webView runJavaScriptTextInputPanelWithPrompt:(NSString*)prompt
-          defaultText:(NSString*)defaultText initiatedByFrame:(WKFrameInfo*)frame
-    completionHandler:(void (^)(NSString* result))completionHandler
+- (void)webView:(WKWebView*)webView runJavaScriptTextInputPanelWithPrompt:(NSString*)prompt defaultText:(NSString*)defaultText initiatedByFrame:(WKFrameInfo*)frame completionHandler:(CDV_SWIFT_UI_ACTOR void (^)(NSString* result))completionHandler
 {
     UIAlertController* alert = [UIAlertController alertControllerWithTitle:self.title
                                                                    message:prompt
@@ -116,12 +119,10 @@
         textField.text = defaultText;
     }];
 
-    UIViewController* rootController = [UIApplication sharedApplication].delegate.window.rootViewController;
-
-    [rootController presentViewController:alert animated:YES completion:nil];
+    [[self topViewController] presentViewController:alert animated:YES completion:nil];
 }
 
-- (WKWebView*) webView:(WKWebView*)webView createWebViewWithConfiguration:(WKWebViewConfiguration*)configuration forNavigationAction:(WKNavigationAction*)navigationAction windowFeatures:(WKWindowFeatures*)windowFeatures
+- (nullable WKWebView*)webView:(WKWebView*)webView createWebViewWithConfiguration:(WKWebViewConfiguration*)configuration forNavigationAction:(WKNavigationAction*)navigationAction windowFeatures:(WKWindowFeatures*)windowFeatures
 {
     if (!navigationAction.targetFrame.isMainFrame) {
         if (self.allowNewWindows) {
@@ -135,8 +136,7 @@
 
             [windows addObject:vc];
 
-            UIViewController* rootController = [UIApplication sharedApplication].delegate.window.rootViewController;
-            [rootController presentViewController:vc animated:YES completion:nil];
+            [[self topViewController] presentViewController:vc animated:YES completion:nil];
             return v;
         } else {
             [webView loadRequest:navigationAction.request];
@@ -159,5 +159,17 @@
     // We do not allow closing the primary WebView
 }
 
+#pragma mark - Utility Methods
+
+- (nullable UIViewController *)topViewController
+{
+    UIViewController *vc = self.viewController;
+
+    while (vc.presentedViewController != nil && ![vc.presentedViewController isBeingDismissed]) {
+        vc = vc.presentedViewController;
+    }
+
+    return vc;
+}
 
 @end


### PR DESCRIPTION


<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1120.
Closes GH-1121.
Closes GH-1429.


### Description
<!-- Describe your changes in detail -->
In cases where the system was presenting something on the screen (such as a permission prompt, or an undo dialog) or in cases where the `CDVViewController` was not the root view controller (such as in a tabbed navigator), trying to show any dialogs triggered from the WebView would attempt to create an alert on the root view controller and get the view hierarchy into a bad state.

Now, we only try to display alerts on the `CDVViewController` that owns the WebView. This means that alerts can potentially end up behind other system dialogs, but the view controller no longer freezes.

(As an aside, having access to the `CDVViewController` here will be helpful for some future things too...)

### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested manually by triggering an alert while a permission prompt was being displayed and confirmed that the app continued working as expected.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))