### PR TITLE
fix: uninstall plugin with asset tag

### DIFF
--- a/lib/plugman/pluginHandlers.js
+++ b/lib/plugman/pluginHandlers.js
@@ -364,7 +364,7 @@ function removeFile (project_dir, src) {
 
 // deletes file/directory without checking
 function removeFileF (file) {
-    fs.rmSync(file);
+    fs.rmSync(file, { recursive: true, force: true });
 }
 
 function removeFileAndParents (baseDir, destFile, stopper) {

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -565,13 +565,13 @@ describe('ios plugin handler', () => {
 
             it('Test 042 : should put module to both www and platform_www when options.usePlatformWww flag is specified', () => {
                 uninstall(jsModule, dummyPluginInfo, dummyProject, { usePlatformWww: true });
-                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest);
-                expect(fs.rmSync).toHaveBeenCalledWith(platformWwwDest);
+                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
+                expect(fs.rmSync).toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
 
             it('Test 043 : should put module to www only when options.usePlatformWww flag is not specified', () => {
                 uninstall(jsModule, dummyPluginInfo, dummyProject);
-                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest);
+                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
                 expect(fs.rmSync).not.toHaveBeenCalledWith(platformWwwDest);
             });
         });


### PR DESCRIPTION
Alternative to #1444 that fixes the tests instead of adding a new function

closes https://github.com/apache/cordova-ios/pull/1444
closes https://github.com/apache/cordova-ios/issues/1443