### PR TITLE
refactor!: Easy deprecation cleanups

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVLaunchScreen/CDVLaunchScreen.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVLaunchScreen/CDVLaunchScreen.m
@@ -24,16 +24,12 @@
 
 - (void)show:(CDVInvokedUrlCommand*)command
 {
-    if ([self.viewController isKindOfClass:[CDVViewController class]]) {
-        [(CDVViewController*)self.viewController showLaunchScreen:YES];
-    }
+    [self.viewController showLaunchScreen:YES];
 }
 
 - (void)hide:(CDVInvokedUrlCommand*)command
 {
-    if ([self.viewController isKindOfClass:[CDVViewController class]]) {
-        [(CDVViewController*)self.viewController showLaunchScreen:NO];
-    }
+    [self.viewController showLaunchScreen:NO];
 }
 
 @end

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -26,7 +26,6 @@
 #import <objc/message.h>
 
 #define CDV_BRIDGE_NAME @"cordova"
-#define CDV_WKWEBVIEW_FILE_URL_LOAD_SELECTOR @"loadFileURL:allowingReadAccessToURL:"
 
 @interface CDVWebViewWeakScriptMessageHandler : NSObject <WKScriptMessageHandler>
 
@@ -272,32 +271,6 @@
                name:UIApplicationWillEnterForegroundNotification object:nil];
 
     NSLog(@"Using WKWebView");
-
-    [self addURLObserver];
-}
-
-- (void)onReset {
-    [self addURLObserver];
-}
-
-static void * KVOContext = &KVOContext;
-
-- (void)addURLObserver {
-    if(!IsAtLeastiOSVersion(@"9.0")){
-        [self.webView addObserver:self forKeyPath:@"URL" options:0 context:KVOContext];
-    }
-}
-
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context
-{
-    if (context == KVOContext) {
-        if (object == [self webView] && [keyPath isEqualToString: @"URL"] && [object valueForKeyPath:keyPath] == nil){
-            NSLog(@"URL is nil. Reloading WKWebView");
-            [(WKWebView*)_engineWebView reload];
-        }
-    } else {
-        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
-    }
 }
 
 - (void) onAppWillEnterForeground:(NSNotification*)notification {
@@ -381,15 +354,7 @@ static void * KVOContext = &KVOContext;
 
 - (BOOL) canLoadRequest:(NSURLRequest*)request
 {
-    // See: https://issues.apache.org/jira/browse/CB-9636
-    SEL wk_sel = NSSelectorFromString(CDV_WKWEBVIEW_FILE_URL_LOAD_SELECTOR);
-
-    // if it's a file URL, check whether WKWebView has the selector (which is in iOS 9 and up only)
-    if (request.URL.fileURL) {
-        return [_engineWebView respondsToSelector:wk_sel];
-    } else {
-        return YES;
-    }
+    return YES;
 }
 
 - (void)updateSettings:(NSDictionary*)settings

--- a/CordovaLib/Classes/Public/CDVAppDelegate.m
+++ b/CordovaLib/Classes/Public/CDVAppDelegate.m
@@ -18,6 +18,9 @@
  */
 
 #import <Cordova/CDVAppDelegate.h>
+#import <Cordova/CDVAvailability.h>
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVViewController.h>
 
 @implementation CDVAppDelegate
 
@@ -68,6 +71,10 @@
         return NO;
     }
 
+    // all plugins will get the notification, and their handlers will be called
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDVPluginHandleOpenURLNotification object:url userInfo:options];
+
+    // TODO: This should be deprecated and removed in Cordova iOS 9, since we're passing this data in the notification userInfo now
     NSMutableDictionary * openURLData = [[NSMutableDictionary alloc] init];
 
     [openURLData setValue:url forKey:@"url"];
@@ -80,9 +87,10 @@
         [openURLData setValue:options[UIApplicationOpenURLOptionsAnnotationKey] forKey:@"annotation"];
     }
 
