### PR TITLE
fix: Update CDVAllowList to support more valid schemes

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVAllowList.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVAllowList.m
@@ -169,7 +169,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
         self.allowList = nil;
         self.permittedSchemes = nil;
     } else { // specific access
-        NSRegularExpression* parts = [NSRegularExpression regularExpressionWithPattern:@"^((\\*|[A-Za-z-]+):/?/?)?(((\\*\\.)?[^*/:]+)|\\*)?(:(\\d+))?(/.*)?" options:0 error:nil];
+        NSRegularExpression* parts = [NSRegularExpression regularExpressionWithPattern:@"^((\\*|([a-z][a-z0-9+\\-.]*)):/?/?)?(((\\*\\.)?[^*/:]+)|\\*)?(:(\\d+))?(/.*)?" options:0 error:nil];
         NSTextCheckingResult* m = [parts firstMatchInString:origin options:NSMatchingAnchored range:NSMakeRange(0, [origin length])];
         if (m != nil) {
             NSRange r;
@@ -180,7 +180,7 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
             }
 
             NSString* host = nil;
-            r = [m rangeAtIndex:3];
+            r = [m rangeAtIndex:4];
             if (r.location != NSNotFound) {
                 host = [origin substringWithRange:r];
             }
@@ -191,13 +191,13 @@ NSString* const kCDVDefaultSchemeName = @"cdv-default-scheme";
             }
 
             NSString* port = nil;
-            r = [m rangeAtIndex:7];
+            r = [m rangeAtIndex:8];
             if (r.location != NSNotFound) {
                 port = [origin substringWithRange:r];
             }
 
             NSString* path = nil;
-            r = [m rangeAtIndex:8];
+            r = [m rangeAtIndex:9];
             if (r.location != NSNotFound) {
                 path = [origin substringWithRange:r];
             }

--- a/tests/CordovaLibTests/CDVAllowListTests.m
+++ b/tests/CordovaLibTests/CDVAllowListTests.m
@@ -209,6 +209,21 @@
     XCTAssertTrue([expectedErrorString isEqualToString:errorString], @"Customized allowList rejection string has unexpected value.");
 }
 
+- (void)testUnusualSchemes
+{
+    NSArray* allowedHosts = [NSArray arrayWithObjects:
+        @"com.myapp://*",
+        @"web+app://*",
+        @"a12345://*",
+        nil];
+
+    CDVAllowList* allowList = [[CDVAllowList alloc] initWithArray:allowedHosts];
+
+    XCTAssertTrue([allowList URLIsAllowed:[NSURL URLWithString:@"com.myapp://www.apache.org"]]);
+    XCTAssertTrue([allowList URLIsAllowed:[NSURL URLWithString:@"web+app://www.apache.org"]]);
+    XCTAssertTrue([allowList URLIsAllowed:[NSURL URLWithString:@"a12345://www.apache.org"]]);
+}
+
 - (void)testSpecificProtocol
 {
     NSArray* allowedHosts = [NSArray arrayWithObjects:


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
These may be unusual schemes, but they are canonically valid and should be supported.

Closes GH-1291.


### Description
<!-- Describe your changes in detail -->
Update the regex in `CDVAllowList` to the one @erisu suggested.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added a test case to confirm the schemes are parsed properly.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
