### PR TITLE
ci: Add Node 24 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [macos-14]
 
     steps:
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   darwin:
     name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -25,6 +25,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Audit Licenses


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Node 24 has been released


### Description
<!-- Describe your changes in detail -->
* Add NodeJS version 24 to the CI matrix since it's now been released
* Update the GHA workflows to explicitly declare what permissions they need, to reduce the scope of default permissions

