### PR TITLE
docs(CordovaLib): Start filling out DocC comments

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVLaunchScreen/CDVLaunchScreen.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVLaunchScreen/CDVLaunchScreen.m
@@ -21,14 +21,14 @@
 
 @implementation CDVLaunchScreen
 
-- (void)show:(CDVInvokedUrlCommand*)command
+- (void)show:(CDVInvokedUrlCommand *)command
 {
-    [self.viewController showLaunchScreen:YES];
+    [self.viewController showSplashScreen:YES];
 }
 
-- (void)hide:(CDVInvokedUrlCommand*)command
+- (void)hide:(CDVInvokedUrlCommand *)command
 {
-    [self.viewController showLaunchScreen:NO];
+    [self.viewController showSplashScreen:NO];
 }
 
 @end

--- a/CordovaLib/Classes/Public/CDVCommandQueue.m
+++ b/CordovaLib/Classes/Public/CDVCommandQueue.m
@@ -21,6 +21,7 @@
 #import <Cordova/CDVCommandQueue.h>
 #import <Cordova/CDVViewController.h>
 #import <Cordova/CDVPlugin.h>
+#import <Cordova/NSMutableArray+QueueAdditions.h>
 #import "CDVCommandDelegateImpl.h"
 #import "CDVJSON_private.h"
 #import "CDVDebug.h"

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -495,13 +495,13 @@ static UIColor* defaultBackgroundColor(void) {
         CGFloat splashScreenDelaySetting = [self.settings cordovaFloatSettingForKey:@"SplashScreenDelay" defaultValue:0];
 
         if (splashScreenDelaySetting == 0) {
-            [self showLaunchScreen:NO];
+            [self showSplashScreen:NO];
         } else {
             // Divide by 1000 because config returns milliseconds and NSTimer takes seconds
             CGFloat splashScreenDelay = splashScreenDelaySetting / 1000;
 
             [NSTimer scheduledTimerWithTimeInterval:splashScreenDelay repeats:NO block:^(NSTimer * _Nonnull timer) {
-                [self showLaunchScreen:NO];
+                [self showSplashScreen:NO];
             }];
         }
     }
