### PR TITLE
refactor: Modernize some ObjC code

### DIFF
--- a/CordovaLib/Classes/Private/CDVCommandDelegateImpl.h
+++ b/CordovaLib/Classes/Private/CDVCommandDelegateImpl.h
@@ -17,7 +17,7 @@
  under the License.
  */
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <Cordova/CDVCommandDelegate.h>
 
 @class CDVViewController;
@@ -31,6 +31,6 @@
     __weak CDVCommandQueue* _commandQueue;
     BOOL _delayResponses;
 }
-- (id)initWithViewController:(CDVViewController*)viewController;
+- (instancetype)initWithViewController:(CDVViewController *)viewController;
 - (void)flushCommandQueueWithDelayedJs;
 @end

--- a/CordovaLib/Classes/Private/CDVCommandDelegateImpl.m
+++ b/CordovaLib/Classes/Private/CDVCommandDelegateImpl.m
@@ -25,9 +25,7 @@
 
 @implementation CDVCommandDelegateImpl
 
-@synthesize urlTransformer;
-
-- (id)initWithViewController:(CDVViewController*)viewController
+- (instancetype)initWithViewController:(CDVViewController *)viewController
 {
     self = [super init];
     if (self != nil) {

--- a/CordovaLib/Classes/Private/CDVJSON_private.h
+++ b/CordovaLib/Classes/Private/CDVJSON_private.h
@@ -17,7 +17,7 @@
  under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSArray (CDVJSONSerializingPrivate)
 - (NSString*)cdv_JSONString;

--- a/CordovaLib/Classes/Private/CDVJSON_private.m
+++ b/CordovaLib/Classes/Private/CDVJSON_private.m
@@ -17,8 +17,6 @@
  under the License.
  */
 
-@import Foundation;
-
 #import "CDVJSON_private.h"
 
 @implementation NSArray (CDVJSONSerializingPrivate)

--- a/CordovaLib/Classes/Private/CDVPlugin+Private.h
+++ b/CordovaLib/Classes/Private/CDVPlugin+Private.h
@@ -17,6 +17,8 @@
  under the License.
  */
 
+#import <Cordova/CDVPlugin.h>
+
 @interface CDVPlugin (Private)
 
 - (instancetype)initWithWebViewEngine:(id <CDVWebViewEngineProtocol>)theWebViewEngine;

--- a/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVGestureHandler/CDVGestureHandler.m
@@ -30,8 +30,7 @@
 {
     // You can't suppress 3D Touch and still have regular longpress,
     // so if this is false, let's not consider the 3D Touch setting at all.
-    if (![self.commandDelegate.settings objectForKey:@"suppresseslongpressgesture"] ||
-        ![[self.commandDelegate.settings objectForKey:@"suppresseslongpressgesture"] boolValue]) {
+    if (![self.commandDelegate.settings cordovaBoolSettingForKey:@"SuppressesLongPressGesture" defaultValue:NO]) {
         return;
     }
 
@@ -41,8 +40,7 @@
 
     // 0.45 is ok for 'regular longpress', 0.05-0.08 is required for '3D Touch longpress',
     // but since this will also kill onclick handlers (not ontouchend) it's optional.
-    if ([self.commandDelegate.settings objectForKey:@"suppresses3dtouchgesture"] &&
-        [[self.commandDelegate.settings objectForKey:@"suppresses3dtouchgesture"] boolValue]) {
+    if ([self.commandDelegate.settings cordovaBoolSettingForKey:@"Suppresses3DTouchGesture" defaultValue:NO]) {
         self.lpgr.minimumPressDuration = 0.15f;
     }
 

--- a/CordovaLib/Classes/Private/Plugins/CDVHandleOpenURL/CDVHandleOpenURL.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVHandleOpenURL/CDVHandleOpenURL.m
@@ -18,7 +18,6 @@
  */
 
 #import "CDVHandleOpenURL.h"
-#import <Cordova/CDV.h>
 
 @implementation CDVHandleOpenURL
 

--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
@@ -18,7 +18,6 @@
  */
 
 #import "CDVIntentAndNavigationFilter.h"
-#import <Cordova/CDV.h>
 
 @interface CDVIntentAndNavigationFilter ()
 

--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
@@ -18,6 +18,7 @@
  */
 
 #import "CDVIntentAndNavigationFilter.h"
+#import <Cordova/CDVConfigParser.h>
 
 @interface CDVIntentAndNavigationFilter ()
 
@@ -73,9 +74,7 @@
 
 - (void)pluginInitialize
 {
-    if ([self.viewController isKindOfClass:[CDVViewController class]]) {
-        [(CDVViewController*)self.viewController parseSettingsWithParser:self];
-    }
+    [CDVConfigParser parseConfigFile:self.viewController.configFilePath withDelegate:self];
 }
 
 + (CDVIntentAndNavigationFilterValue) filterUrl:(NSURL*)url allowIntentsList:(CDVAllowList*)allowIntentsList navigationsAllowList:(CDVAllowList*)navigationsAllowList

--- a/CordovaLib/Classes/Private/Plugins/CDVLaunchScreen/CDVLaunchScreen.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVLaunchScreen/CDVLaunchScreen.m
@@ -18,7 +18,6 @@
  */
 
 #import "CDVLaunchScreen.h"
-#import <Cordova/CDVViewController.h>
 
 @implementation CDVLaunchScreen
 

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.h
@@ -17,8 +17,8 @@
  under the License.
  */
 
-@import WebKit;
-#import <Cordova/CDV.h>
+#import <WebKit/WebKit.h>
+#import <Cordova/CDVPlugin.h>
 
 @interface CDVWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol, WKScriptMessageHandler, WKNavigationDelegate>
 

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewUIDelegate.h
@@ -17,7 +17,7 @@
  under the License.
  */
 
-@import WebKit;
+#import <WebKit/WebKit.h>
 
 @interface CDVWebViewUIDelegate : NSObject <WKUIDelegate>
 {

--- a/CordovaLib/Classes/Public/CDVCommandQueue.m
+++ b/CordovaLib/Classes/Public/CDVCommandQueue.m
@@ -45,7 +45,12 @@ static const double MAX_EXECUTION_TIME = .008; // Half of a 60fps frame.
     return _startExecutionTime > 0;
 }
 
-- (id)initWithViewController:(CDVViewController*)viewController
+- (instancetype)init
+{
+    return [self initWithViewController:nil];
+}
+
+- (instancetype)initWithViewController:(CDVViewController *)viewController
 {
     self = [super init];
     if (self != nil) {

--- a/CordovaLib/Classes/Public/CDVInvokedUrlCommand.m
+++ b/CordovaLib/Classes/Public/CDVInvokedUrlCommand.m
@@ -27,12 +27,17 @@
 @synthesize className = _className;
 @synthesize methodName = _methodName;
 
-+ (CDVInvokedUrlCommand*)commandFromJson:(NSArray*)jsonEntry
++ (instancetype)commandFromJson:(NSArray *)jsonEntry
 {
     return [[CDVInvokedUrlCommand alloc] initFromJson:jsonEntry];
 }
 
-- (id)initFromJson:(NSArray*)jsonEntry
+- (instancetype)init
+{
+    return [self initWithArguments:nil callbackId:nil className:nil methodName:nil];
+}
+
+- (instancetype)initFromJson:(NSArray *)jsonEntry
 {
     id tmp = [jsonEntry objectAtIndex:0];
     NSString* callbackId = tmp == [NSNull null] ? nil : tmp;
@@ -46,10 +51,10 @@
                         methodName:methodName];
 }
 
-- (id)initWithArguments:(NSArray*)arguments
-             callbackId:(NSString*)callbackId
-              className:(NSString*)className
-             methodName:(NSString*)methodName
+- (instancetype)initWithArguments:(NSArray *)arguments
+                       callbackId:(NSString *)callbackId
+                        className:(NSString *)className
+                       methodName:(NSString *)methodName
 {
     self = [super init];
     if (self != nil) {

--- a/CordovaLib/Classes/Public/CDVPlugin.m
+++ b/CordovaLib/Classes/Public/CDVPlugin.m
@@ -18,8 +18,8 @@
  */
 
 #import <Cordova/CDVPlugin.h>
-#import "CDVPlugin+Private.h"
 #import <Cordova/CDVPlugin+Resources.h>
+#import "CDVPlugin+Private.h"
 #import <Cordova/CDVViewController.h>
 #include <objc/message.h>
 
@@ -40,17 +40,17 @@
 
 @end
 
-NSString* const CDVPageDidLoadNotification = @"CDVPageDidLoadNotification";
-NSString* const CDVPluginHandleOpenURLNotification = @"CDVPluginHandleOpenURLNotification";
-NSString* const CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification = @"CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification";
-NSString* const CDVPluginResetNotification = @"CDVPluginResetNotification";
-NSString* const CDVViewWillAppearNotification = @"CDVViewWillAppearNotification";
-NSString* const CDVViewDidAppearNotification = @"CDVViewDidAppearNotification";
-NSString* const CDVViewWillDisappearNotification = @"CDVViewWillDisappearNotification";
-NSString* const CDVViewDidDisappearNotification = @"CDVViewDidDisappearNotification";
-NSString* const CDVViewWillLayoutSubviewsNotification = @"CDVViewWillLayoutSubviewsNotification";
-NSString* const CDVViewDidLayoutSubviewsNotification = @"CDVViewDidLayoutSubviewsNotification";
-NSString* const CDVViewWillTransitionToSizeNotification = @"CDVViewWillTransitionToSizeNotification";
+const NSNotificationName CDVPageDidLoadNotification = @"CDVPageDidLoadNotification";
+const NSNotificationName CDVPluginHandleOpenURLNotification = @"CDVPluginHandleOpenURLNotification";
+const NSNotificationName CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification = @"CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification";
+const NSNotificationName CDVPluginResetNotification = @"CDVPluginResetNotification";
+const NSNotificationName CDVViewWillAppearNotification = @"CDVViewWillAppearNotification";
+const NSNotificationName CDVViewDidAppearNotification = @"CDVViewDidAppearNotification";
+const NSNotificationName CDVViewWillDisappearNotification = @"CDVViewWillDisappearNotification";
+const NSNotificationName CDVViewDidDisappearNotification = @"CDVViewDidDisappearNotification";
+const NSNotificationName CDVViewWillLayoutSubviewsNotification = @"CDVViewWillLayoutSubviewsNotification";
+const NSNotificationName CDVViewDidLayoutSubviewsNotification = @"CDVViewDidLayoutSubviewsNotification";
+const NSNotificationName CDVViewWillTransitionToSizeNotification = @"CDVViewWillTransitionToSizeNotification";
 
 @interface CDVPlugin ()
 

--- a/CordovaLib/Classes/Public/CDVPluginResult.m
+++ b/CordovaLib/Classes/Public/CDVPluginResult.m
@@ -41,7 +41,7 @@ SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ERROR);
 
 @interface CDVPluginResult ()
 
-- (CDVPluginResult*)initWithStatus:(CDVCommandStatus)statusOrdinal message:(id)theMessage;
+- (instancetype)initWithStatus:(CDVCommandStatus)statusOrdinal message:(id)theMessage;
 
 @end
 
@@ -95,12 +95,12 @@ id messageFromMultipart(NSArray* theMessages)
         nil];
 }
 
-- (CDVPluginResult*)init
+- (instancetype)init
 {
     return [self initWithStatus:CDVCommandStatus_NO_RESULT message:nil];
 }
 
-- (CDVPluginResult*)initWithStatus:(CDVCommandStatus)statusOrdinal message:(id)theMessage
+- (instancetype)initWithStatus:(CDVCommandStatus)statusOrdinal message:(id)theMessage
 {
     self = [super init];
     if (self) {
@@ -111,62 +111,62 @@ id messageFromMultipart(NSArray* theMessages)
     return self;
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal
 {
     return [[self alloc] initWithStatus:statusOrdinal message:nil];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsString:(NSString*)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsString:(NSString *)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:theMessage];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArray:(NSArray*)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArray:(NSArray *)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:theMessage];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsInt:(int)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsInt:(int)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:[NSNumber numberWithInt:theMessage]];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSInteger:(NSInteger)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSInteger:(NSInteger)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:[NSNumber numberWithInteger:theMessage]];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSUInteger:(NSUInteger)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSUInteger:(NSUInteger)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:[NSNumber numberWithUnsignedInteger:theMessage]];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDouble:(double)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDouble:(double)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:[NSNumber numberWithDouble:theMessage]];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsBool:(BOOL)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsBool:(BOOL)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:[NSNumber numberWithBool:theMessage]];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDictionary:(NSDictionary*)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDictionary:(NSDictionary *)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:theMessage];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArrayBuffer:(NSData*)theMessage
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArrayBuffer:(NSData *)theMessage
 {
     return [[self alloc] initWithStatus:statusOrdinal message:messageFromArrayBuffer(theMessage)];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsMultipart:(NSArray*)theMessages
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsMultipart:(NSArray *)theMessages
 {
     return [[self alloc] initWithStatus:statusOrdinal message:messageFromMultipart(theMessages)];
 }
 
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageToErrorObject:(int)errorCode
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageToErrorObject:(int)errorCode
 {
     NSDictionary* errDict = @{@"code" :[NSNumber numberWithInt:errorCode]};
 

--- a/CordovaLib/Classes/Public/CDVWebViewProcessPoolFactory.m
+++ b/CordovaLib/Classes/Public/CDVWebViewProcessPoolFactory.m
@@ -17,8 +17,6 @@
  under the License.
  */
 
-@import Foundation;
-@import WebKit;
 #import <Cordova/CDVWebViewProcessPoolFactory.h>
 
 static CDVWebViewProcessPoolFactory *factory = nil;

--- a/CordovaLib/Classes/Public/NSDictionary+CordovaPreferences.m
+++ b/CordovaLib/Classes/Public/NSDictionary+CordovaPreferences.m
@@ -17,7 +17,7 @@
  under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #define __CORDOVA_SILENCE_HEADER_DEPRECATIONS
 #import <Cordova/NSDictionary+CordovaPreferences.h>

--- a/CordovaLib/include/Cordova/CDV.h
+++ b/CordovaLib/include/Cordova/CDV.h
@@ -17,26 +17,7 @@
  under the License.
  */
 
-#define __CORDOVA_SILENCE_HEADER_DEPRECATIONS
-
-#import <Cordova/CDVAvailability.h>
-#import <Cordova/CDVAvailabilityDeprecated.h>
-#import <Cordova/CDVAppDelegate.h>
-#import <Cordova/CDVPlugin.h>
-#import <Cordova/CDVPluginResult.h>
-#import <Cordova/CDVViewController.h>
-#import <Cordova/CDVCommandDelegate.h>
-#import <Cordova/CDVCommandQueue.h>
-#import <Cordova/CDVConfigParser.h>
-#import <Cordova/CDVInvokedUrlCommand.h>
-#import <Cordova/CDVPlugin+Resources.h>
-#import <Cordova/CDVSettingsDictionary.h>
-#import <Cordova/CDVWebViewEngineProtocol.h>
-#import <Cordova/CDVWebViewProcessPoolFactory.h>
-#import <Cordova/NSDictionary+CordovaPreferences.h>
-#import <Cordova/NSMutableArray+QueueAdditions.h>
-#import <Cordova/CDVScreenOrientationDelegate.h>
-#import <Cordova/CDVTimer.h>
-#import <Cordova/CDVURLSchemeHandler.h>
-
-#undef __CORDOVA_SILENCE_HEADER_DEPRECATIONS
+#ifndef __CORDOVA_SILENCE_HEADER_DEPRECATIONS
+    #warning Import <Cordova/Cordova.h> rather than <Cordova/CDV.h>
+    #import <Cordova/Cordova.h>
+#endif

--- a/CordovaLib/include/Cordova/CDVAppDelegate.h
+++ b/CordovaLib/include/Cordova/CDVAppDelegate.h
@@ -22,11 +22,27 @@
 
 @class CDVViewController;
 
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ App delegate class with some additional Cordova-specific behavior.
+
+ The app delegate object manages your app’s shared behaviors. Your app should
+ include its own AppDelegate class which is a subclass of `CDVAppDelegate`.
+
+ `CDVAppDelegate` provides an extension point for Cordova plugins to safely add
+ behavior to the app by building on system events such as URL handling, push
+ notification registration, and deep linking.
+
+ See ``UIApplicationDelegate`` for more details about app delegates.
+ */
 @interface CDVAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (nullable, nonatomic, strong) IBOutlet UIWindow* window __deprecated_msg("The window is now managed through the iOS SceneDelegate.");
+@property (nullable, nonatomic, strong) IBOutlet UIWindow *window API_DEPRECATED_WITH_REPLACEMENT("SceneDelegate:window", ios(2.0, 13.0));
 
 // TODO: Remove in Cordova iOS 9
-@property (nullable, nonatomic, strong) IBOutlet CDVViewController* viewController CDV_DEPRECATED(8, "");
+@property (nullable, nonatomic, strong) IBOutlet CDVViewController *viewController CDV_DEPRECATED(8, "This will always be nil.");
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CordovaLib/include/Cordova/CDVAvailability.h
+++ b/CordovaLib/include/Cordova/CDVAvailability.h
@@ -83,6 +83,7 @@
 #define __CORDOVA_7_0_1 70001
 #define __CORDOVA_7_1_0 70100
 #define __CORDOVA_7_1_1 70101
+#define __CORDOVA_8_0_0 80000
 /* coho:next-version,insert-before */
 #define __CORDOVA_NA 99999      /* not available */
 
@@ -106,8 +107,9 @@
      }
  */
 #define IsAtLeastiOSVersion(X) ([[[UIDevice currentDevice] systemVersion] compare:X options:NSNumericSearch] != NSOrderedAscending)
+#pragma clang deprecated(IsAtLeastiOSVersion, "Use the built-in #available syntax")
 
-/* Return the string version of the decimal version */
+/** Return the string version of the decimal version */
 #define CDV_VERSION [NSString stringWithFormat:@"%d.%d.%d", \
     (CORDOVA_VERSION_MIN_REQUIRED / 10000),                 \
     (CORDOVA_VERSION_MIN_REQUIRED % 10000) / 100,           \

--- a/CordovaLib/include/Cordova/CDVAvailabilityDeprecated.h
+++ b/CordovaLib/include/Cordova/CDVAvailabilityDeprecated.h
@@ -17,12 +17,5 @@
  under the License.
  */
 
-#import <UIKit/UIKit.h>
-
-#ifdef __clang__
-    #define CDV_DEPRECATED(version, msg) __attribute__((deprecated("Deprecated in Cordova " #version ". " msg)))
-    #define CDV_DEPRECATED_WITH_REPLACEMENT(version, msg, repl) __attribute__((deprecated("Deprecated in Cordova " #version ". " msg, repl)))
-#else
-    #define CDV_DEPRECATED(version, msg) __attribute__((deprecated()))
-    #define CDV_DEPRECATED_WITH_REPLACEMENT(version, msg, repl) __attribute__((deprecated()))
-#endif
+#define CDV_DEPRECATED(version, msg) __attribute__((deprecated("Deprecated in Cordova " #version ". " msg)))
+#define CDV_DEPRECATED_WITH_REPLACEMENT(version, msg, repl) __attribute__((deprecated("Deprecated in Cordova " #version ". " msg, repl)))

--- a/CordovaLib/include/Cordova/CDVCommandDelegate.h
+++ b/CordovaLib/include/Cordova/CDVCommandDelegate.h
@@ -24,12 +24,15 @@
 @class CDVPluginResult;
 @class CDVSettingsDictionary;
 
-typedef NSURL* (^ UrlTransformerBlock)(NSURL*);
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol CDVCommandDelegate <NSObject>
 
+@optional
+@property (nonatomic, nullable, copy) NSURL *(^urlTransformer)(NSURL *) CDV_DEPRECATED(8, "Unused");
+
+@required
 @property (nonatomic, readonly) CDVSettingsDictionary* settings;
-@property (nonatomic, copy) UrlTransformerBlock urlTransformer;
 
 - (NSString*)pathForResource:(NSString*)resourcepath;
 - (id)getCommandInstance:(NSString*)pluginName;
@@ -47,3 +50,5 @@ typedef NSURL* (^ UrlTransformerBlock)(NSURL*);
 - (void)runInBackground:(void (^)(void))block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CordovaLib/include/Cordova/CDVCommandQueue.h
+++ b/CordovaLib/include/Cordova/CDVCommandQueue.h
@@ -26,7 +26,8 @@
 
 @property (nonatomic, readonly) BOOL currentlyExecuting;
 
-- (id)initWithViewController:(CDVViewController*)viewController;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithViewController:(CDVViewController *)viewController;
 - (void)dispose;
 
 - (void)resetRequestId;

--- a/CordovaLib/include/Cordova/CDVConfigParser.h
+++ b/CordovaLib/include/Cordova/CDVConfigParser.h
@@ -15,18 +15,70 @@
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
- */
+*/
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An object that handles parsing Cordova XML configuration files.
+
+ ## Overview
+ The `CDVConfigParser` class provides methods to parse a Cordova XML
+ configuration file and then access the resulting configuration data.
+
+ Use ``parseConfigFile:`` to load data from a file path.
+
+ Use ``parseConfigFile:withDelegate:`` if you need to intercept the XML parsing
+ and handle the data yourself with an ``NSXMLParserDelegate``.
+ */
 @interface CDVConfigParser : NSObject <NSXMLParserDelegate>
-{
-    NSString* featureName;
-}
 
-@property (nonatomic, readonly, strong) NSMutableDictionary* pluginsDict;
-@property (nonatomic, readonly, strong) NSMutableDictionary* settings;
-@property (nonatomic, readonly, strong) NSMutableArray* startupPluginNames;
-@property (nonatomic, readonly, strong) NSString* startPage;
+/**
+ A dictionary mapping Cordova plugin name keys to the plugin classes that implement them.
+ */
+@property (nonatomic, readonly, strong) NSMutableDictionary *pluginsDict;
 
+/**
+ A dictionary of Cordova preference keys and their values.
+
+ This should not be used directly, you should only use it to initialize a
+ ``CDVSettingsDictionary`` object.
+ */
+@property (nonatomic, readonly, strong) NSMutableDictionary *settings;
+
+/**
+ An array of plugin names to load immediately when Cordova initializes.
+ */
+@property (nonatomic, readonly, strong) NSMutableArray *startupPluginNames;
+
+/**
+ The path to the HTML page to display when the web view loads.
+ */
+@property (nonatomic, nullable, readonly, strong) NSString *startPage;
+
+/**
+ Parses the given path as a  Cordova XML configuration file.
+
+ If the file could not be loaded or parsed, the resulting ``CDVConfigParser``
+ object will have empty values.
+
+ - Parameters:
+   - filePath: The file path URL to the configuration file.
+ - Returns: A ``CDVConfigParser`` with the parsed result.
+ */
++ (instancetype)parseConfigFile:(NSURL *)filePath;
+
+/**
+ Parses the given path as a  Cordova XML configuration file using the given delegate.
+
+ - Parameters:
+   - filePath: The file path URL to the configuration file.
+   - delegate: The delegate to handle the parsed XML data.
+ - Returns: Whether the given file was successfully parsed.
+ */
++ (BOOL)parseConfigFile:(NSURL *)filePath withDelegate:(id <NSXMLParserDelegate>)delegate;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CordovaLib/include/Cordova/CDVInvokedUrlCommand.h
+++ b/CordovaLib/include/Cordova/CDVInvokedUrlCommand.h
@@ -31,14 +31,14 @@
 @property (nonatomic, readonly) NSString* className;
 @property (nonatomic, readonly) NSString* methodName;
 
-+ (CDVInvokedUrlCommand*)commandFromJson:(NSArray*)jsonEntry;
++ (instancetype)commandFromJson:(NSArray *)jsonEntry;
 
-- (id)initWithArguments:(NSArray*)arguments
-             callbackId:(NSString*)callbackId
-              className:(NSString*)className
-             methodName:(NSString*)methodName;
+- (instancetype)initWithArguments:(NSArray *)arguments
+                       callbackId:(NSString *)callbackId
+                        className:(NSString *)className
+                       methodName:(NSString *)methodName NS_DESIGNATED_INITIALIZER;
 
-- (id)initFromJson:(NSArray*)jsonEntry;
+- (instancetype)initFromJson:(NSArray *)jsonEntry;
 
 // Returns the argument at the given index.
 // If index >= the number of arguments, returns nil.

--- a/CordovaLib/include/Cordova/CDVPlugin.h
+++ b/CordovaLib/include/Cordova/CDVPlugin.h
@@ -26,6 +26,7 @@
 #import <Cordova/CDVSettingsDictionary.h>
 #import <Cordova/CDVViewController.h>
 #import <Cordova/CDVWebViewEngineProtocol.h>
+#import <Cordova/CDVInvokedUrlCommand.h>
 
 @interface UIView (org_apache_cordova_UIView_Extension)
 
@@ -33,17 +34,17 @@
 
 @end
 
-extern NSString* const CDVPageDidLoadNotification;
-extern NSString* const CDVPluginHandleOpenURLNotification;
-extern NSString* const CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification CDV_DEPRECATED(8, "Find sourceApplication and annotations in the userInfo of the CDVPluginHandleOpenURLNotification notification.");
-extern NSString* const CDVPluginResetNotification;
-extern NSString* const CDVViewWillAppearNotification;
-extern NSString* const CDVViewDidAppearNotification;
-extern NSString* const CDVViewWillDisappearNotification;
-extern NSString* const CDVViewDidDisappearNotification;
-extern NSString* const CDVViewWillLayoutSubviewsNotification;
-extern NSString* const CDVViewDidLayoutSubviewsNotification;
-extern NSString* const CDVViewWillTransitionToSizeNotification;
+extern const NSNotificationName CDVPageDidLoadNotification;
+extern const NSNotificationName CDVPluginHandleOpenURLNotification;
+extern const NSNotificationName CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification CDV_DEPRECATED(8, "Find sourceApplication and annotations in the userInfo of the CDVPluginHandleOpenURLNotification notification.");
+extern const NSNotificationName CDVPluginResetNotification;
+extern const NSNotificationName CDVViewWillAppearNotification;
+extern const NSNotificationName CDVViewDidAppearNotification;
+extern const NSNotificationName CDVViewWillDisappearNotification;
+extern const NSNotificationName CDVViewDidDisappearNotification;
+extern const NSNotificationName CDVViewWillLayoutSubviewsNotification;
+extern const NSNotificationName CDVViewDidLayoutSubviewsNotification;
+extern const NSNotificationName CDVViewWillTransitionToSizeNotification;
 
 @interface CDVPlugin : NSObject {}
 

--- a/CordovaLib/include/Cordova/CDVPluginResult.h
+++ b/CordovaLib/include/Cordova/CDVPluginResult.h
@@ -53,28 +53,31 @@ SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ERROR, error);
 #undef SWIFT_ENUM_COMPAT_HACK
 #endif
 
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CDVPluginResult : NSObject {}
 
-@property (nonatomic, strong, readonly) NSNumber* status;
+@property (nonatomic, strong, readonly) NSNumber *status;
 @property (nonatomic, strong, readonly) id message;
-@property (nonatomic, strong)           NSNumber* keepCallback;
+@property (nonatomic, strong)           NSNumber *keepCallback;
 // This property can be used to scope the lifetime of another object. For example,
 // Use it to store the associated NSData when `message` is created using initWithBytesNoCopy.
 @property (nonatomic, strong) id associatedObject;
 
-- (CDVPluginResult*)init;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsString:(NSString*)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArray:(NSArray*)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsInt:(int)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSInteger:(NSInteger)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSUInteger:(NSUInteger)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDouble:(double)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsBool:(BOOL)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDictionary:(NSDictionary*)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArrayBuffer:(NSData*)theMessage;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsMultipart:(NSArray*)theMessages;
-+ (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageToErrorObject:(int)errorCode;
+- (instancetype)init;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsString:(NSString *)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArray:(NSArray *)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsInt:(int)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSInteger:(NSInteger)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsNSUInteger:(NSUInteger)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDouble:(double)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsBool:(BOOL)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsDictionary:(NSDictionary *)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsArrayBuffer:(NSData *)theMessage;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsMultipart:(NSArray *)theMessages;
++ (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageToErrorObject:(int)errorCode;
 
 + (void)setVerbose:(BOOL)verbose;
 + (BOOL)isVerbose;
@@ -84,3 +87,5 @@ SWIFT_ENUM_COMPAT_HACK(CDVCommandStatus_ERROR, error);
 - (NSString*)argumentsAsJSON;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -30,9 +30,11 @@
 
 @class CDVPlugin;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CDVViewController : UIViewController
 
-NS_ASSUME_NONNULL_BEGIN
+@property (nonatomic, nullable, readonly, strong) NSXMLParser *configParser CDV_DEPRECATED(8, "Unused");
 
 @property (nonatomic, readonly, nullable, weak) IBOutlet UIView* webView;
 
@@ -47,8 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, strong) CDVSettingsDictionary* settings;
 
-@property (nonatomic, readonly, strong) NSXMLParser* configParser;
-
 @property (nonatomic, readwrite, copy) NSString* appScheme;
 @property (nonatomic, readwrite, copy) NSString* configFile;
 @property (nonatomic, readwrite, copy) NSString* wwwFolderName;
@@ -57,6 +57,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) id <CDVWebViewEngineProtocol> webViewEngine;
 @property (nonatomic, readonly, strong) id <CDVCommandDelegate> commandDelegate;
 