-    // all plugins will get the notification, and their handlers will be called
-    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:openURLData]];
+#pragma clang diagnostic pop
 
     return YES;
 }

--- a/CordovaLib/Classes/Public/CDVCommandQueue.m
+++ b/CordovaLib/Classes/Public/CDVCommandQueue.m
@@ -20,6 +20,7 @@
 #include <objc/message.h>
 #import <Cordova/CDVCommandQueue.h>
 #import <Cordova/CDVViewController.h>
+#import <Cordova/CDVPlugin.h>
 #import "CDVCommandDelegateImpl.h"
 #import "CDVJSON_private.h"
 #import "CDVDebug.h"

--- a/CordovaLib/Classes/Public/CDVPlugin.m
+++ b/CordovaLib/Classes/Public/CDVPlugin.m
@@ -71,8 +71,12 @@ NSString* const CDVViewWillTransitionToSizeNotification = @"CDVViewWillTransitio
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppTerminate) name:UIApplicationWillTerminateNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onMemoryWarning) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOpenURL:) name:CDVPluginHandleOpenURLNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOpenURLWithApplicationSourceAndAnnotation:) name:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onReset) name:CDVPluginResetNotification object:theWebViewEngine.engineWebView];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOpenURLWithApplicationSourceAndAnnotation:) name:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:nil];
+#pragma clang diagnostic pop
 
         self.webViewEngine = theWebViewEngine;
     }

--- a/CordovaLib/Classes/Public/CDVPluginResult.m
+++ b/CordovaLib/Classes/Public/CDVPluginResult.m
@@ -25,6 +25,7 @@
 // using CDVCommandStatus as ObjC-style constants rather than as Swift enum
 // values.
 // These constants alias the enum values back to their previous names.
+// TODO: Remove in Cordova iOS 9
 #define SWIFT_ENUM_COMPAT_HACK(enumVal) const CDVCommandStatus SWIFT_##enumVal NS_SWIFT_NAME(enumVal) = enumVal
 SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_NO_RESULT);
 SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_OK);

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -56,7 +56,6 @@ UIColor* defaultBackgroundColor(void) {
 
 @implementation CDVViewController
 
-@synthesize supportedOrientations;
 @synthesize pluginObjects, pluginsMap, startupPluginNames;
 @synthesize configParser, settings;
 @synthesize wwwFolderName, startPage, initialized, openURL;
@@ -85,9 +84,6 @@ UIColor* defaultBackgroundColor(void) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onWebViewPageDidLoad:)
                                                      name:CDVPageDidLoadNotification object:nil];
 
-        // read from UISupportedInterfaceOrientations (or UISupportedInterfaceOrientations~iPad, if its iPad) from -Info.plist
-        self.supportedOrientations = [self parseInterfaceOrientations:
-            [[[NSBundle mainBundle] infoDictionary] objectForKey:@"UISupportedInterfaceOrientations"]];
 
         self.initialized = YES;
     }