@@ -719,10 +719,12 @@ static UIColor* defaultBackgroundColor(void) {
 
 #pragma mark - API Methods for Plugins
 
-/**
- Method to be called from the plugin JavaScript to show or hide the launch screen.
- */
 - (void)showLaunchScreen:(BOOL)visible
+{
+    [self showSplashScreen:visible];
+}
+
+- (void)showSplashScreen:(BOOL)visible
 {
     CGFloat fadeSplashScreenDuration = [self.settings cordovaFloatSettingForKey:@"FadeSplashScreenDuration" defaultValue:250.f];
 

--- a/CordovaLib/CordovaLib.docc/CordovaLib.md
+++ b/CordovaLib/CordovaLib.docc/CordovaLib.md
@@ -1,0 +1,69 @@
+# ``Cordova``
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-->
+
+Build your app using web technologies
+
+## Overview
+
+For more information about Apache Cordova, visit [https://cordova.apache.org](https://cordova.apache.org).
+
+## Topics
+
+### Using Cordova in your app
+
+- ``CDVAppDelegate``
+- ``CDVViewController``
+
+### Cordova plugins
+
+- ``CDVPlugin``
+- ``CDVPluginResult``
+- ``CDVCommandStatus``
+- ``CDVInvokedUrlCommand``
+- ``CDVCommandDelegate``
+
+### Web View plugins
+
+- ``CDVWebViewEngineProtocol``
+- ``CDVWebViewEngineConfigurationDelegate``
+
+### Utilities
+
+- ``CDVSettingsDictionary``
+- ``CDVCommandQueue``
+- ``CDVConfigParser``
+- ``CDVTimer``
+
+### Deprecated
+
+- ``IsAtLeastiOSVersion``
+- ``CDVScreenOrientationDelegate``
+- ``CDVCommandStatus_NO_RESULT`` <!-- Swift alias -->
+- ``CDVCommandStatus_OK`` <!-- Swift alias -->
+- ``CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION`` <!-- Swift alias -->
+- ``CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION`` <!-- Swift alias -->
+- ``CDVCommandStatus_INSTANTIATION_EXCEPTION`` <!-- Swift alias -->
+- ``CDVCommandStatus_MALFORMED_URL_EXCEPTION`` <!-- Swift alias -->
+- ``CDVCommandStatus_IO_EXCEPTION`` <!-- Swift alias -->
+- ``CDVCommandStatus_INVALID_ACTION`` <!-- Swift alias -->
+- ``CDVCommandStatus_JSON_EXCEPTION`` <!-- Swift alias -->
+- ``CDVCommandStatus_ERROR`` <!-- Swift alias -->

--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		7ED95D581AB9029B008C4574 /* NSDictionary+CordovaPreferences.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED95D321AB9029B008C4574 /* NSDictionary+CordovaPreferences.m */; };
 		7ED95D591AB9029B008C4574 /* NSMutableArray+QueueAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED95D331AB9029B008C4574 /* NSMutableArray+QueueAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7ED95D5A1AB9029B008C4574 /* NSMutableArray+QueueAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED95D341AB9029B008C4574 /* NSMutableArray+QueueAdditions.m */; };
+		902B30742C6C5A7E00C6804C /* CordovaLib.docc in Sources */ = {isa = PBXBuildFile; fileRef = 902B30732C6C5A7E00C6804C /* CordovaLib.docc */; };
+		902B30752C6C5A7E00C6804C /* CordovaLib.docc in Sources */ = {isa = PBXBuildFile; fileRef = 902B30732C6C5A7E00C6804C /* CordovaLib.docc */; };
 		9036843D2C6EB06500A3338C /* CDVAllowList.h in Headers */ = {isa = PBXBuildFile; fileRef = 9036843B2C6EB06500A3338C /* CDVAllowList.h */; };
 		9036843E2C6EB06500A3338C /* CDVAllowList.m in Sources */ = {isa = PBXBuildFile; fileRef = 9036843C2C6EB06500A3338C /* CDVAllowList.m */; };
 		9036843F2C6EB06500A3338C /* CDVAllowList.m in Sources */ = {isa = PBXBuildFile; fileRef = 9036843C2C6EB06500A3338C /* CDVAllowList.m */; };
@@ -193,6 +195,7 @@
 		7ED95D331AB9029B008C4574 /* NSMutableArray+QueueAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+QueueAdditions.h"; sourceTree = "<group>"; };
 		7ED95D341AB9029B008C4574 /* NSMutableArray+QueueAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+QueueAdditions.m"; sourceTree = "<group>"; };
 		902D0BC12AEB64EB009C68E5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		902B30732C6C5A7E00C6804C /* CordovaLib.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = CordovaLib.docc; sourceTree = "<group>"; };
 		9036843B2C6EB06500A3338C /* CDVAllowList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVAllowList.h; sourceTree = "<group>"; };
 		9036843C2C6EB06500A3338C /* CDVAllowList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVAllowList.m; sourceTree = "<group>"; };
 		9047732D2C7A57E900373636 /* CDVURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVURLSchemeHandler.h; sourceTree = "<group>"; };
@@ -236,6 +239,7 @@
 		0867D691FE84028FC02AAC07 = {
 			isa = PBXGroup;
 			children = (
+				902B30732C6C5A7E00C6804C /* CordovaLib.docc */,
 				9064EF5E26FAB74200C9D65B /* include */,
 				7ED95D0E1AB9029B008C4574 /* Public */,
 				7ED95CF11AB9028C008C4574 /* Private */,
@@ -567,6 +571,7 @@
 				9052DE712150D040008E83D4 /* CDVAppDelegate.m in Sources */,
 				9052DE722150D040008E83D4 /* CDVCommandDelegateImpl.m in Sources */,
 				9052DE732150D040008E83D4 /* CDVCommandQueue.m in Sources */,
+				902B30742C6C5A7E00C6804C /* CordovaLib.docc in Sources */,
 				9052DE742150D040008E83D4 /* CDVConfigParser.m in Sources */,
 				9052DE752150D040008E83D4 /* CDVInvokedUrlCommand.m in Sources */,
 				9052DE762150D040008E83D4 /* CDVPlugin+Resources.m in Sources */,
@@ -598,6 +603,7 @@
 				7ED95D371AB9029B008C4574 /* CDVAppDelegate.m in Sources */,
 				7ED95D3C1AB9029B008C4574 /* CDVCommandDelegateImpl.m in Sources */,
 				7ED95D3E1AB9029B008C4574 /* CDVCommandQueue.m in Sources */,
+				902B30752C6C5A7E00C6804C /* CordovaLib.docc in Sources */,
 				7ED95D401AB9029B008C4574 /* CDVConfigParser.m in Sources */,
 				7ED95D421AB9029B008C4574 /* CDVInvokedUrlCommand.m in Sources */,
 				7ED95D441AB9029B008C4574 /* CDVPlugin+Resources.m in Sources */,
@@ -685,6 +691,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
+				DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS = YES;
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -756,6 +763,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS = YES;
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/CordovaLib/include/Cordova/CDVCommandDelegate.h
+++ b/CordovaLib/include/Cordova/CDVCommandDelegate.h
@@ -29,24 +29,67 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol CDVCommandDelegate <NSObject>
 
 @optional
-@property (nonatomic, nullable, copy) NSURL *(^urlTransformer)(NSURL *) CDV_DEPRECATED(8, "Unused");
+
+@property (nonatomic, nullable, copy) NSURL *(^urlTransformer)(NSURL *) CDV_DEPRECATED(8, "");
 
 @required
+/**
+ The Cordova preferences for the web view.
+
+ This is a dictionary populated from the preference key/value pairs in the
+ Cordova XML configuration file.
+ */
 @property (nonatomic, readonly) CDVSettingsDictionary* settings;
 
-- (NSString*)pathForResource:(NSString*)resourcepath;
-- (id)getCommandInstance:(NSString*)pluginName;
+- (NSString *)pathForResource:(NSString *)resourcepath;
 
-// Sends a plugin result to the JS. This is thread-safe.
-- (void)sendPluginResult:(CDVPluginResult*)result callbackId:(NSString*)callbackId;
-// Evaluates the given JS. This is thread-safe.
-- (void)evalJs:(NSString*)js;
-// Can be used to evaluate JS right away instead of scheduling it on the run-loop.
-// This is required for dispatch resign and pause events, but should not be used
-// without reason. Without the run-loop delay, alerts used in JS callbacks may result
-// in dead-lock. This method must be called from the UI thread.
-- (void)evalJs:(NSString*)js scheduledOnRunLoop:(BOOL)scheduledOnRunLoop;
-// Runs the given block on a background thread using a shared thread-pool.
+/**
+ Returns the CDVPlugin instance of the given plugin name.
+
+ - Parameters:
+   - pluginName: The name of the plugin to return.
+ - Returns: The ``CDVPlugin`` instance, or `nil` if no plugin instance was
+   found with the given name.
+ */
+- (nullable CDVPlugin *)getCommandInstance:(NSString *)pluginName;
+
+/**
+ Sends a plugin result to the web view. This is thread-safe.
+
+ - Parameters:
+   - result: The plugin result to send to the web view.
+   - callbackId: The ID of the JavaScript callback to invoke.
+ */
+- (void)sendPluginResult:(CDVPluginResult *)result callbackId:(NSString *)callbackId;
+
+/**
+ Evaluates the given JavaScript string in the web view. This is thread-safe.
+
+ - Parameters:
+   - js: The string of JavaScript code to run.
+ */
+- (void)evalJs:(NSString *)js;
+
+/**
+ Evaluates the given JavaScript string right away instead of scheduling it on
+ the run-loop.
+
+ This is required for dispatching `resign` and `pause` events, but should not
+ be used without reason. Without the run-loop delay, alerts used in JS callbacks
+ may result in dead-lock. This method must be called from the UI thread.
+
+ - Parameters:
+   - js: The string of JavaScript code to run.
+   - scheduledOnRunLoop: Whether to schedule the code to run on the run-loop.
+ */
+- (void)evalJs:(NSString *)js scheduledOnRunLoop:(BOOL)scheduledOnRunLoop;
+
+/**
+ Runs the given block on a background thread using a shared thread-pool.
+
+ - Parameters:
+   - block: The block to be run.
+ */
 - (void)runInBackground:(void (^)(void))block;
 
 @end

--- a/CordovaLib/include/Cordova/CDVPlugin.h
+++ b/CordovaLib/include/Cordova/CDVPlugin.h
@@ -21,7 +21,6 @@
 #import <UIKit/UIKit.h>
 #import <Cordova/CDVAvailabilityDeprecated.h>
 #import <Cordova/CDVPluginResult.h>
-#import <Cordova/NSMutableArray+QueueAdditions.h>
 #import <Cordova/CDVCommandDelegate.h>
 #import <Cordova/CDVSettingsDictionary.h>
 #import <Cordova/CDVViewController.h>

--- a/CordovaLib/include/Cordova/CDVPluginResult.h
+++ b/CordovaLib/include/Cordova/CDVPluginResult.h
@@ -20,16 +20,42 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVAvailability.h>
 
+/**
+ An enumeration that describes the result of handling a plugin command.
+
+ ## See Also
+
+ - ``CDVPluginResult``
+ */
 typedef NS_ENUM(NSUInteger, CDVCommandStatus) {
+    /** Status code indicating no command result. */
     CDVCommandStatus_NO_RESULT NS_SWIFT_NAME(noResult) = 0,
+
+    /** Status code indicating successful handling of the command. */
     CDVCommandStatus_OK NS_SWIFT_NAME(ok),
+
+    /** Status code indicating the command's plugin class could not be found. */
     CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION NS_SWIFT_NAME(classNotFoundException),
+
+    /** Status code indicating there was an illegal access exception while handling the command. */
     CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION NS_SWIFT_NAME(illegalAccessException),
+
+    /** Status code indicating the command's plugin class could not be instantiated. */
     CDVCommandStatus_INSTANTIATION_EXCEPTION NS_SWIFT_NAME(instantiationException),
+
+    /** Status code indicating the command included a malformed URL. */
     CDVCommandStatus_MALFORMED_URL_EXCEPTION NS_SWIFT_NAME(malformedUrlException),
+
+    /** Status code indicating there was an I/O exception while handling the command. */
     CDVCommandStatus_IO_EXCEPTION NS_SWIFT_NAME(ioException),
+
+    /** Status code indicating the command's action was not valid. */
     CDVCommandStatus_INVALID_ACTION NS_SWIFT_NAME(invalidAction),
+
+    /** Status code indicating the command's JSON data was invalid. */
     CDVCommandStatus_JSON_EXCEPTION NS_SWIFT_NAME(jsonException),
+
+    /** Status code indicating there was an error handling the command. */
     CDVCommandStatus_ERROR NS_SWIFT_NAME(error)
 };
 
@@ -59,11 +85,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CDVPluginResult : NSObject {}
 
 @property (nonatomic, strong, readonly) NSNumber *status;
-@property (nonatomic, strong, readonly) id message;
-@property (nonatomic, strong)           NSNumber *keepCallback;
-// This property can be used to scope the lifetime of another object. For example,
-// Use it to store the associated NSData when `message` is created using initWithBytesNoCopy.
-@property (nonatomic, strong) id associatedObject;
+@property (nonatomic, nullable, strong, readonly) id message;
+@property (nonatomic, strong) NSNumber *keepCallback;
+@property (nonatomic, strong) id associatedObject CDV_DEPRECATED(8, "");
 
 - (instancetype)init;
 + (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal;
@@ -79,8 +103,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAsMultipart:(NSArray *)theMessages;
 + (instancetype)resultWithStatus:(CDVCommandStatus)statusOrdinal messageToErrorObject:(int)errorCode;
 
-+ (void)setVerbose:(BOOL)verbose;
-+ (BOOL)isVerbose;
++ (void)setVerbose:(BOOL)verbose CDV_DEPRECATED(8, "");
++ (BOOL)isVerbose CDV_DEPRECATED(8, "");
 
 - (void)setKeepCallbackAsBool:(BOOL)bKeepCallback;
 

--- a/CordovaLib/include/Cordova/CDVScreenOrientationDelegate.h
+++ b/CordovaLib/include/Cordova/CDVScreenOrientationDelegate.h
@@ -20,7 +20,7 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVAvailabilityDeprecated.h>
 
-CDV_DEPRECATED(8, "Unused")
+CDV_DEPRECATED(8, "")
 @protocol CDVScreenOrientationDelegate <NSObject>
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations;

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -32,11 +32,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ A view controller that specializes in displaying Cordova web content.
+
+ ## Overview
+ `CDVViewController` presents a view that displays Cordova web content in a
+ ``webView``. Although often presented as the root view controller for an app,
+ a `CDVViewController` can safely be placed within view controller
+ hierarchies—such as navigation and tabbed controllers—or presented modally.
+
+ The behavior preferences and web content to be loaded are defined in a Cordova
+ XML configuration file, for which a separate [reference
+ guide](https://cordova.apache.org/docs/en/latest/config_ref/index.html)
+ exists. The web content displayed within the view has access to Cordova
+ plugins via their exposed JavaScript APIs.
+
+ > Important: In accordance with [App Store review
+ > guidelines](https://developer.apple.com/app-store/review/guidelines/), you
+ > must not expose Apple device APIs to web content that is not bundled within
+ > the app.
+ */
 @interface CDVViewController : UIViewController
 
-@property (nonatomic, nullable, readonly, strong) NSXMLParser *configParser CDV_DEPRECATED(8, "Unused");
-@property (nonatomic, nullable, readonly, copy) NSString *appURLScheme CDV_DEPRECATED(8, "Unused");
+@property (nonatomic, nullable, readonly, strong) NSXMLParser *configParser CDV_DEPRECATED(8, "");
+@property (nonatomic, nullable, readonly, copy) NSString *appURLScheme CDV_DEPRECATED(8, "");
 
+/**
+ The view displaying web content for this Cordova controller.
+
+ The exact type of this UIView subclass varies based on which
+ plugin is being used to provide the web view implementation. Interactions
+ with the web view and its content should be done through the ``webViewEngine``
+ property.
+ */
 @property (nonatomic, readonly, nullable, weak) IBOutlet UIView *webView;
 
 @property (nonatomic, readonly, strong) NSDictionary<NSString *, CDVPlugin *> *pluginObjects;
@@ -46,6 +74,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, strong) CDVCommandQueue *commandQueue;
 @property (nonatomic, readonly, strong) id <CDVCommandDelegate> commandDelegate;
+
+/**
+ The associated web view engine implementation.
+
+ This provides a reference to the web view plugin class, which
+ implements ``CDVWebViewEngineProtocol`` and allows for interaction with the
+ web view.
+ */
 @property (nonatomic, readonly, strong) id <CDVWebViewEngineProtocol> webViewEngine;
 
 /**
@@ -56,6 +92,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, strong) CDVSettingsDictionary *settings;
 
+/**
+ The filename of the Cordova XML configuration file.
+
+ The default value is `"config.xml"`.
+
+ This can be set in the storyboard file as a view controller attribute.
+ */
 @property (nonatomic, readwrite, copy) IBInspectable NSString *configFile;
 
 /**
@@ -70,13 +113,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The folder path containing the web content to be displayed.
+
  The default value is `"www"`.
+
  This can be set in the storyboard file as a view controller attribute.
-  */
+ */
 @property (nonatomic, readwrite, copy) IBInspectable NSString *webContentFolderName;
 
+/**
+ @DeprecationSummary {
+   Use ``webContentFolderName`` instead.
+ }
+ */
 @property (nonatomic, readwrite, copy) NSString *wwwFolderName CDV_DEPRECATED_WITH_REPLACEMENT(8, "Use webContentFolderName instead", "webContentFolderName");
 
+/**
+ The filename of the HTML file to load into the web view.
+
+ The default value will be read from the Cordova XML configuration file, and
+ fall back to `"index.html"` if not specified.
+
+ This can be set in the storyboard file as a view controller attribute.
+ */
 @property (nonatomic, nullable, readwrite, copy) IBInspectable NSString *startPage;
 
 /**
@@ -113,9 +171,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UIView*)newCordovaViewWithFrame:(CGRect)bounds;
 
+/**
+ Returns the ``CDVPlugin`` instance of the given plugin name, creating the
+ instance if one does not exist.
+
+ - Parameters:
+   - pluginName: The name of the plugin to return.
+ - Returns: The ``CDVPlugin`` instance, or `nil` if no plugin exists with the
+   given name.
+ */
 - (nullable CDVPlugin *)getCommandInstance:(NSString *)pluginName;
 - (void)registerPlugin:(CDVPlugin*)plugin withClassName:(NSString*)className;
 - (void)registerPlugin:(CDVPlugin*)plugin withPluginName:(NSString*)pluginName;
+
+/**
+ @DeprecationSummary {
+   Use ``showSplashScreen:`` instead.
+ }
+
+ - Parameters:
+   - visible: Whether to make the splash screen visible or not.
+ */
+- (void)showLaunchScreen:(BOOL)visible CDV_DEPRECATED_WITH_REPLACEMENT(8, "Use showSplashScreen: instead", "showSplashScreen");;
 
 /**
  Toggles the display of the splash screen overtop of the web view.
@@ -123,9 +200,16 @@ NS_ASSUME_NONNULL_BEGIN
  - Parameters:
    - visible: Whether to make the splash screen visible or not.
  */
-- (void)showLaunchScreen:(BOOL)visible;
+- (void)showSplashScreen:(BOOL)visible;
 
-- (void)parseSettingsWithParser:(NSObject <NSXMLParserDelegate>*)delegate;
+/**
+ Parses the  Cordova XML configuration file using the given delegate.
+
+ @DeprecationSummary {
+    Use `CDVConfigParser` ``CDVConfigParser/parseConfigFile:withDelegate:`` instead.
+ }
+ */
+- (void)parseSettingsWithParser:(id <NSXMLParserDelegate>)delegate CDV_DEPRECATED(8, "Use CDVConfigParser parseConfigFile:withDelegate: instead");;
 
 @end
 

--- a/CordovaLib/include/Cordova/Cordova.h
+++ b/CordovaLib/include/Cordova/Cordova.h
@@ -33,12 +33,12 @@
 #import <Cordova/CDVSettingsDictionary.h>
 #import <Cordova/CDVWebViewEngineProtocol.h>
 #import <Cordova/CDVWebViewProcessPoolFactory.h>
-#import <Cordova/NSMutableArray+QueueAdditions.h>
 #import <Cordova/CDVScreenOrientationDelegate.h>
 #import <Cordova/CDVTimer.h>
 
 // Deprecated
 #import <Cordova/CDV.h>
 #import <Cordova/NSDictionary+CordovaPreferences.h>
+#import <Cordova/NSMutableArray+QueueAdditions.h>
 
 #undef __CORDOVA_SILENCE_HEADER_DEPRECATIONS

--- a/CordovaLib/include/Cordova/NSMutableArray+QueueAdditions.h
+++ b/CordovaLib/include/Cordova/NSMutableArray+QueueAdditions.h
@@ -18,12 +18,17 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Cordova/CDVAvailabilityDeprecated.h>
+
+#ifndef __CORDOVA_SILENCE_HEADER_DEPRECATIONS
+//#warning "This should not be used"
+#endif
 
 @interface NSMutableArray (QueueAdditions)
 
-- (id)cdv_pop;
-- (id)cdv_queueHead;
+- (id)cdv_pop CDV_DEPRECATED(8, "");
+- (id)cdv_queueHead CDV_DEPRECATED(8, "");
 - (id)cdv_dequeue;
-- (void)cdv_enqueue:(id)obj;
+- (void)cdv_enqueue:(id)obj CDV_DEPRECATED(8, "");
 
 @end


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The API available to people embedding CordovaLib as a framework in their existing apps is not well documented, nor is the API available to plugin authors.

With DocC comments, we can generate Apple-style documentation for our framework, and serve it on GitHub Pages.


### Description
<!-- Describe your changes in detail -->
Add DocC comments to some of CordovaLib and add a main page file. This is only an initial pass over the sections of code that I've been touching recently, but the goal is to have everything that's public API commented appropriately.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass.
Built documentation bundle with Xcode for local testing.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I've updated the documentation if necessary