+/**
+ The filepath to the Cordova XML configuration file.
+ */
+@property (nonatomic, nullable, readonly, copy) NSURL *configFilePath;
 
 /**
  A boolean value indicating whether to show the splash screen while the webview
@@ -109,6 +113,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)showLaunchScreen:(BOOL)visible;
 
-NS_ASSUME_NONNULL_END
-
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -34,7 +34,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@property (nonatomic, readonly, weak) IBOutlet UIView* webView;
+@property (nonatomic, readonly, nullable, weak) IBOutlet UIView* webView;
 
 @property (nullable, nonatomic, readonly, strong) NSMutableDictionary* pluginObjects;
 @property (nonatomic, readonly, strong) NSDictionary* pluginsMap;
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString*)appURLScheme;
 - (nullable NSURL*)errorURL;
 
-- (nullable id)getCommandInstance:(NSString*)pluginName;
+- (nullable CDVPlugin *)getCommandInstance:(NSString *)pluginName;
 - (void)registerPlugin:(CDVPlugin*)plugin withClassName:(NSString*)className;
 - (void)registerPlugin:(CDVPlugin*)plugin withPluginName:(NSString*)pluginName;
 

--- a/CordovaLib/include/Cordova/Cordova.h
+++ b/CordovaLib/include/Cordova/Cordova.h
@@ -17,12 +17,29 @@
  under the License.
  */
 
