### PR TITLE
fix(create): Copy config.xml data during creation

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -107,8 +107,6 @@ class Api {
      * @param  {Object}  [options]  An options object. The most common options are:
      * @param  {String}  [options.customTemplate]  A path to custom template, that
      *   should override the default one from platform.
-     * @param  {Boolean}  [options.link]  Flag that indicates that platform's
-     *   sources will be linked to installed platform instead of copying.
      * @param {EventEmitter} [events] An EventEmitter instance that will be used for
      *   logging purposes. If no EventEmitter provided, all events will be logged to
      *   console

--- a/lib/create.js
+++ b/lib/create.js
@@ -19,7 +19,7 @@
 
 const path = require('node:path');
 const fs = require('node:fs');
-const { CordovaError, events } = require('cordova-common');
+const { ConfigParser, CordovaError, events, xmlHelpers } = require('cordova-common');
 const xcode = require('xcode');
 const pkg = require('../package');
 
@@ -31,10 +31,11 @@ const ROOT = path.join(__dirname, '..');
  * @param {string} project_path Path to your new Cordova iOS project
  * @param {string} package_name Package name, following reverse-domain style convention
  * @param {string} project_name Project name
- * @param {{ link: boolean, customTemplate: string }} opts Project creation options
+ * @param {{ customTemplate: string }} opts Project creation options
+ * @param {ConfigParser} root_config The application config.xml
  * @returns {Promise<void>} resolves when the project has been created
  */
-exports.createProject = async (project_path, package_name, project_name, opts) => {
+exports.createProject = async (project_path, package_name, project_name, opts, root_config) => {
     package_name = package_name || 'my.cordova.project';
     project_name = project_name || 'CordovaExample';
 
@@ -56,7 +57,7 @@ exports.createProject = async (project_path, package_name, project_name, opts) =
         },
         options: {
             templatePath: opts.customTemplate || path.join(ROOT, 'templates', 'project'),
-            linkLib: !!opts.link
+            rootConfig: root_config
         }
     }).create();
 
@@ -73,6 +74,7 @@ class ProjectCreator {
         this.provideCordovaJs();
         this.provideBuildScripts();
         this.updateProjectSettings();
+        this.updatePlatformConfigFile();
     }
 
     provideProjectTemplate () {
@@ -97,6 +99,17 @@ class ProjectCreator {
         fs.cpSync(srcScriptsDir, destScriptsDir, { recursive: true });
     }
 
+    updatePlatformConfigFile () {
+        const defaultXmlPath = this.projectPath('cordova', 'defaults.xml');
+        const configXmlPath = this.projectPath('App', 'config.xml');
+
+        fs.cpSync(defaultXmlPath, configXmlPath);
+
+        const config = new ConfigParser(configXmlPath);
+        xmlHelpers.mergeXml(this.options.rootConfig.doc.getroot(), config.doc.getroot(), 'ios', /* clobber= */true);
+        config.write();
+    }
+
     updateProjectSettings () {
         const projectPath = this.projectPath('App.xcodeproj', 'project.pbxproj');
         const xcodeproj = xcode.project(projectPath);
@@ -104,6 +117,11 @@ class ProjectCreator {
 
         xcodeproj.updateBuildProperty('PRODUCT_NAME', `"${this.project.name}"`, null, 'App');
         xcodeproj.updateBuildProperty('PRODUCT_BUNDLE_IDENTIFIER', `"${this.project.id}"`, null, 'App');
+
+        const deploymentTarget = this.options.rootConfig.getPreference('deployment-target', 'ios');
+        if (deploymentTarget) {
+            xcodeproj.updateBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', deploymentTarget);
+        }
 
         // Update the CordovaLib Swift package reference path
         const pkgRefs = xcodeproj.hash.project.objects.XCLocalSwiftPackageReference;

--- a/tests/spec/createAndBuild.spec.js
+++ b/tests/spec/createAndBuild.spec.js
@@ -21,12 +21,15 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const xcode = require('xcode');
+const { ConfigParser } = require('cordova-common');
 const create = require('../../lib/create');
 
 const makeTempDir = () => path.join(
     fs.realpathSync(os.tmpdir()),
     `cordova-ios-create-test-${Date.now()}`
 );
+
+const templateConfigXmlPath = path.join(__dirname, '..', '..', 'templates', 'project', 'App', 'config.xml');
 
 /**
  * Verifies that some of the project file exists. Not all will be tested.
@@ -90,7 +93,9 @@ function verifyBuild (tmpDir) {
  * @returns {Promise}
  */
 async function verifyCreateAndBuild (tmpDir, packageName, projectName) {
-    await create.createProject(tmpDir, packageName, projectName, {}, undefined)
+    const configXml = new ConfigParser(templateConfigXmlPath);
+
+    await create.createProject(tmpDir, packageName, projectName, {}, configXml)
         .then(() => verifyProjectFiles(tmpDir, projectName))
         .then(() => verifyProjectBundleIdentifier(tmpDir, projectName, packageName))
         .then(() => verifyBuild(tmpDir));

--- a/tests/spec/unit/fixtures/test-config-3.xml
+++ b/tests/spec/unit/fixtures/test-config-3.xml
@@ -12,7 +12,7 @@
     <platform name="ios">
         <preference name="orientation" value="all" />
         <preference name="target-device" value="handset" />
-        <preference name="deployment-target" value="13.0" />
+        <preference name="deployment-target" value="15.0" />
         <preference name="SwiftVersion" value="4.1" />
     </platform>
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This ensures that by the time plugin installation happens, the preferences from the root application config.xml can be read as expected.

Closes GH-1422.


### Description
<!-- Describe your changes in detail -->
Merge the app's config.xml into the defaults.xml at creation time for the platform config.xml.

Also removed comments about the `link` option since that's no longer relevant (with CordovaLib consumed as a Swift package, it is always linked).


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass, and added a new unit test to verify new behaviour.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))