### PR TITLE
fix: uninstall plugin with asset tag

### DIFF
--- a/lib/plugman/pluginHandlers.js
+++ b/lib/plugman/pluginHandlers.js
@@ -364,7 +364,7 @@ function removeFile (project_dir, src) {
 
 // deletes file/directory without checking
 function removeFileF (file) {
-    fs.rmSync(file);
+    fs.rmSync(file, { recursive: true, force: true });
 }
 
 function removeFileAndParents (baseDir, destFile, stopper) {

--- a/lib/plugman/pluginHandlers.js
+++ b/lib/plugman/pluginHandlers.js
@@ -185,10 +185,10 @@ const handlers = {
             }
 
             removeFile(project.www, target);
-            removeFileF(path.resolve(project.www, 'plugins', plugin.id));
+            removeFolderF(path.resolve(project.www, 'plugins', plugin.id));
             if (options && options.usePlatformWww) {
                 removeFile(project.platformWww, target);
-                removeFileF(path.resolve(project.platformWww, 'plugins', plugin.id));
+                removeFolderF(path.resolve(project.platformWww, 'plugins', plugin.id));
             }
         }
     },
@@ -362,8 +362,13 @@ function removeFile (project_dir, src) {
     fs.rmSync(file);
 }
 
-// deletes file/directory without checking
+// deletes file without checking
 function removeFileF (file) {
+    fs.rmSync(file);
+}
+
+// deletes directory without checking
+function removeFolderF (file) {
     fs.rmSync(file, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
The comment says `// deletes file/directory without checking`, but it can't delete directories without the `{ recursive: true, force: true }`.
I've created a new function for deleting directories as deleting files this way breaks the tests, so changed the two calls that removed folders to use the new function and kept the other that deleted a file with the old method call.

closes https://github.com/apache/cordova-ios/issues/1443