### PR TITLE
(ios) Adds a routine to flush WkWebView diskcache when the bundle ver…

### DIFF
--- a/templates/project/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/templates/project/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		4E7CA2B7272ABB0D00177EF9 /* www in Copy Staging Resources */ = {isa = PBXBuildFile; fileRef = 301BF56E109A69640062928A /* www */; };
 		6AFF5BF91D6E424B00AB3073 /* CDVLaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6AFF5BF81D6E424B00AB3073 /* CDVLaunchScreen.storyboard */; };
 		90B630EF2AECBBD0009EF368 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 90B630EE2AECBBD0009EF368 /* PrivacyInfo.xcprivacy */; };
+		D0A4184E2C599F4800A109D2 /* WkWebViewCacheClear.m in Sources */ = {isa = PBXBuildFile; fileRef = D0A4184D2C599F4800A109D2 /* WkWebViewCacheClear.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +95,8 @@
 		6AFF5BF81D6E424B00AB3073 /* CDVLaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = CDVLaunchScreen.storyboard; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* __PROJECT_NAME__-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "__PROJECT_NAME__-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 		90B630EE2AECBBD0009EF368 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		D0A4184C2C599F4800A109D2 /* WkWebViewCacheClear.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WkWebViewCacheClear.h; sourceTree = "<group>"; };
+		D0A4184D2C599F4800A109D2 /* WkWebViewCacheClear.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WkWebViewCacheClear.m; sourceTree = "<group>"; };
 		EB87FDF31871DA8E0020F90C /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = www; path = ../../www; sourceTree = "<group>"; };
 		EB87FDF41871DAF40020F90C /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = config.xml; path = ../../config.xml; sourceTree = "<group>"; };
 		ED33DF2A687741AEAF9F8254 /* Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bridging-Header.h"; sourceTree = "<group>"; };
@@ -151,6 +154,8 @@
 				302D95F014D2391D003F00A1 /* MainViewController.xib */,
 				1D3623240D0F684500981E51 /* AppDelegate.h */,
 				1D3623250D0F684500981E51 /* AppDelegate.m */,
+				D0A4184C2C599F4800A109D2 /* WkWebViewCacheClear.h */,
+				D0A4184D2C599F4800A109D2 /* WkWebViewCacheClear.m */,
 				29B97316FDCFA39411CA2CEA /* main.m */,
 			);
 			name = "__PROJECT_NAME__";