@@ -350,65 +346,6 @@ UIColor* defaultBackgroundColor(void) {
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVViewWillTransitionToSizeNotification object:[NSValue valueWithCGSize:size]]];
-}
-
-- (NSArray*)parseInterfaceOrientations:(NSArray*)orientations
-{
-    NSMutableArray* result = [[NSMutableArray alloc] init];
-
-    if (orientations != nil) {
-        NSEnumerator* enumerator = [orientations objectEnumerator];
-        NSString* orientationString;
-
-        while (orientationString = [enumerator nextObject]) {
-            if ([orientationString isEqualToString:@"UIInterfaceOrientationPortrait"]) {
-                [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationPortrait]];
-            } else if ([orientationString isEqualToString:@"UIInterfaceOrientationPortraitUpsideDown"]) {
-                [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown]];
-            } else if ([orientationString isEqualToString:@"UIInterfaceOrientationLandscapeLeft"]) {
-                [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft]];
-            } else if ([orientationString isEqualToString:@"UIInterfaceOrientationLandscapeRight"]) {
-                [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight]];
-            }
-        }
-    }
-
-    // default
-    if ([result count] == 0) {
-        [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationPortrait]];
-    }
-
-    return result;
-}
-
-- (BOOL)shouldAutorotate
-{
-    return YES;
-}
-
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-{
-    NSUInteger ret = 0;
-
-    if ([self supportsOrientation:UIInterfaceOrientationPortrait]) {
-        ret = ret | (1 << UIInterfaceOrientationPortrait);
-    }
-    if ([self supportsOrientation:UIInterfaceOrientationPortraitUpsideDown]) {
-        ret = ret | (1 << UIInterfaceOrientationPortraitUpsideDown);
-    }
-    if ([self supportsOrientation:UIInterfaceOrientationLandscapeRight]) {
-        ret = ret | (1 << UIInterfaceOrientationLandscapeRight);
-    }
-    if ([self supportsOrientation:UIInterfaceOrientationLandscapeLeft]) {
-        ret = ret | (1 << UIInterfaceOrientationLandscapeLeft);
-    }
-
-    return ret;
-}
-
-- (BOOL)supportsOrientation:(UIInterfaceOrientation)orientation
-{
-    return [self.supportedOrientations containsObject:@(orientation)];
 }
 
 /// Retrieves the view from a newwly initialized webViewEngine

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -24,6 +24,7 @@
 #import <objc/message.h>
 #import <Foundation/NSCharacterSet.h>
 #import <Cordova/CDV.h>
