### PR TITLE
refactor: Define a protocol for scheme-handling plugins

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.h
@@ -17,19 +17,14 @@
  under the License.
  */
 
-#import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
-#import <Cordova/CDVViewController.h>
-#import <Cordova/CDVPlugin.h>
 
+@class CDVViewController;
 
 @interface CDVURLSchemeHandler : NSObject <WKURLSchemeHandler>
+NS_ASSUME_NONNULL_BEGIN
 
-@property (nonatomic, weak) CDVViewController* viewController;
+- (instancetype)initWithViewController:(CDVViewController *)controller;
 
-@property (nonatomic) CDVPlugin* schemePlugin;
-
-- (instancetype)initWithVC:(CDVViewController *)controller;
-
-
+NS_ASSUME_NONNULL_END
 @end

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -215,7 +215,7 @@
 
     // Do not configure the scheme handler if the scheme is default (file)
     if(!self.cdvIsFileScheme) {
-        self.schemeHandler = [[CDVURLSchemeHandler alloc] initWithVC:vc];
+        self.schemeHandler = [[CDVURLSchemeHandler alloc] initWithViewController:vc];
         [configuration setURLSchemeHandler:self.schemeHandler forURLScheme:scheme];
     }
 
@@ -551,8 +551,7 @@
     BOOL anyPluginsResponded = NO;
     BOOL shouldAllowRequest = NO;
 
-    for (NSString* pluginName in vc.pluginObjects) {
-        CDVPlugin* plugin = [vc.pluginObjects objectForKey:pluginName];
+    for (CDVPlugin *plugin in vc.enumerablePlugins) {
         SEL selector = NSSelectorFromString(@"shouldOverrideLoadWithRequest:navigationType:");
         if ([plugin respondsToSelector:selector]) {
             anyPluginsResponded = YES;

--- a/CordovaLib/Classes/Public/CDVWebViewProcessPoolFactory.m
+++ b/CordovaLib/Classes/Public/CDVWebViewProcessPoolFactory.m
@@ -17,6 +17,7 @@
  under the License.
  */
 
+#import <WebKit/WebKit.h>
 #import <Cordova/CDVWebViewProcessPoolFactory.h>
 
 static CDVWebViewProcessPoolFactory *factory = nil;

--- a/CordovaLib/CordovaLib.docc/CordovaLib.md
+++ b/CordovaLib/CordovaLib.docc/CordovaLib.md
@@ -36,6 +36,9 @@ For more information about Apache Cordova, visit [https://cordova.apache.org](ht
 ### Cordova plugins
 
 - ``CDVPlugin``
+- ``CDVPluginSchemeHandler``
+
+### Plugin communication
 - ``CDVPluginResult``
 - ``CDVCommandStatus``
 - ``CDVInvokedUrlCommand``

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -18,8 +18,6 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <WebKit/WebKit.h>
-#import <Foundation/NSJSONSerialization.h>
 #import <Cordova/CDVAvailability.h>
 #import <Cordova/CDVInvokedUrlCommand.h>
 #import <Cordova/CDVCommandDelegate.h>
@@ -67,8 +65,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, nullable, weak) IBOutlet UIView *webView;
 
-@property (nonatomic, readonly, strong) NSDictionary<NSString *, CDVPlugin *> *pluginObjects;
+@property (nonatomic, readonly, strong) NSDictionary<NSString *, CDVPlugin *> *pluginObjects CDV_DEPRECATED(8, "Internal implementation detail, should not be used");
 @property (nullable, nonatomic, readonly, strong) NSDictionary<NSString *, NSString *> *pluginsMap CDV_DEPRECATED(8, "Internal implementation detail, should not be used");
+
+/**
+ An array of loaded Cordova plugin instances.
+
+ This array is safe to iterate using a `for...in` loop.
+ */
+@property (nonatomic, readonly, copy) NSArray <CDVPlugin *> *enumerablePlugins;
 
 @property (nonatomic, readwrite, copy) NSString *appScheme;
 

--- a/CordovaLib/include/Cordova/CDVWebViewEngineProtocol.h
+++ b/CordovaLib/include/Cordova/CDVWebViewEngineProtocol.h
@@ -18,12 +18,13 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <WebKit/WebKit.h>
 
 #define kCDVWebViewEngineScriptMessageHandlers @"kCDVWebViewEngineScriptMessageHandlers"
 #define kCDVWebViewEngineWKNavigationDelegate @"kCDVWebViewEngineWKNavigationDelegate"
 #define kCDVWebViewEngineWKUIDelegate @"kCDVWebViewEngineWKUIDelegate"
 #define kCDVWebViewEngineWebViewPreferences @"kCDVWebViewEngineWebViewPreferences"
+
+@class WKWebViewConfiguration;
 
 @protocol CDVWebViewEngineProtocol <NSObject>
 

--- a/CordovaLib/include/Cordova/CDVWebViewProcessPoolFactory.h
+++ b/CordovaLib/include/Cordova/CDVWebViewProcessPoolFactory.h
@@ -17,7 +17,7 @@
  under the License.
  */
 
-#import <WebKit/WebKit.h>
+@class WKProcessPool;
 
 @interface CDVWebViewProcessPoolFactory : NSObject
 @property (nonatomic, retain) WKProcessPool* sharedPool;

--- a/CordovaLib/include/Cordova/NSDictionary+CordovaPreferences.h
+++ b/CordovaLib/include/Cordova/NSDictionary+CordovaPreferences.h
@@ -18,7 +18,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 #import <Cordova/CDVAvailabilityDeprecated.h>
 
 #ifndef __CORDOVA_SILENCE_HEADER_DEPRECATIONS


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Existing behaviour for plugins to opt-in to handling custom scheme resource loads was not documented and there were some unsafe assumptions around only a single plugin handling all requests.


### Description
<!-- Describe your changes in detail -->
Add a `CDVPluginSchemeHandler` protocol to allow plugins to declare that they want to intercept WebKit resource loads.  
We don't rely on the protocol itself being implemented by the plugins (we continue to check with `-respondsToSelector:`) but this allows us to avoid `objc_msgSend` and provides a way to document some of this plugin behaviour that is not otherwise explained.

Also, use a `NSMapTable` to associate plugin instances with the request being handled. Since we loop over the plugins, there's a chance that multiple plugins might want to handle different requests (which sounds like a logistical nightmare, but it's definitely possible). Now we keep a map of which plugin is handling each request so that we can make sure the right plugin gets called when the resource load is cancelled. `NSMapTable` uses weak associations, so when the task is done and released, the key and value will be dropped from the table automatically.

This should also resolve the unsafe plugin iteration issue that was mentioned in GH-1272 and GH-1030 by always iterating over an array of plugin objects that is a copy (due to calling `-allValues`).


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass. Tested manually in simulator with custom scheme.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
