### PR TITLE
refactor(template): Copy CordovaLib into a packages folder

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -107,6 +107,8 @@ class Api {
      * @param  {Object}  [options]  An options object. The most common options are:
      * @param  {String}  [options.customTemplate]  A path to custom template, that
      *   should override the default one from platform.
+     * @param  {Boolean}  [options.link]  Flag that indicates that platform's
+     *   sources will be linked to installed platform instead of copying.
      * @param {EventEmitter} [events] An EventEmitter instance that will be used for
      *   logging purposes. If no EventEmitter provided, all events will be logged to
      *   console

--- a/lib/create.js
+++ b/lib/create.js
@@ -31,7 +31,7 @@ const ROOT = path.join(__dirname, '..');
  * @param {string} project_path Path to your new Cordova iOS project
  * @param {string} package_name Package name, following reverse-domain style convention
  * @param {string} project_name Project name
- * @param {{ customTemplate: string }} opts Project creation options
+ * @param {{ link: boolean, customTemplate: string }} opts Project creation options
  * @param {ConfigParser} root_config The application config.xml
  * @returns {Promise<void>} resolves when the project has been created
  */
@@ -57,6 +57,7 @@ exports.createProject = async (project_path, package_name, project_name, opts, r
         },
         options: {
             templatePath: opts.customTemplate || path.join(ROOT, 'templates', 'project'),
+            linkLib: !!opts.link,
             rootConfig: root_config
         }
     }).create();
@@ -84,6 +85,13 @@ class ProjectCreator {
         const r = this.projectPath('App');
         fs.renameSync(path.join(r, 'gitignore'), path.join(r, '.gitignore'));
         fs.cpSync(path.join(r, '.gitignore'), this.projectPath('.gitignore'));
+
+        if (!this.options.linkLib) {
+            // Copy CordovaLib into the packages folder
+            fs.mkdirSync(this.projectPath('packages', 'cordova-ios'), { recursive: true });
+            fs.cpSync(path.join(ROOT, 'CordovaLib'), this.projectPath('packages', 'cordova-ios', 'CordovaLib'), { recursive: true });
+            fs.cpSync(path.join(ROOT, 'Package.swift'), this.projectPath('packages', 'cordova-ios', 'Package.swift'));
+        }
     }
 
     provideCordovaJs () {
@@ -133,7 +141,14 @@ class ProjectCreator {
                 }
 
                 if (ref.relativePath?.match(/\/cordova-ios/)) {
-                    ref.relativePath = `"${path.relative(this.project.path, ROOT).replaceAll(path.sep, path.posix.sep)}"`;
+                    let relPath = path.relative(this.project.path, this.projectPath('packages', 'cordova-ios'));
+
+                    if (this.options.linkLib) {
+                        // Point to CordovaLib in node_modules
+                        relPath = path.relative(this.project.path, ROOT);
+                    }
+
+                    ref.relativePath = `"${relPath.replaceAll(path.sep, path.posix.sep)}"`;
                     break;
                 }
             }


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Pointing a relative path to CordovaLib in the node_modules folder means that the Xcode project is no longer self-contained, which is significant change in terms of assumptions people can make about the project files in CI environments (i.e., preparing all platforms once, then copying just the platform folders to different runners to build).


### Description
<!-- Describe your changes in detail -->
We now copy the CordovaLib folder into a `platforms/ios/packages` directory and point to it there. (We will need to do the same for SPM plugins, which sorta turns out to our advantage...)

As a side effect, it seemed worth bringing back the `--link` option to continue pointing to node_modules for easier development.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested with mobilespec and unit tests.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change