+#import <Cordova/CDVPlugin.h>
 #import "CDVPlugin+Private.h"
 #import <Cordova/CDVConfigParser.h>
 #import <Cordova/NSDictionary+CordovaPreferences.h>

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -697,15 +697,6 @@ UIColor* defaultBackgroundColor(void) {
     [self checkAndReinitViewUrl];
     // NSLog(@"%@",@"applicationWillEnterForeground");
     [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resume');"];
-
-    if (!IsAtLeastiOSVersion(@"11.0")) {
-        /** Clipboard fix **/
-        UIPasteboard* pasteboard = [UIPasteboard generalPasteboard];
-        NSString* string = pasteboard.string;
-        if (string) {
-            [pasteboard setValue:string forPasteboardType:@"public.text"];
-        }
-    }
 }
 
 // This method is called to let your application know that it moved from the inactive to active state.

--- a/CordovaLib/include/Cordova/CDVAppDelegate.h
+++ b/CordovaLib/include/Cordova/CDVAppDelegate.h
@@ -18,11 +18,15 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <Cordova/CDVViewController.h>
+#import <Cordova/CDVAvailabilityDeprecated.h>
+
+@class CDVViewController;
 
 @interface CDVAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (nullable, nonatomic, strong) IBOutlet UIWindow* window;
-@property (nullable, nonatomic, strong) IBOutlet CDVViewController* viewController;
+@property (nullable, nonatomic, strong) IBOutlet UIWindow* window __deprecated_msg("The window is now managed through the iOS SceneDelegate.");
+
+// TODO: Remove in Cordova iOS 9
+@property (nullable, nonatomic, strong) IBOutlet CDVViewController* viewController CDV_DEPRECATED(8, "");
 
 @end

--- a/CordovaLib/include/Cordova/CDVAvailabilityDeprecated.h
+++ b/CordovaLib/include/Cordova/CDVAvailabilityDeprecated.h
@@ -21,6 +21,8 @@
 
 #ifdef __clang__
     #define CDV_DEPRECATED(version, msg) __attribute__((deprecated("Deprecated in Cordova " #version ". " msg)))
+    #define CDV_DEPRECATED_WITH_REPLACEMENT(version, msg, repl) __attribute__((deprecated("Deprecated in Cordova " #version ". " msg, repl)))
 #else
     #define CDV_DEPRECATED(version, msg) __attribute__((deprecated()))
+    #define CDV_DEPRECATED_WITH_REPLACEMENT(version, msg, repl) __attribute__((deprecated()))
 #endif

--- a/CordovaLib/include/Cordova/CDVPlugin.h
+++ b/CordovaLib/include/Cordova/CDVPlugin.h
@@ -23,6 +23,7 @@
 #import <Cordova/CDVPluginResult.h>
 #import <Cordova/NSMutableArray+QueueAdditions.h>
 #import <Cordova/CDVCommandDelegate.h>
+#import <Cordova/CDVViewController.h>
 #import <Cordova/CDVWebViewEngineProtocol.h>
 
 @interface UIView (org_apache_cordova_UIView_Extension)
@@ -48,7 +49,7 @@ extern NSString* const CDVViewWillTransitionToSizeNotification;
 @property (nonatomic, readonly, weak) UIView* webView;
 @property (nonatomic, readonly, weak) id <CDVWebViewEngineProtocol> webViewEngine;
 
-@property (nonatomic, weak) UIViewController* viewController;
+@property (nonatomic, weak) CDVViewController* viewController;
 @property (nonatomic, weak) id <CDVCommandDelegate> commandDelegate;
 
 @property (readonly, assign) BOOL hasPendingOperation;

--- a/CordovaLib/include/Cordova/CDVPlugin.h
+++ b/CordovaLib/include/Cordova/CDVPlugin.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <Cordova/CDVAvailabilityDeprecated.h>
 #import <Cordova/CDVPluginResult.h>
 #import <Cordova/NSMutableArray+QueueAdditions.h>
 #import <Cordova/CDVCommandDelegate.h>
@@ -32,7 +33,7 @@
 
 extern NSString* const CDVPageDidLoadNotification;
 extern NSString* const CDVPluginHandleOpenURLNotification;
-extern NSString* const CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification;
+extern NSString* const CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification CDV_DEPRECATED(8, "Find sourceApplication and annotations in the userInfo of the CDVPluginHandleOpenURLNotification notification.");
 extern NSString* const CDVPluginResetNotification;
 extern NSString* const CDVViewWillAppearNotification;
 extern NSString* const CDVViewDidAppearNotification;
@@ -55,7 +56,7 @@ extern NSString* const CDVViewWillTransitionToSizeNotification;
 - (void)pluginInitialize;
 
 - (void)handleOpenURL:(NSNotification*)notification;
-- (void)handleOpenURLWithApplicationSourceAndAnnotation:(NSNotification*)notification;
+- (void)handleOpenURLWithApplicationSourceAndAnnotation:(NSNotification*)notification CDV_DEPRECATED(8, "Use the handleOpenUrl method and the notification userInfo data.");
 - (void)onAppTerminate;
 - (void)onMemoryWarning;
 - (void)onReset;

--- a/CordovaLib/include/Cordova/CDVPluginResult.h
+++ b/CordovaLib/include/Cordova/CDVPluginResult.h
@@ -33,22 +33,25 @@ typedef NS_ENUM(NSUInteger, CDVCommandStatus) {
     CDVCommandStatus_ERROR NS_SWIFT_NAME(error)
 };
 
+#ifdef __swift__
 // This exists to preserve compatibility with early Swift plugins, who are
 // using CDVCommandStatus as ObjC-style constants rather than as Swift enum
 // values.
 // This declares extern'ed constants (implemented in CDVPluginResult.m)
-#define SWIFT_ENUM_COMPAT_HACK(enumVal) extern const CDVCommandStatus SWIFT_##enumVal NS_SWIFT_NAME(enumVal)
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_NO_RESULT);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_OK);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INSTANTIATION_EXCEPTION);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_MALFORMED_URL_EXCEPTION);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_IO_EXCEPTION);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INVALID_ACTION);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_JSON_EXCEPTION);
-SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ERROR);
+// TODO: Remove this in Cordova iOS 9
+#define SWIFT_ENUM_COMPAT_HACK(enumVal, replacement) extern const CDVCommandStatus SWIFT_##enumVal NS_SWIFT_NAME(enumVal) CDV_DEPRECATED_WITH_REPLACEMENT(8, "Use the CDVCommandStatus." #replacement " enum value instead", "CDVCommandStatus." #replacement)
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_NO_RESULT, noResult);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_OK, ok);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION, classNotFoundException);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION, illegalAccessException);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INSTANTIATION_EXCEPTION, instantiationException);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_MALFORMED_URL_EXCEPTION, malformedUrlException);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_IO_EXCEPTION, ioException);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_INVALID_ACTION, invalidAction);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_JSON_EXCEPTION, jsonException);
+SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ERROR, error);
 #undef SWIFT_ENUM_COMPAT_HACK
