### PR TITLE
fix: Error when no simulators are available

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -85,10 +85,11 @@ function getDefaultSimulatorTarget () {
     events.emit('log', 'Select last emulator from list as default.');
     return require('./listEmulatorBuildTargets').run()
         .then(emulators => {
-            let targetEmulator;
-            if (emulators.length > 0) {
-                targetEmulator = emulators[0];
+            if (emulators.length === 0) {
+                return Promise.reject(new CordovaError('Could not find any iOS simulators. Use Xcode to install simulator devices for testing.'));
             }
+
+            let targetEmulator = emulators[0];
             emulators.forEach(emulator => {
                 if (emulator.name.indexOf('iPhone') === 0) {
                     targetEmulator = emulator;

--- a/tests/spec/unit/build.spec.js
+++ b/tests/spec/unit/build.spec.js
@@ -418,6 +418,21 @@ describe('build', () => {
                 });
             });
         });
+
+        it('should handle the case of no simulators being available', () => {
+            // This method will require a module that supports the run method.
+            build.__set__('require', () => ({
+                run: () => Promise.resolve([])
+            }));
+
+            const getDefaultSimulatorTarget = build.__get__('getDefaultSimulatorTarget');
+
+            return getDefaultSimulatorTarget().then(sim => {
+                return Promise.reject(new Error('Should not resolve if no simulators are present'));
+            }, (err) => {
+                expect(err).toBeInstanceOf(CordovaError);
+            });
+        });
     });
 
     describe('findXCodeProjectIn method', () => {


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes GH-526.
Closes GH-1366.
Closes GH-1377.
Closes GH-1469.


### Description
<!-- Describe your changes in detail -->
Changed `getDefaultSimulatorTarget()` to reject with an error message when no simulators are found.

This should at least return a useful and actionable error message to the end user, rather than "Cannot read property name of undefined".


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing unit tests pass.
Added unit test to confirm the function now rejects when no simulators are present.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