-#import <Foundation/Foundation.h>
+#define __CORDOVA_SILENCE_HEADER_DEPRECATIONS
 
-//! Project version number for Cordova.
-FOUNDATION_EXPORT double CordovaVersionNumber;
+#import <Cordova/CDVAvailability.h>
+#import <Cordova/CDVAvailabilityDeprecated.h>
+#import <Cordova/CDVAppDelegate.h>
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVPluginResult.h>
+#import <Cordova/CDVViewController.h>
+#import <Cordova/CDVCommandDelegate.h>
+#import <Cordova/CDVCommandQueue.h>
+#import <Cordova/CDVConfigParser.h>
+#import <Cordova/CDVInvokedUrlCommand.h>
+#import <Cordova/CDVPlugin+Resources.h>
+#import <Cordova/CDVSettingsDictionary.h>
+#import <Cordova/CDVWebViewEngineProtocol.h>
+#import <Cordova/CDVWebViewProcessPoolFactory.h>
+#import <Cordova/NSMutableArray+QueueAdditions.h>
+#import <Cordova/CDVScreenOrientationDelegate.h>
+#import <Cordova/CDVTimer.h>
+#import <Cordova/CDVURLSchemeHandler.h>
 
-//! Project version string for Cordova.
-FOUNDATION_EXPORT const unsigned char CordovaVersionString[];
-
+// Deprecated
 #import <Cordova/CDV.h>