@@ -304,6 +309,7 @@
 			files = (
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
 				1D3623260D0F684500981E51 /* AppDelegate.m in Sources */,
+				D0A4184E2C599F4800A109D2 /* WkWebViewCacheClear.m in Sources */,
 				302D95F114D2391D003F00A1 /* MainViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/templates/project/__PROJECT_NAME__/AppDelegate.m
+++ b/templates/project/__PROJECT_NAME__/AppDelegate.m
@@ -19,11 +19,36 @@
 
 #import "AppDelegate.h"
 #import "MainViewController.h"
+#import "WkWebViewCacheClear.h"
 
 @implementation AppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
-{
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    NSString *currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *storedVersion = [defaults stringForKey:@"appVersion"];
+
+    // Check if the app has been updated
+    if (storedVersion == nil || ![storedVersion isEqualToString:currentVersion]) {
+        // Clear webview cache here.
+        WkWebViewCacheClear *cacheClearer = [[WkWebViewCacheClear alloc] init];
+        [cacheClearer clearCacheOfType:WKWebsiteDataTypeDiskCache completion:^{
+            NSLog(@"Disk cache cleared");
+            // Display cache info after ensuring cache is cleared
+            [cacheClearer displayCacheInfo];
+
+            // Update the stored version to the current version
+            [defaults setObject:currentVersion forKey:@"appVersion"];
+            [defaults synchronize];
+        }];
+    } else {
+        NSLog(@"Skipped cache clear, stored version is %@", storedVersion);
+    }
+
+    return YES;
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     self.viewController = [[MainViewController alloc] init];
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/templates/project/__PROJECT_NAME__/WkWebViewCacheClear.h
+++ b/templates/project/__PROJECT_NAME__/WkWebViewCacheClear.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <WebKit/WebKit.h>
+
+@interface WkWebViewCacheClear : NSObject
+
+// Method to clear a specific cache type
+- (void)clearCacheOfType:(NSString *)cacheType completion:(void (^)(void))completion;
+
+// Method to clear multiple cache types
+- (void)clearCaches:(NSArray<NSString *> *)cacheTypes completion:(void (^)(void))completion;
+
+// Method to display cached files, domain, etc.
+- (void)displayCacheInfo;
+
+@end

--- a/templates/project/__PROJECT_NAME__/WkWebViewCacheClear.m
+++ b/templates/project/__PROJECT_NAME__/WkWebViewCacheClear.m
@@ -1,0 +1,87 @@
+#import "WkWebViewCacheClear.h"
+
+@implementation WkWebViewCacheClear
+
+- (NSArray *)getDomains {
+    NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+
+    // Extract the domain from the bundle identifier
+    NSArray *bundleComponents = [bundleID componentsSeparatedByString:@"."];
+    NSString *domain = [NSString stringWithFormat:@"%@.%@", bundleComponents[1], bundleComponents[0]];
+
+    // Create the domains array with the dynamically determined domain and localhost
+    NSArray *domains = @[domain, @"localhost"];
+    
+    return domains;
+}
+
+- (void)clearCacheOfType:(NSString *)cacheType completion:(void (^)(void))completion {
+    NSArray *domains = [self getDomains];
+
+    WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
+    NSSet *dataTypes = [NSSet setWithObject:cacheType];
+    
+    [dataStore fetchDataRecordsOfTypes:dataTypes completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        NSMutableArray<WKWebsiteDataRecord *> *filteredRecords = [NSMutableArray array];
+        for (WKWebsiteDataRecord *record in records) {
+            for (NSString *domain in domains) {
+                if ([record.displayName containsString:domain]) {
+                    [filteredRecords addObject:record];
+                    break;
+                }
+            }
+        }
+        
+        [dataStore removeDataOfTypes:dataTypes forDataRecords:filteredRecords completionHandler:^{
+            NSLog(@"Cache of type %@ for domains %@ cleared", cacheType, domains);
+            if (completion) {
+                completion();
+            }
+        }];
+    }];
+}
+
+- (void)clearCaches:(NSArray<NSString *> *)cacheTypes completion:(void (^)(void))completion {
+    NSArray *domains = [self getDomains];
+
+    WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
+    NSSet *dataTypes = [NSSet setWithArray:cacheTypes];
+    
+    [dataStore fetchDataRecordsOfTypes:dataTypes completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        NSMutableArray<WKWebsiteDataRecord *> *filteredRecords = [NSMutableArray array];
+        for (WKWebsiteDataRecord *record in records) {
+            for (NSString *domain in domains) {
+                if ([record.displayName containsString:domain]) {
+                    [filteredRecords addObject:record];
+                    break;
+                }
+            }
+        }
+        
+        [dataStore removeDataOfTypes:dataTypes forDataRecords:filteredRecords completionHandler:^{
+            NSLog(@"Caches of types %@ for domains %@ cleared", cacheTypes, domains);
+            if (completion) {
+                completion();
+            }
+        }];
+    }];
+}
+
+- (void)displayCacheInfo {
+    NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+    WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
+    NSSet *diskCacheType = [NSSet setWithObject:WKWebsiteDataTypeDiskCache];
+    
+    [dataStore fetchDataRecordsOfTypes:diskCacheType completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        if (records.count > 0) {
+            NSLog(@"Disk cache is available:");
+            for (WKWebsiteDataRecord *record in records) {
+                NSLog(@"Record: %@", record.displayName);
+            }
+        } else {
+            NSLog(@"No disk cache available.");
+        }
+    }];
+}
+
+@end


### PR DESCRIPTION
…ion changes

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
 - ios



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This Pull Request adds a routine to the Boot of cordova-ios so that we can flush diskcache in the WkWebView. There is a problem with iOS where the diskcache aka .js, html, and css etc files are cached between .ipa installs. 

There is no issue for this at this time, I was discussing it with Norman Breau in the Slack Space

### Description
<!-- Describe your changes in detail -->

In the AppDelegate.m file I have added a routine to clear the `WKWebsiteDataTypeDiskCache` for the domain from the `Bundle ID`, and `localhost`. This cache needs to be flushed because it latches on to previous `js, html, css, etc` files from a previous `.ipa` installation.  These cached files include the `cordova.js` and `cordova_plugins.js` files. I know this because I added hacks into these files, but they were not registered on the target production application.

The main problem this addresses is removals of Cordova Plugins. Where the cached cordova_plugins.js thinks that it needs to load a removed plugin, but since the plugins www directory was removed it doesn't exist. 

An example error message is as follows:
```
Module branch-cordova-sdk.Branch does not exist.
```

Now I cannot confirm at this time, but it does indicate that with this cached files, that any additions to cordova_plugins.js may not be loaded at runtime. 

I want to mention that this problem is extremely hard to reproduce in local environments. It _needs_ to be on device, and it needs to be an update to an already installed application in production. Eg. I have 3.72.0 on my device, a new 3.73.0 version is released with removed/updated plugins, then this case _can_ happen it is not guaranteed to happen for all users.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Our QA engineer had an instance of the application stuck in this state. The Error: 
```
Module branch-cordova-sdk.Branch does not exist.
```

This error was thrown everytime they booted the application, where the UI was stuck on the Splashscreen. 

Updating to the latest .ipa (with these changes in the PR) and booting, the user was able to get "unstuck".  However, it's not a _perfect_ solution because while the cache did get flushed, it didn't immediately repopulate it, and the user had to reboot the app. On second boot after this fix was introduced the user was able to boot the application successfully.

### Checklist

- [*] I've run the tests to see all new and existing tests pass
- [*] I added automated test coverage as appropriate for this change
- [*] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [*] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [*] I've updated the documentation if necessary
