### PR TITLE
doc: add precompiled prefix header deprecation notice to 8.x upgrade

### DIFF
--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -152,6 +152,28 @@ if webView.responds(to: scrollViewSelector) {
 
 This updated code is compatible with existing versions of Cordova iOS.
 
+# Precompiled Prefix Header deprecation
+
+Previously, Cordova projects included a precompiled prefix header that automatically imported the `Foundation` and `UIKit` frameworks. This made these frameworks available globally, without requiring explicit imports in each Objective-C file.
+
+While this may have offered convenience, it also introduced an implicit dependency on the Cordova-managed prefix header and prefix headers have gradually been replaced with module imports in Objective-C and were never supported in Swift.
+
+To align with Xcode defaults and improve long-term maintainability, the precompiled prefix header has been removed from generated Cordova app projects. While this may be a breaking change for some plugins, developers are now expected to explicitly declare the frameworks their code depends on by adding the appropriate import statements directly in their source files.
+
+**Objective-C Example:**
+
+```objc
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+```
+
+**Swift Example:**
+
+```swift
+import Foundation
+import UIKit
+```
+
 ## Other Major Changes
 ### Deprecating AppDelegate category extensions
 

--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -152,7 +152,7 @@ if webView.responds(to: scrollViewSelector) {
 
 This updated code is compatible with existing versions of Cordova iOS.
 
-# Precompiled Prefix Header deprecation
+### Precompiled prefix header removal
 
 Previously, Cordova projects included a precompiled prefix header that automatically imported the `Foundation` and `UIKit` frameworks. This made these frameworks available globally, without requiring explicit imports in each Objective-C file.
 
@@ -160,16 +160,14 @@ While this may have offered convenience, it also introduced an implicit dependen
 
 To align with Xcode defaults and improve long-term maintainability, the precompiled prefix header has been removed from generated Cordova app projects. While this may be a breaking change for some plugins, developers are now expected to explicitly declare the frameworks their code depends on by adding the appropriate import statements directly in their source files.
 
-**Objective-C Example:**
-
 ```objc
+// New code (Objective-C)
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 ```
 
-**Swift Example:**
-
 ```swift
+// New code (Swift)
 import Foundation
 import UIKit
 ```


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation, Context & Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Update Cordova-iOS 8 upgrade docs to include the precompiled prefix header deprecation notice.

### Testing
<!-- Please describe in detail how you tested your changes. -->

N/A

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
