### PR TITLE
chore(ci): Add code scanning & fix dependabot failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@
 
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   darwin:
@@ -41,12 +47,24 @@ jobs:
           node --version
           npm --version
 
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - coverage
+              - node_modules
+              - templates/project/www/cordova.js
+
       - name: npm install and test
         run: |
           npm i -g ios-deploy
           npm cit
         env:
           CI: true
+
+      - uses: github/codeql-action/analyze@v3
 
       - uses: codecov/codecov-action@v4
         if: success()
@@ -76,6 +94,16 @@ jobs:
           node --version
           npm --version
 
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - coverage
+              - node_modules
+              - templates/project/www/cordova.js
+
       - name: npm install and test
         run: |
           npm ci
@@ -83,6 +111,8 @@ jobs:
           npm run unit-tests
         env:
           CI: true
+
+      - uses: github/codeql-action/analyze@v3
 
       - uses: codecov/codecov-action@v4
         if: success()

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -17,7 +17,13 @@
 
 name: Release Auditing
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   test:


### PR DESCRIPTION
### Platforms affected
all


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Improve CI.


### Description
<!-- Describe your changes in detail -->
* Fix errors when dependabot PRs try to run tests in CI
* Add JavaScript code scanning with CodeQL

CodeQL doesn't support Objective C, and I tried enabling the Swift scanning but it caused everything to run so slowly that all the tests timed out. But we don't actually have much Swift code, do I doubt that it worth trying to enable that right now.


### Testing
<!-- Please describe in detail how you tested your changes. -->
* Ran in CI, tests pass


### Checklist

- [x] I've run the tests to see all new and existing tests pass