+#endif
 
 @interface CDVPluginResult : NSObject {}
 

--- a/CordovaLib/include/Cordova/CDVScreenOrientationDelegate.h
+++ b/CordovaLib/include/Cordova/CDVScreenOrientationDelegate.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVAvailabilityDeprecated.h>
 
+CDV_DEPRECATED(8, "Unused")
 @protocol CDVScreenOrientationDelegate <NSObject>
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations;

--- a/CordovaLib/include/Cordova/CDVScreenOrientationDelegate.h
+++ b/CordovaLib/include/Cordova/CDVScreenOrientationDelegate.h
@@ -18,6 +18,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Cordova/CDVAvailabilityDeprecated.h>
 
 @protocol CDVScreenOrientationDelegate <NSObject>
 

--- a/CordovaLib/include/Cordova/CDVURLSchemeHandler.h
+++ b/CordovaLib/include/Cordova/CDVURLSchemeHandler.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
 #import <Cordova/CDVViewController.h>
+#import <Cordova/CDVPlugin.h>
 
 
 @interface CDVURLSchemeHandler : NSObject <WKURLSchemeHandler>

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -25,8 +25,9 @@
 #import <Cordova/CDVCommandDelegate.h>
 #import <Cordova/CDVCommandQueue.h>
 #import <Cordova/CDVScreenOrientationDelegate.h>
-#import <Cordova/CDVPlugin.h>
 #import <Cordova/CDVWebViewEngineProtocol.h>
+
+@class CDVPlugin;
 
 @protocol CDVWebViewEngineConfigurationDelegate <NSObject>
 

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -29,24 +29,6 @@
 
 @class CDVPlugin;
 
-@protocol CDVWebViewEngineConfigurationDelegate <NSObject>
-
-@optional
-/// Provides a fully configured WKWebViewConfiguration which will be overriden with
-/// any related settings you add to config.xml (e.g., `PreferredContentMode`).
-/// Useful for more complex configuration, including websiteDataStore.
-///
-/// Example usage:
-///
-/// extension CDVViewController: CDVWebViewEngineConfigurationDelegate {
-///     public func configuration() -> WKWebViewConfiguration {
-///         // return your config here
-///     }
-/// }
-- (nonnull WKWebViewConfiguration*)configuration;
-
-@end
-
 /*!
   @abstract The main view controller for Cordova web content.
  */

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -47,7 +47,10 @@
 
 @end
 
