### PR TITLE
fix(swift): Fix some new Swift deprecation warnings

### DIFF
--- a/templates/project/App/AppDelegate.swift
+++ b/templates/project/App/AppDelegate.swift
@@ -20,7 +20,11 @@
 import UIKit
 
 @main
+#if compiler(>=6.1)
+@objc @implementation
+#else
 @_objcImplementation
+#endif
 extension AppDelegate {
     open override func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)

--- a/templates/project/App/ViewController.swift
+++ b/templates/project/App/ViewController.swift
@@ -19,7 +19,11 @@
 
 import Cordova
 
+#if compiler(>=6.1)
+@objc @implementation
+#else
 @_objcImplementation
+#endif
 extension MainViewController {
 }
 


### PR DESCRIPTION
Can't even go one Xcode minor version without new stuff getting deprecated 🙄

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix some new Swift deprecation warnings about `@_objcImplementation`


### Description
<!-- Describe your changes in detail -->
Changed `@_objcImplementation` to `@objc @implementation` if we're using a Swift 6.1 compiler or newer.

To be fair, this is now an officially supported Swift feature rather than an experimental option, so this is better in the long run.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Confirmed that this builds without deprecation warnings in Xcode 16.4.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
