### PR TITLE
fix(compat): Set the app delegate viewController for plugins

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -22,6 +22,7 @@
 #import <WebKit/WebKit.h>
 #import <objc/message.h>
 
+#import <Cordova/CDVAppDelegate.h>
 #import <Cordova/CDVPlugin.h>
 #import "CDVPlugin+Private.h"
 #import <Cordova/CDVConfigParser.h>
@@ -294,6 +295,17 @@ static UIColor* defaultBackgroundColor(void) {
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+
+    // TODO: Remove in Cordova iOS 9
+    if ([UIApplication.sharedApplication.delegate isKindOfClass:[CDVAppDelegate class]]) {
+        CDVAppDelegate *appDelegate = (CDVAppDelegate *)UIApplication.sharedApplication.delegate;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if (appDelegate.viewController == nil) {
+            appDelegate.viewController = self;
+        }
+#pragma clang diagnostic pop
+    }
 
     // Load settings
     [self loadSettings];

--- a/CordovaLib/include/Cordova/CDVAppDelegate.h
+++ b/CordovaLib/include/Cordova/CDVAppDelegate.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong) IBOutlet UIWindow *window API_DEPRECATED_WITH_REPLACEMENT("SceneDelegate:window", ios(2.0, 13.0));
 
 // TODO: Remove in Cordova iOS 9
-@property (nullable, nonatomic, strong) IBOutlet CDVViewController *viewController CDV_DEPRECATED(8, "This will always be nil.");
+@property (nullable, nonatomic, strong) IBOutlet CDVViewController *viewController CDV_DEPRECATED(8, "");
 
 @end
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some plugins expect to be able to access the applications's CDVViewController via the AppDelegate. While previously we guaranteed that the `viewController` property was set to a non-nil CDVViewController, there was never any guarantee that it was set to the CDVViewController that is actually displaying the app (particularly in cases such as apps using CordovaLib only for a few pages as part of a larger app).

We've attempted to deprecate the property here, but some plugins still rely on the assumption that it will be non-nil, so we are trying to maintain compatibility in the common case here by assigning to it when a CDVViewController is loaded. This means there are still times in the app lifecycle where the `viewController` property is nil, but the deprecation warning will hopefully spur plugin developers to move away from that pattern.

> [!NOTE]
> CDVPlugin always has a non-nil viewController property of its own, which is set to the CDVViewController instance the plugin was loaded into. This is almost always the better choice for plugins to use.



### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing unit tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass