### PR TITLE
fix(plugins): Handle uninstalling multiple plugin assets

### DIFF
--- a/lib/plugman/pluginHandlers.js
+++ b/lib/plugman/pluginHandlers.js
@@ -184,11 +184,9 @@ const handlers = {
                 throw new CordovaError(generateAttributeError('target', 'asset', plugin.id));
             }
 
-            removeFile(project.www, target);
-            removeFileF(path.resolve(project.www, 'plugins', plugin.id));
+            removeFileAndParents(project.www, target);
             if (options && options.usePlatformWww) {
-                removeFile(project.platformWww, target);
-                removeFileF(path.resolve(project.platformWww, 'plugins', plugin.id));
+                removeFileAndParents(project.platformWww, target);
             }
         }
     },
@@ -353,12 +351,6 @@ function linkFileOrDirTree (src, dest) {
     } else {
         fs.linkSync(src, dest);
     }
-}
-
-// checks if file exists and then deletes. Error if doesn't exist
-function removeFile (project_dir, src) {
-    const file = path.resolve(project_dir, src);
-    fs.rmSync(file);
 }
 
 // deletes file/directory without checking

--- a/tests/spec/unit/Plugman/pluginHandler.spec.js
+++ b/tests/spec/unit/Plugman/pluginHandler.spec.js
@@ -575,7 +575,7 @@ describe('ios plugin handler', () => {
             it('Test 043 : should put module to www only when options.usePlatformWww flag is not specified', () => {
                 uninstall(jsModule, dummyPluginInfo, dummyProject);
                 expect(fs.rmSync).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
-                expect(fs.rmSync).not.toHaveBeenCalledWith(platformWwwDest);
+                expect(fs.rmSync).not.toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
         });
 
@@ -600,14 +600,14 @@ describe('ios plugin handler', () => {
 
             it('Test 044 : should put module to both www and platform_www when options.usePlatformWww flag is specified', () => {
                 uninstall(asset, dummyPluginInfo, dummyProject, { usePlatformWww: true });
-                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest);
-                expect(fs.rmSync).toHaveBeenCalledWith(platformWwwDest);
+                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
+                expect(fs.rmSync).toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
 
             it('Test 045 : should put module to www only when options.usePlatformWww flag is not specified', () => {
                 uninstall(asset, dummyPluginInfo, dummyProject);
-                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest);
-                expect(fs.rmSync).not.toHaveBeenCalledWith(platformWwwDest);
+                expect(fs.rmSync).toHaveBeenCalledWith(wwwDest, { recursive: true, force: true });
+                expect(fs.rmSync).not.toHaveBeenCalledWith(platformWwwDest, { recursive: true, force: true });
             });
         });
     });


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1530.


### Description
<!-- Describe your changes in detail -->
Try to safely clean up empty directories when uninstalling plugin assets without always forcibly removing the plugin directory itself. This should provide better handling for cases where plugins have multiple assets that get added to the plugin folder.

The `removeFileAndParents` function is already used for uninstall plugin JS module files.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Updated existing tests (minimally) and they are passing.

Have not testing in an actual project with an affected plugin
(/cc @cdm-tao if you are able to give this a try and report back)


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
