### PR TITLE
ci: Publish DocC documentation to GitHub pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Publish Docs
+
+on:
+  push:
+    branches: ["master"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: macos-14
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build DocC
+        working-directory: ./CordovaLib
+        run: |
+          xcodebuild docbuild \
+            -scheme Cordova \
+            -destination 'generic/platform=iOS' \
+            DOCC_HOSTING_BASE_PATH=${{ github.event.repository.name }} \
+            OTHER_DOCC_FLAGS="--output-path ./docs --source-service github --source-service-base-url https://github.com/${{ github.repository }}/tree/${{ github.ref_name }} --checkout-path ${{ github.workspace }}";
+
+          echo "<script>window.location.href += \"/documentation/cordova\"</script>" > docs/index.html;
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'CordovaLib/docs'
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Actions-based publishing to GitHub Pages should now be enabled on this repo: https://issues.apache.org/jira/browse/INFRA-26070

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If we're adding docs to our CordovaLib public API, we might as well make them available online for people.


### Description
<!-- Describe your changes in detail -->
Generates API documentation from the DocC code comments in CordovaLib, and publishes it to GitHub Pages.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Confirmed that this publishes correctly in my fork.
