### PR TITLE
refactor: Clean up properties/ivars in CDVViewController

### DIFF
--- a/CordovaLib/Classes/Private/CDVCommandDelegateImpl.m
+++ b/CordovaLib/Classes/Private/CDVCommandDelegateImpl.m
@@ -52,10 +52,10 @@
     [directoryParts removeLastObject];
 
     NSString* directoryPartsJoined = [directoryParts componentsJoinedByString:@"/"];
-    NSString* directoryStr = _viewController.wwwFolderName;
+    NSString* directoryStr = _viewController.webContentFolderName;
 
     if ([directoryPartsJoined length] > 0) {
-        directoryStr = [NSString stringWithFormat:@"%@/%@", _viewController.wwwFolderName, [directoryParts componentsJoinedByString:@"/"]];
+        directoryStr = [NSString stringWithFormat:@"%@/%@", _viewController.webContentFolderName, [directoryParts componentsJoinedByString:@"/"]];
     }
 
     return [mainBundle pathForResource:filename ofType:@"" inDirectory:directoryStr];

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -37,7 +37,7 @@
 
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
-    NSString * startPath = [[NSBundle mainBundle] pathForResource:self.viewController.wwwFolderName ofType: nil];
+    NSString * startPath = [[NSBundle mainBundle] pathForResource:self.viewController.webContentFolderName ofType: nil];
     NSURL * url = urlSchemeTask.request.URL;
     NSString * stringToLoad = url.path;
     NSString * scheme = url.scheme;

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -36,10 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable, readonly, strong) NSXMLParser *configParser CDV_DEPRECATED(8, "Unused");
 
-@property (nonatomic, readonly, nullable, weak) IBOutlet UIView* webView;
+@property (nonatomic, readonly, nullable, weak) IBOutlet UIView *webView;
 
-@property (nullable, nonatomic, readonly, strong) NSMutableDictionary* pluginObjects;
-@property (nonatomic, readonly, strong) NSDictionary* pluginsMap;
+@property (nonatomic, readonly, strong) NSDictionary<NSString *, CDVPlugin *> *pluginObjects;
+@property (nullable, nonatomic, readonly, strong) NSDictionary<NSString *, NSString *> *pluginsMap CDV_DEPRECATED(8, "Internal implementation detail, should not be used");
 
 /**
  The Cordova preferences for this view.
@@ -47,13 +47,13 @@ NS_ASSUME_NONNULL_BEGIN
  This is a dictionary populated from the preference key/value pairs in the
  Cordova XML configuration file.
  */
-@property (nonatomic, readonly, strong) CDVSettingsDictionary* settings;
+@property (nonatomic, readonly, strong) CDVSettingsDictionary *settings;
 
-@property (nonatomic, readwrite, copy) NSString* appScheme;
-@property (nonatomic, readwrite, copy) NSString* configFile;
-@property (nonatomic, readwrite, copy) NSString* wwwFolderName;
-@property (nonatomic, readwrite, copy) NSString* startPage;
-@property (nonatomic, readonly, strong) CDVCommandQueue* commandQueue;
+@property (nonatomic, readwrite, copy) NSString *appScheme;
+@property (nonatomic, readwrite, copy) IBInspectable NSString *configFile;
+@property (nonatomic, readwrite, copy) NSString *wwwFolderName CDV_DEPRECATED_WITH_REPLACEMENT(8, "Use webContentFolderName instead", "webContentFolderName");
+@property (nonatomic, nullable, readwrite, copy) IBInspectable NSString *startPage;
+@property (nonatomic, readonly, strong) CDVCommandQueue *commandQueue;
 @property (nonatomic, readonly, strong) id <CDVWebViewEngineProtocol> webViewEngine;
 @property (nonatomic, readonly, strong) id <CDVCommandDelegate> commandDelegate;
 
@@ -61,6 +61,18 @@ NS_ASSUME_NONNULL_BEGIN
  The filepath to the Cordova XML configuration file.
  */
 @property (nonatomic, nullable, readonly, copy) NSURL *configFilePath;
+
+/**
+ The filepath to the HTML error fallback page, if one has been provided.
+ */
+@property (nonatomic, nullable, readonly, copy) NSURL *errorURL;
+
+/**
+ The folder path containing the web content to be displayed.
+ The default value is `"www"`.
+ This can be set in the storyboard file as a view controller attribute.
+  */
+@property (nonatomic, readwrite, copy) IBInspectable NSString *webContentFolderName;
 
 /**
  A boolean value indicating whether to show the splash screen while the webview
@@ -96,8 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UIView*)newCordovaViewWithFrame:(CGRect)bounds;
 
-- (nullable NSString*)appURLScheme;
-- (nullable NSURL*)errorURL;
+- (nullable NSString*)appURLScheme CDV_DEPRECATED(8, "Unused");
 
 - (nullable CDVPlugin *)getCommandInstance:(NSString *)pluginName;
 - (void)registerPlugin:(CDVPlugin*)plugin withClassName:(NSString*)className;

--- a/tests/CordovaLibTests/CordovaLibApp/AppDelegate.m
+++ b/tests/CordovaLibTests/CordovaLibApp/AppDelegate.m
@@ -34,7 +34,7 @@
 - (void)createViewController
 {
     _viewController = [[ViewController alloc] init];
-    _viewController.wwwFolderName = @"www";
+    _viewController.webContentFolderName = @"www";
     _viewController.startPage = @"index.html";
 
     // NOTE: To customize the view's frame size (which defaults to full screen), override


### PR DESCRIPTION


<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A bunch of properties on CDVViewController were publicly exposing internal state that should be private to the instance. We can't completely solve that problem right now, but we can make the API boundary more clearly delineated.


### Description
<!-- Describe your changes in detail -->
Clean up properties/ivars in CDVViewController

Rename wwwFolderName to webContentFolderName so that it gets a useful label in Xcode's Interface Builder for people embedding CDVViewController inside their own apps (IB showed it as "Www Folder Name" and there's no way to alias that, so now it shows up as "Web Content Folder Name")


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass