### PR TITLE
fix: Avoid showing error page on cancelled navigation

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -511,17 +511,17 @@
 
 - (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error
 {
-    CDVViewController* vc = (CDVViewController*)self.viewController;
-
     NSString* message = [NSString stringWithFormat:@"Failed to load webpage with error: %@", [error localizedDescription]];
     NSLog(@"%@", message);
 
-    NSURL* errorUrl = vc.errorURL;
-    if (errorUrl) {
-        NSCharacterSet *charSet = [NSCharacterSet URLFragmentAllowedCharacterSet];
-        errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEncodingWithAllowedCharacters:charSet]] relativeToURL:errorUrl];
-        NSLog(@"%@", [errorUrl absoluteString]);
-        [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
+    if (error.code != NSURLErrorCancelled) {
+        NSURL* errorUrl = self.viewController.errorURL;
+        if (errorUrl) {
+            NSCharacterSet *charSet = [NSCharacterSet URLFragmentAllowedCharacterSet];
+            errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEncodingWithAllowedCharacters:charSet]] relativeToURL:errorUrl];
+            NSLog(@"%@", [errorUrl absoluteString]);
+            [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-959.


### Description
<!-- Describe your changes in detail -->
If the navigation was cancelled, don't show an error page. This can cause issues where a subsequent request never loads into the webview because the error page is being shown.

This was previously implemented back in the UIWebView days as CB-13222 in https://github.com/apache/cordova-ios/pull/334 and was then proposed in https://github.com/apache/cordova-plugin-wkwebview-engine/pull/84 for the WKWebView plugin, but that didn't get reviewed/merged before the repo was archived. The fix is still valid, so we'll port it to the current version of the WKWebView plugin.


### Testing
<!-- Please describe in detail how you tested your changes. -->
All existing tests passed.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))