### PR TITLE
fix(Podfile): Avoid creating an empty Podfile on plugin install

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -338,6 +338,10 @@ class Api {
      * @return  {Promise}  Return a promise
      */
     addPodSpecs (plugin, podSpecs, installOptions) {
+        if (!podSpecs.length) {
+            return;
+        }
+
         const project_dir = this.locations.root;
         const project_name = this.locations.xcodeCordovaProj.split(path.sep).pop();
         const minDeploymentTarget = this.getPlatformInfo().projectConfig.getPreference('deployment-target', 'ios');
@@ -347,80 +351,77 @@ class Api {
         const podsjsonFile = new PodsJson(path.join(project_dir, PodsJson.FILENAME));
         const podfileFile = new Podfile(path.join(project_dir, Podfile.FILENAME), project_name, minDeploymentTarget);
 
-        if (podSpecs.length) {
-            events.emit('verbose', 'Adding pods since the plugin contained <podspecs>');
-            podSpecs.forEach(obj => {
-                // declarations
-                if (obj.declarations) {
-                    Object.keys(obj.declarations).forEach(key => {
-                        if (obj.declarations[key] === 'true') {
-                            const declaration = Podfile.proofDeclaration(key);
-                            const podJson = {
-                                declaration
-                            };
-                            const val = podsjsonFile.getDeclaration(declaration);
-                            if (val) {
-                                podsjsonFile.incrementDeclaration(declaration);
-                            } else {
-                                podJson.count = 1;
-                                podsjsonFile.setJsonDeclaration(declaration, podJson);
-                                podfileFile.addDeclaration(podJson.declaration);
-                            }
-                        }
-                    });
-                }
-
-                // sources
-                if (obj.sources) {
-                    Object.keys(obj.sources).forEach(key => {
+        events.emit('verbose', 'Adding pods since the plugin contained <podspecs>');
+        podSpecs.forEach(obj => {
+            // declarations
+            if (obj.declarations) {
+                Object.keys(obj.declarations).forEach(key => {
+                    if (obj.declarations[key] === 'true') {
+                        const declaration = Podfile.proofDeclaration(key);
                         const podJson = {
-                            source: obj.sources[key].source
+                            declaration
                         };
-                        const val = podsjsonFile.getSource(key);
+                        const val = podsjsonFile.getDeclaration(declaration);
                         if (val) {
-                            podsjsonFile.incrementSource(key);
+                            podsjsonFile.incrementDeclaration(declaration);
                         } else {
                             podJson.count = 1;
-                            podsjsonFile.setJsonSource(key, podJson);
-                            podfileFile.addSource(podJson.source);
+                            podsjsonFile.setJsonDeclaration(declaration, podJson);
+                            podfileFile.addDeclaration(podJson.declaration);
                         }
-                    });
-                }
-
-                // libraries
-                if (obj.libraries) {
-                    Object.keys(obj.libraries).forEach(key => {
-                        let podJson = Object.assign({}, obj.libraries[key]);
-                        podJson = replacePodSpecVariables(podJson, installOptions);
-                        const val = podsjsonFile.getLibrary(key);
-                        if (val) {
-                            events.emit('warn', `${plugin.id} depends on ${podJson.name}, which may conflict with another plugin. ${podJson.name}@${val.spec} is already installed and was not overwritten.`);
-                            podsjsonFile.incrementLibrary(key);
-                        } else {
-                            podJson.count = 1;
-                            podsjsonFile.setJsonLibrary(key, podJson);
-                            podfileFile.addSpec(podJson.name, podJson);
-                        }
-                    });
-                }
-            });
-
-            // now that all the pods have been processed, write to pods.json
-            podsjsonFile.write();
-
-            // only write and pod install if the Podfile changed
-            if (podfileFile.isDirty()) {
-                podfileFile.write();
-                events.emit('verbose', 'Running `pod install` (to install plugins)');
-                projectFile.purgeProjectFileCache(this.locations.root);
-
-                return podfileFile.install(check_reqs.check_cocoapods)
-                    .then(() => podsjsonFile.setSwiftVersionForCocoaPodsLibraries(this.root));
-            } else {
-                events.emit('verbose', 'Podfile unchanged, skipping `pod install`');
+                    }
+                });
             }
+
+            // sources
+            if (obj.sources) {
+                Object.keys(obj.sources).forEach(key => {
+                    const podJson = {
+                        source: obj.sources[key].source
+                    };
+                    const val = podsjsonFile.getSource(key);
+                    if (val) {
+                        podsjsonFile.incrementSource(key);
+                    } else {
+                        podJson.count = 1;
+                        podsjsonFile.setJsonSource(key, podJson);
+                        podfileFile.addSource(podJson.source);
+                    }
+                });
+            }
+
+            // libraries
+            if (obj.libraries) {
+                Object.keys(obj.libraries).forEach(key => {
+                    let podJson = Object.assign({}, obj.libraries[key]);
+                    podJson = replacePodSpecVariables(podJson, installOptions);
+                    const val = podsjsonFile.getLibrary(key);
+                    if (val) {
+                        events.emit('warn', `${plugin.id} depends on ${podJson.name}, which may conflict with another plugin. ${podJson.name}@${val.spec} is already installed and was not overwritten.`);
+                        podsjsonFile.incrementLibrary(key);
+                    } else {
+                        podJson.count = 1;
+                        podsjsonFile.setJsonLibrary(key, podJson);
+                        podfileFile.addSpec(podJson.name, podJson);
+                    }
+                });
+            }
+        });
+
+        // now that all the pods have been processed, write to pods.json
+        podsjsonFile.write();
+
+        // only write and pod install if the Podfile changed
+        if (podfileFile.isDirty()) {
+            podfileFile.write();
+            events.emit('verbose', 'Running `pod install` (to install plugins)');
+            projectFile.purgeProjectFileCache(this.locations.root);
+
+            return podfileFile.install(check_reqs.check_cocoapods)
+                .then(() => podsjsonFile.setSwiftVersionForCocoaPodsLibraries(this.root));
+        } else {
+            events.emit('verbose', 'Podfile unchanged, skipping `pod install`');
         }
-        return Promise.resolve();
     }
 
     /**


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1365.


### Description
<!-- Describe your changes in detail -->
Calling `new Podfile(...)` will create an empty Podfile in the project if it does not exist. If we don't have any pods to add for a given plugin, we can skip doing anything at all with the Podfile and avoid needlessly creating it.

Note: I moved an `if` block to do an early return, which de-indented the majority of the code in that function. This PR is easier to review with whitespace changes disabled.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested manually by creating a new project and installing the `cordova-plugin-inappbrowser` and confirmed that no Podfile was present in the `platforms/ios` directory.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))