### PR TITLE
fix(Swift): Nullability stuff broke Swift compatibility

### DIFF
--- a/CordovaLib/include/Cordova/CDVPlugin.h
+++ b/CordovaLib/include/Cordova/CDVPlugin.h
@@ -32,6 +32,8 @@
 
 typedef int CDVWebViewNavigationType;
 
+NS_ASSUME_NONNULL_BEGIN
+
 #ifndef __swift__
 // This global extension to the UIView class causes issues for Swift subclasses
 // of UIView with their own scrollView properties, so we're removing it from
@@ -41,8 +43,6 @@ typedef int CDVWebViewNavigationType;
 @property (nonatomic, weak, nullable) UIScrollView* scrollView CDV_DEPRECATED(8, "Check for a scrollView property on the view object at runtime and invoke it dynamically.");
 @end
 #endif
-
-NS_ASSUME_NONNULL_BEGIN
 
 extern const NSNotificationName CDVPageDidLoadNotification;
 extern const NSNotificationName CDVPluginHandleOpenURLNotification;
@@ -56,6 +56,8 @@ extern const NSNotificationName CDVViewWillLayoutSubviewsNotification;
 extern const NSNotificationName CDVViewDidLayoutSubviewsNotification;
 extern const NSNotificationName CDVViewWillTransitionToSizeNotification;
 
+NS_ASSUME_NONNULL_END
+
 @interface CDVPlugin : NSObject {}
 
 @property (nonatomic, readonly, weak) UIView* webView;
@@ -68,8 +70,8 @@ extern const NSNotificationName CDVViewWillTransitionToSizeNotification;
 
 - (void)pluginInitialize;
 
-- (void)handleOpenURL:(NSNotification*)notification;
-- (void)handleOpenURLWithApplicationSourceAndAnnotation:(NSNotification*)notification CDV_DEPRECATED(8, "Use the handleOpenUrl method and the notification userInfo data.");
+- (void)handleOpenURL:(nonnull NSNotification*)notification;
+- (void)handleOpenURLWithApplicationSourceAndAnnotation:(nonnull NSNotification*)notification CDV_DEPRECATED(8, "Use the handleOpenUrl method and the notification userInfo data.");
 - (void)onAppTerminate;
 - (void)onMemoryWarning;
 - (void)onReset;
@@ -83,11 +85,13 @@ extern const NSNotificationName CDVViewWillTransitionToSizeNotification;
  - (void) onOrientationDidChange {}
  */
 
-- (id)appDelegate;
+- (nonnull id)appDelegate;
 
 @end
 
 #pragma mark - Plugin protocols
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  A protocol for Cordova plugins to intercept and respond to server


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
CDVPlugin's commandDelegate is a weak pointer, which means technically in Swift it should be an optional type that requires unwrapping. For some reason, it is not.

If the wrap the CDVPlugin class in the `ASSUME_NONNULL` macro, Swift suddenly starts enforcing that it's an optional, and this breaks all existing Swift plugins.


### Description
<!-- Describe your changes in detail -->
You aren't allowed to combine `weak` and `nonnull`, and all the properties in CDVPlugin are weak, so just... don't wrap it in `ASSUME_NONNULL` to make life easier for everyone 🙃


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested with mobilespec (which fails on master and passes with this change)


### Checklist

- [x] I've run the tests to see all new and existing tests pass
