### PR TITLE
fix(catalyst): Fix content behind titlebar

### DIFF
--- a/CordovaLib/Classes/Public/CDVPlugin.m
+++ b/CordovaLib/Classes/Public/CDVPlugin.m
@@ -21,7 +21,6 @@
 #import <Cordova/CDVPlugin+Resources.h>
 #import "CDVPlugin+Private.h"
 #import <Cordova/CDVViewController.h>
-#include <objc/message.h>
 
 @implementation UIView (org_apache_cordova_UIView_Extension)
 
@@ -29,12 +28,9 @@
 
 - (UIScrollView*)scrollView
 {
-    SEL scrollViewSelector = NSSelectorFromString(@"scrollView");
-
-    if ([self respondsToSelector:scrollViewSelector]) {
-        return ((id (*)(id, SEL))objc_msgSend)(self, scrollViewSelector);
+    if ([self respondsToSelector:@selector(scrollView)]) {
+        return [self performSelector:@selector(scrollView)];
     }
-
     return nil;
 }
 


### PR DESCRIPTION
### Platforms affected
macOS Catalyst


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1491.


### Description
<!-- Describe your changes in detail -->
When showing a webview on macOS Catalyst, always position it below the titlebar when a titlebar is displayed. This has the side effect of making all the `safe-area-inset` values 0, regardless of the `viewport-fit` value.

Also adds a `HideDesktopTitlebar` preference to make the titlebar invisible on macOS Catalyst with content extending behind it. I named this in a generic way because it sounds like this should also be feasible to apply to the cordova-electron platform.

When using a preference to disable drawing the titlebar, `safe-area-inset` works as expected (but generally requires `viewport-fit=cover` to be specified).


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested with `viewport-fit=cover` and `viewport-fit=contain` and measured the calculated `safe-area-inset-top` value.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
