### PR TITLE
fix(objc): Workaround for Swift/ObjC template issues

### DIFF
--- a/templates/project/App/AppDelegate.h
+++ b/templates/project/App/AppDelegate.h
@@ -19,10 +19,11 @@
 
 #import <Cordova/CDVAppDelegate.h>
 
-#warning It is unsafe to rely on the AppDelegate class as an extension point. \
-         Update your code to extend CDVAppDelegate instead -- \
-         This code will stop working in Cordova iOS 9!
+#ifndef __CORDOVA_SILENCE_HEADER_DEPRECATIONS
+    #warning It is unsafe to rely on the AppDelegate class as an extension point. \
+             Update your code to extend CDVAppDelegate instead -- \
+             This code will stop working in Cordova iOS 9!
+#endif
 
-@class AppDelegate;
-
-#import "App-Swift.h"
+@interface AppDelegate : CDVAppDelegate
+@end

--- a/templates/project/App/AppDelegate.swift
+++ b/templates/project/App/AppDelegate.swift
@@ -18,12 +18,11 @@
 */
 
 import UIKit
-import Cordova
 
 @main
-@objc // Remove compat hack in Cordova iOS 9
-class AppDelegate: CDVAppDelegate {
-    override func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+@_objcImplementation
+extension AppDelegate {
+    open override func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 }

--- a/templates/project/App/Bridging-Header.h
+++ b/templates/project/App/Bridging-Header.h
@@ -18,3 +18,8 @@
  */
 
 #import <Cordova/Cordova.h>
+
+#define __CORDOVA_SILENCE_HEADER_DEPRECATIONS
+#import "AppDelegate.h"
+#import "MainViewController.h"
+#undef __CORDOVA_SILENCE_HEADER_DEPRECATIONS

--- a/templates/project/App/MainViewController.h
+++ b/templates/project/App/MainViewController.h
@@ -19,10 +19,11 @@
 
 #import <Cordova/CDVViewController.h>
 
-#warning It is unsafe to rely on the MainViewController class as an extension point. \
-         Update your code to extend CDVViewController instead -- \
-         This code will stop working in Cordova iOS 9!
+#ifndef __CORDOVA_SILENCE_HEADER_DEPRECATIONS
+    #warning It is unsafe to rely on the MainViewController class as an extension point. \
+             Update your code to extend CDVViewController instead -- \
+             This code will stop working in Cordova iOS 9!
+#endif
 
-@class MainViewController;
-
-#import "App-Swift.h"
+@interface MainViewController : CDVViewController
+@end

--- a/templates/project/App/ViewController.swift
+++ b/templates/project/App/ViewController.swift
@@ -19,7 +19,9 @@
 
 import Cordova
 
-@objc(MainViewController) // Remove compat hack in Cordova iOS 9
-class ViewController: CDVViewController {
+@_objcImplementation
+extension MainViewController {
 }
 
+class ViewController: MainViewController {
+}


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Hopefully closes GH-1487.


### Description
<!-- Describe your changes in detail -->
This uses "non-standard" Swift annotations, but they've been supported by the past few versions of Xcode and are in the process of being standardized. Most importantly, they work for what we need.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran unit tests.
Ran mobilespec tests.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
