### PR TITLE
fix(emulators): Fix listing emulator targets

### DIFF
--- a/lib/listEmulatorBuildTargets.js
+++ b/lib/listEmulatorBuildTargets.js
@@ -18,7 +18,6 @@
 */
 
 const execa = require('execa');
-const { events } = require('cordova-common');
 
 /**
  * Returns a list of available simulator build targets of the form
@@ -32,7 +31,6 @@ const { events } = require('cordova-common');
  *
  */
 function listEmulatorBuildTargets () {
-    events.emit('log', 'List simulator targets');
     return execa('xcrun', ['simctl', 'list', '--json'])
         .then(({ stdout }) => JSON.parse(stdout))
         .then(function (simInfo) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -138,7 +138,7 @@ module.exports.startSim = startSim;
 module.exports.listDevices = listDevices;
 module.exports.listEmulators = listEmulators;
 module.exports.execListDevices = execListDevices;
-module.exports.execListEmulatorTargets = execListEmulatorTargets;
+module.exports.execListEmulatorImages = execListEmulatorImages;
 
 /**
  * Filters the args array and removes supported args for the 'run' command.
@@ -207,7 +207,7 @@ async function deployToSim (appPath, target) {
 
     if (!target) {
         // Select target device for emulator (preferring iPhone Emulators)
-        const emulators = await module.exports.execListEmulatorTargets();
+        const emulators = await module.exports.execListEmulatorImages();
         const iPhoneEmus = emulators.filter(emulator => emulator.startsWith('iPhone'));
         target = iPhoneEmus.concat(emulators)[0];
         events.emit('log', `No target specified for emulator. Deploying to "${target}" simulator.`);
@@ -248,8 +248,8 @@ function execListDevices () {
 }
 
 /* istanbul ignore next */
-function execListEmulatorTargets () {
-    return require('./listEmulatorTargets').run();
+function execListEmulatorImages () {
+    return require('./listEmulatorImages').run();
 }
 
 function listDevices () {
@@ -263,7 +263,7 @@ function listDevices () {
 }
 
 function listEmulators () {
-    return module.exports.execListEmulatorTargets()
+    return module.exports.execListEmulatorImages()
         .then(emulators => {
             events.emit('log', 'Available iOS Simulators:');
             emulators.forEach(emulator => {

--- a/tests/spec/unit/run.spec.js
+++ b/tests/spec/unit/run.spec.js
@@ -35,22 +35,22 @@ describe('cordova/lib/run', () => {
         beforeEach(() => {
             spyOn(events, 'emit');
             spyOn(run, 'execListDevices').and.returnValue(Promise.resolve(['iPhone Xs']));
-            spyOn(run, 'execListEmulatorTargets').and.returnValue(Promise.resolve(['iPhone 15 Simulator']));
+            spyOn(run, 'execListEmulatorImages').and.returnValue(Promise.resolve(['iPhone 15 Simulator']));
         });
 
         it('should delegate to "listDevices" when the "runListDevices" method options param contains "options.device".', () => {
             return run.runListDevices({ options: { device: true } }).then(() => {
                 expect(run.execListDevices).toHaveBeenCalled();
-                expect(run.execListEmulatorTargets).not.toHaveBeenCalled();
+                expect(run.execListEmulatorImages).not.toHaveBeenCalled();
 
                 expect(events.emit).toHaveBeenCalledWith('log', '\tiPhone Xs');
             });
         });
 
-        it('should delegate to "listDevices" when the "runListDevices" method options param contains "options.emulator".', () => {
+        it('should delegate to "listEmulators" when the "runListDevices" method options param contains "options.emulator".', () => {
             return run.runListDevices({ options: { emulator: true } }).then(() => {
                 expect(run.execListDevices).not.toHaveBeenCalled();
-                expect(run.execListEmulatorTargets).toHaveBeenCalled();
+                expect(run.execListEmulatorImages).toHaveBeenCalled();
 
                 expect(events.emit).toHaveBeenCalledWith('log', '\tiPhone 15 Simulator');
             });
@@ -59,7 +59,7 @@ describe('cordova/lib/run', () => {
         it('should delegate to both "listEmulators" and "listDevices" when the "runListDevices" method does not contain "options.device" or "options.emulator".', () => {
             return run.runListDevices().then(() => {
                 expect(run.execListDevices).toHaveBeenCalled();
-                expect(run.execListEmulatorTargets).toHaveBeenCalled();
+                expect(run.execListEmulatorImages).toHaveBeenCalled();
 
                 expect(events.emit).toHaveBeenCalledWith('log', '\tiPhone Xs');
                 expect(events.emit).toHaveBeenCalledWith('log', '\tiPhone 15 Simulator');
@@ -80,7 +80,7 @@ describe('cordova/lib/run', () => {
             spyOn(build, 'run').and.returnValue(Promise.resolve());
             spyOn(projectFile, 'parse').and.returnValue(fakeXcodeProject);
             spyOn(run, 'execListDevices').and.resolveTo([]);
-            spyOn(run, 'execListEmulatorTargets').and.resolveTo([]);
+            spyOn(run, 'execListEmulatorImages').and.resolveTo([]);
             spyOn(run, 'listDevices').and.resolveTo();
             spyOn(run, 'deployToMac').and.resolveTo();
             spyOn(run, 'deployToSim').and.resolveTo();


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I think I accidentally broke this during earlier refactoring for 8.0.0, but it was now trying to (and incorrectly) listing the simulator devices rather than the simulator device/runtime combinations.


### Description
<!-- Describe your changes in detail -->
Restore the correct listing for simulator devices/runtimes when using `cordova run ios --list`


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested running `npx cordova run ios --list` and ensured the output matched between these changes and 7.1.1


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