-@interface CDVViewController : UIViewController <CDVScreenOrientationDelegate>{
+/*!
+  @abstract The main view controller for Cordova web content.
+ */
+@interface CDVViewController : UIViewController {
     @protected
     id <CDVWebViewEngineProtocol> _webViewEngine;
     @protected
@@ -74,19 +77,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) id <CDVWebViewEngineProtocol> webViewEngine;
 @property (nonatomic, readonly, strong) id <CDVCommandDelegate> commandDelegate;
 
-/**
-    Takes/Gives an array of UIInterfaceOrientation (int) objects
-    ex. UIInterfaceOrientationPortrait
-*/
-@property (nonatomic, readwrite, strong) NSArray* supportedOrientations;
 
 - (UIView*)newCordovaViewWithFrame:(CGRect)bounds;
 
 - (nullable NSString*)appURLScheme;
 - (nullable NSURL*)errorURL;
-
-- (NSArray*)parseInterfaceOrientations:(NSArray*)orientations;
-- (BOOL)supportsOrientation:(UIInterfaceOrientation)orientation;
 
 - (nullable id)getCommandInstance:(NSString*)pluginName;
 - (void)registerPlugin:(CDVPlugin*)plugin withClassName:(NSString*)className;

--- a/CordovaLib/include/Cordova/CDVWebViewEngineProtocol.h
+++ b/CordovaLib/include/Cordova/CDVWebViewEngineProtocol.h
@@ -49,3 +49,22 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 @end
+
+
+@protocol CDVWebViewEngineConfigurationDelegate <NSObject>
+
+@optional
+/// Provides a fully configured WKWebViewConfiguration which will be overriden with
+/// any related settings you add to config.xml (e.g., `PreferredContentMode`).
+/// Useful for more complex configuration, including websiteDataStore.
+///
+/// Example usage:
+///
+/// extension CDVViewController: CDVWebViewEngineConfigurationDelegate {
+///     public func configuration() -> WKWebViewConfiguration {
+///         // return your config here
+///     }
+/// }
+- (nonnull WKWebViewConfiguration*)configuration;
+
+@end

--- a/tests/CordovaLibTests/CDVPluginInitTests.m
+++ b/tests/CordovaLibTests/CDVPluginInitTests.m
@@ -40,7 +40,7 @@
 
     self.appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
     [self.appDelegate createViewController];
-    self.viewController = self.appDelegate.viewController;
+    self.viewController = self.appDelegate.testViewController;
 }
 
 - (void)tearDown

--- a/tests/CordovaLibTests/CordovaLibApp/AppDelegate.h
+++ b/tests/CordovaLibTests/CordovaLibApp/AppDelegate.h
@@ -20,9 +20,11 @@
 #import <UIKit/UIKit.h>
 #import <Cordova/CDVAppDelegate.h>
 
-@class ViewController;
+@class CDVViewController;
 
 @interface AppDelegate : CDVAppDelegate
+
+@property (nullable, nonatomic, strong, readonly) CDVViewController *testViewController;
 
 - (void)createViewController;
 - (void)destroyViewController;

--- a/tests/CordovaLibTests/CordovaLibApp/AppDelegate.m
+++ b/tests/CordovaLibTests/CordovaLibApp/AppDelegate.m
@@ -21,23 +21,31 @@
 
 #import "ViewController.h"
 
+@interface AppDelegate () {
+    UIWindow *_window;
+    CDVViewController *_viewController;
+}
+@end
+
 @implementation AppDelegate
+
+@synthesize testViewController = _viewController;
 
 - (void)createViewController
 {
-    self.viewController = [[ViewController alloc] init];
-    self.viewController.wwwFolderName = @"www";
-    self.viewController.startPage = @"index.html";
+    _viewController = [[ViewController alloc] init];
+    _viewController.wwwFolderName = @"www";
+    _viewController.startPage = @"index.html";
 
     // NOTE: To customize the view's frame size (which defaults to full screen), override
     // [self.viewController viewWillAppear:] in your view controller.
 
-    self.window.rootViewController = self.viewController;
+    self.window.rootViewController = _viewController;
 }
 
 - (void)destroyViewController
 {
-    self.viewController = nil;
+    _viewController = nil;
 }
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1428.


### Description
<!-- Describe your changes in detail -->
* Added deprecation annotations to things we want to discourage people from using (some of these can be removed in Cordova iOS 9)
* Remove some conditionals for iOS versions pre-11 and dead code
* Change CDVPlugin's `viewController` from a `UIViewController*` to a `CDVViewController*`
* Move a webview engine-related delegate to a header that makes more sense


### Testing
<!-- Please describe in detail how you tested your changes. -->
Unit tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))