### PR TITLE
chore!: Bump CordovaLib requirements to iOS 13+

### DIFF
--- a/Cordova.podspec
+++ b/Cordova.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.homepage            = "https://github.com/apache/cordova-ios"
   s.license             = { :type => "Apache 2.0", :file => "LICENSE" }
   s.author              = "Apache Software Foundation"
-  s.platform            = :ios, "11.0"
+  s.platform            = :ios, "13.0"
   s.source              = relSource
   s.requires_arc        = true
   s.frameworks          = ["Foundation", "UIKit", "WebKit"]

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -147,14 +147,11 @@
     }
     configuration.applicationNameForUserAgent = userAgent;
 
-    if (@available(iOS 13.0, *)) {
-        NSString *contentMode = [settings cordovaSettingForKey:@"PreferredContentMode"];
-        if ([contentMode isEqual: @"mobile"]) {
-            configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
-        } else if ([contentMode isEqual: @"desktop"]) {
-            configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
-        }
-        
+    NSString *contentMode = [settings cordovaSettingForKey:@"PreferredContentMode"];
+    if ([contentMode isEqual: @"mobile"]) {
+        configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
+    } else if ([contentMode isEqual: @"desktop"]) {
+        configuration.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
     }
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -30,13 +30,7 @@
 #import "CDVCommandDelegateImpl.h"
 
 static UIColor* defaultBackgroundColor(void) {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-    if (@available(iOS 13.0, *)) {
-        return UIColor.systemBackgroundColor;
-    }
-#endif
-
-    return UIColor.whiteColor;
+    return UIColor.systemBackgroundColor;
 }
 
 @interface CDVViewController () <CDVWebViewEngineConfigurationDelegate> {

--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -194,8 +194,8 @@
 		7ED95D321AB9029B008C4574 /* NSDictionary+CordovaPreferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+CordovaPreferences.m"; sourceTree = "<group>"; };
 		7ED95D331AB9029B008C4574 /* NSMutableArray+QueueAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+QueueAdditions.h"; sourceTree = "<group>"; };
 		7ED95D341AB9029B008C4574 /* NSMutableArray+QueueAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+QueueAdditions.m"; sourceTree = "<group>"; };
-		902D0BC12AEB64EB009C68E5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		902B30732C6C5A7E00C6804C /* CordovaLib.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = CordovaLib.docc; sourceTree = "<group>"; };
+		902D0BC12AEB64EB009C68E5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		9036843B2C6EB06500A3338C /* CDVAllowList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVAllowList.h; sourceTree = "<group>"; };
 		9036843C2C6EB06500A3338C /* CDVAllowList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVAllowList.m; sourceTree = "<group>"; };
 		9047732D2C7A57E900373636 /* CDVURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVURLSchemeHandler.h; sourceTree = "<group>"; };
@@ -521,7 +521,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1540;
 				TargetAttributes = {
 					C0C01EB11E3911D50056E6CB = {
 						CreatedOnToolsVersion = 10.1;
@@ -711,7 +711,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MERGEABLE_LIBRARY = YES;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
@@ -778,7 +778,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MERGEABLE_LIBRARY = YES;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
@@ -800,7 +800,6 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -824,7 +823,6 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/CordovaLib/CordovaLib.xcodeproj/xcshareddata/xcschemes/Cordova.xcscheme
+++ b/CordovaLib/CordovaLib.xcodeproj/xcshareddata/xcschemes/Cordova.xcscheme
@@ -18,7 +18,7 @@
    under the License.
 -->
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1540"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ import PackageDescription
 let package = Package(
     name: "Cordova",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v13),
         .macCatalyst(.v13)
     ],
     products: [

--- a/lib/Podfile.js
+++ b/lib/Podfile.js
@@ -37,7 +37,7 @@ function Podfile (podFilePath, projectName, minDeploymentTarget) {
 
     this.path = podFilePath;
     this.projectName = projectName;
-    this.minDeploymentTarget = minDeploymentTarget || '11.0';
+    this.minDeploymentTarget = minDeploymentTarget || '13.0';
     this.contents = null;
     this.sources = null;
     this.declarations = null;
@@ -73,7 +73,7 @@ Podfile.prototype.__parseForDeclarations = function (text) {
     // split by \n
     const arr = text.split('\n');
 
-    // getting lines between "platform :ios, '11.0'"" and "target 'HelloCordova'" do
+    // getting lines between "platform :ios, '13.0'"" and "target 'HelloCordova'" do
     const declarationsPreRE = /platform :ios,\s+'[^']+'/;
     const declarationsPostRE = /target\s+'[^']+'\s+do/;
     const declarationRE = /^\s*[^#]/;

--- a/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
+++ b/tests/CordovaLibTests/CordovaLibTests.xcodeproj/project.pbxproj
@@ -581,7 +581,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MERGED_BINARY_TYPE = automatic;
 				ONLY_ACTIVE_ARCH = YES;
@@ -638,7 +638,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MERGED_BINARY_TYPE = automatic;
 				ONLY_ACTIVE_ARCH = NO;
@@ -677,7 +677,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "CordovaLibApp/CordovaLibApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.cordovalibapptests.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -702,7 +702,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "CordovaLibApp/CordovaLibApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.cordovalibapptests.${PRODUCT_NAME:rfc1034identifier}";
@@ -736,7 +736,7 @@
 					"$(BUILT_PRODUCTS_DIR)/include/Cordova/**",
 				);
 				INFOPLIST_FILE = "CordovaLibTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-all_load",
@@ -768,7 +768,7 @@
 					"$(BUILT_PRODUCTS_DIR)/include/Cordova/**",
 				);
 				INFOPLIST_FILE = "CordovaLibTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-all_load",
@@ -800,7 +800,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/CordovaLibApp/CordovaLibApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -829,7 +829,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/CordovaLibApp/CordovaLibApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -867,7 +867,7 @@
 					"$(BUILT_PRODUCTS_DIR)/include/Cordova/**",
 				);
 				INFOPLIST_FILE = "CordovaLibTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-all_load",
@@ -899,7 +899,7 @@
 					"$(BUILT_PRODUCTS_DIR)/include/Cordova/**",
 				);
 				INFOPLIST_FILE = "CordovaLibTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-all_load",

--- a/tests/spec/unit/fixtures/icon-support/configs/multi.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/multi.xml
@@ -10,10 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="13.0" />
-
         <icon src="res/ios/AppIcon-20x20@2x.png" height="40" width="40" />
         <icon src="res/ios/AppIcon-20x20@3x.png" height="60" width="60" />
         <icon src="res/ios/AppIcon-29x29@2x.png" height="58" width="58" />

--- a/tests/spec/unit/fixtures/icon-support/configs/none.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/none.xml
@@ -10,9 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="13.0" />
     </platform>
 
     <access origin="http://*.apache.org" />

--- a/tests/spec/unit/fixtures/icon-support/configs/single-only.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/single-only.xml
@@ -10,10 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="13.0" />
-
         <icon src="res/ios/appicon.png" />
     </platform>
 

--- a/tests/spec/unit/fixtures/icon-support/configs/single-variants.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/single-variants.xml
@@ -10,10 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="13.0" />
-
         <icon src="res/ios/appicon.png" foreground="res/ios/appicon-dark.png" monochrome="res/ios/appicon-tint.png" />
     </platform>
 

--- a/tests/spec/unit/fixtures/ios-config-xml/SampleApp.xcodeproj/project.pbxproj
+++ b/tests/spec/unit/fixtures/ios-config-xml/SampleApp.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "SampleApp/SampleApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.friendstring;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -349,7 +349,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "SampleApp/SampleApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.friendstring;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/legacy-only.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/legacy-only.xml
@@ -10,10 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="11.0" />
-
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
         <splash src="res/screen/ios/Default@2x~iphone.png" width="640" height="960"/>
         <splash src="res/screen/ios/Default-Portrait~ipad.png" width="768" height="1024"/>

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-and-legacy.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-and-legacy.xml
@@ -10,10 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="11.0" />
-
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
         <splash src="res/screen/ios/Default@2x~iphone.png" width="640" height="960"/>
         <splash src="res/screen/ios/Default-Portrait~ipad.png" width="768" height="1024"/>

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-only.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-only.xml
@@ -10,10 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="11.0" />
-
         <splash src="res/screen/ios/Default@2x~universal~anyany.png" />
         <splash src="res/screen/ios/Default@2x~universal~comany.png" />
         <splash src="res/screen/ios/Default@2x~universal~comcom.png" />

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/none.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/none.xml
@@ -10,9 +10,6 @@
     <content src="index.html" />
 
     <platform name="ios">
-        <preference name="orientation" value="all" />
-        <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="11.0" />
     </platform>
 
     <access origin="http://*.apache.org" />

--- a/tests/spec/unit/fixtures/test-config-2.xml
+++ b/tests/spec/unit/fixtures/test-config-2.xml
@@ -12,7 +12,7 @@
     <platform name="ios">
         <preference name="orientation" value="all" />
         <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="11.0" />
+        <preference name="deployment-target" value="15.0" />
     </platform>
 
     <access origin="http://*.apache.org" />

--- a/tests/spec/unit/fixtures/test-config-3.xml
+++ b/tests/spec/unit/fixtures/test-config-3.xml
@@ -12,7 +12,7 @@
     <platform name="ios">
         <preference name="orientation" value="all" />
         <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="11.0" />
+        <preference name="deployment-target" value="13.0" />
         <preference name="SwiftVersion" value="4.1" />
     </platform>
 

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -986,7 +986,7 @@ describe('prepare', () => {
                 const proj = new XcodeProject(p.locations.pbxproj);
                 proj.parseSync();
                 const prop = proj.getBuildProperty('IPHONEOS_DEPLOYMENT_TARGET');
-                expect(prop).toEqual('11.0');
+                expect(prop).toEqual('15.0');
             });
         });
         it('should write SwiftVersion preference (4.1)', () => {


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We already bumped the app template to a minimum of iOS 13 to support UISceneDelegates, and it turns out iOS 13 is the first version where WKURLSchemeTask is properly thread-safe, so we might as well bump CordovaLib and silence that warning that people keep complaining about 🥲


### Description
<!-- Describe your changes in detail -->
Bump the minimum iOS target for CordovaLib to 13.0, and update tests/project files to match.

Closes #1427.


### Testing
<!-- Please describe in detail how you tested your changes. -->
All existing tests pass, no warnings in Xcode.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