+#import <Cordova/NSDictionary+CordovaPreferences.h>
+
+#undef __CORDOVA_SILENCE_HEADER_DEPRECATIONS

--- a/tests/CordovaLibTests/CDVPluginInitTests.m
+++ b/tests/CordovaLibTests/CDVPluginInitTests.m
@@ -18,7 +18,7 @@
  */
 
 #import <XCTest/XCTest.h>
-#import <Cordova/CDV.h>
+#import <Cordova/Cordova.h>
 #import "AppDelegate.h"
 
 @interface CDVPluginInitTests : XCTestCase

--- a/tests/CordovaLibTests/CDVWebViewTest.h
+++ b/tests/CordovaLibTests/CDVWebViewTest.h
@@ -18,7 +18,7 @@
  */
 
 #import <WebKit/WebKit.h>
-#import <Cordova/CDV.h>
+#import <Cordova/CDVPlugin.h>
 
 @interface CDVWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol, WKScriptMessageHandler, WKNavigationDelegate>
 

--- a/tests/CordovaLibTests/CordovaLibApp/Bridging-Header.h
+++ b/tests/CordovaLibTests/CordovaLibApp/Bridging-Header.h
@@ -25,4 +25,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <Cordova/CDV.h>
+#import <Cordova/Cordova.h>

