### PR TITLE
test: Improve test coverage of Bridging Headers & fix edge case

### DIFF
--- a/lib/BridgingHeader.js
+++ b/lib/BridgingHeader.js
@@ -111,7 +111,7 @@ BridgingHeader.prototype.__parseForBridgingHeader = function (text) {
         }
     }
     if (start < i) {
-        list.push({ type, code: text.slice(start, i) });
+        list.push({ type, code: text.slice(start, i) + '\n' });
     }
     return list;
 };

--- a/tests/spec/unit/fixtures/test-Bridging-Header.h
+++ b/tests/spec/unit/fixtures/test-Bridging-Header.h
@@ -17,6 +17,7 @@
  under the License.
  */
 
-#import <Cordova/Cordova.h>
-#import "CDVSwift22Object.h"
+// This is a bridging header to expose stuff to Swift
+#import <Cordova/Cordova.h> // CordovaLib
+#import /* Other headers */ "CDVSwift22Object.h"
 #import "CDVSwift2Object.h"


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Our fixture file for Bridging Header tests didn't contain a bunch of stuff that the Bridging Header code tries to handle, so that code was never properly tested.


### Description
<!-- Describe your changes in detail -->
Update the Bridging Header fixture file to include more comment types and inline comments and not have a final newline.
That missing newline ended up uncovering a bug in the Bridging Header code where headers from multiple plugins could end up on a single line without separation, so that edge case is also fixed now.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ensured existing unit tests pass


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
