### PR TITLE
fix: CDV.h wasn't bringing in Cordova.h consistently

### DIFF
--- a/CordovaLib/include/Cordova/CDV.h
+++ b/CordovaLib/include/Cordova/CDV.h
@@ -19,5 +19,6 @@
 
 #ifndef __CORDOVA_SILENCE_HEADER_DEPRECATIONS
     #warning Import <Cordova/Cordova.h> rather than <Cordova/CDV.h>
-    #import <Cordova/Cordova.h>
 #endif
+
+#import <Cordova/Cordova.h>


### PR DESCRIPTION


### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Plugins that included only `<Cordova/CDV.h>` were seeing issues around extending `CDVPlugin`.


### Description
<!-- Describe your changes in detail -->
Make `CDV.h` consistently import `Cordova.h` to define the full module.

The fact that there's a circular dependency between the headers isn't actually a problem in Objective-C because it uses `#import` rather than `#include` and the compiler ensures each header is only included once.

Somehow that was also causing it to only evaluate the header once and not differentiate imports where the macro was defined vs not defined.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Compiled a test app whose plugins used `#import <Cordova/CDV.h>` and were broken before this change.


### Checklist

- [x] I've run the tests to see all new and existing tests pass