--- a/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Bridging-Header.h
+++ b/tests/spec/unit/fixtures/ios-config-xml/SampleApp/Bridging-Header.h
@@ -25,4 +25,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <Cordova/CDV.h>
+#import <Cordova/Cordova.h>

--- a/tests/spec/unit/fixtures/test-Bridging-Header.h
+++ b/tests/spec/unit/fixtures/test-Bridging-Header.h
@@ -25,6 +25,6 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <Cordova/CDV.h>
+#import <Cordova/Cordova.h>
 #import "CDVSwift22Object.h"
 #import "CDVSwift2Object.h"


### PR DESCRIPTION
### Platforms affected
ios


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some of the code in CordovaLib dates back to the very early dates of cordova-ios and an era when iOS 4 introduced breaking changes and Objective C was having new language features introduced (yes, Cordova actually predates the transition to ObjC ARC 💀).

Nowadays there are some conventions that are pretty standard (like `instancetype` for initializer methods) that we should aim to adopt for consistency.

Also, refactored `CDVConfigParser` to avoid needing a round-trip through weird `CDVViewController` methods to do anything useful. I can split this commit out into its own PR if that makes it easier for review.


### Description
<!-- Describe your changes in detail -->
* Various small ObjC cleanups
* Add some static methods to `CDVConfigParser` to facilitate parsing config.xml


### Testing
<!-- Please describe in detail how you tested your changes. -->
All existing unit tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
