### PR TITLE
fix: potential problems overriding OTHER_LDFLAGS

### DIFF
--- a/templates/project/App.xcodeproj/project.pbxproj
+++ b/templates/project/App.xcodeproj/project.pbxproj
@@ -447,7 +447,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
-					"$(OTHER_LDFLAGS)",
+					"$(inherited)",
 					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.AppTemplate$(DEVELOPMENT_TEAM)";
@@ -485,7 +485,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
-					"$(OTHER_LDFLAGS)",
+					"$(inherited)",
 					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.AppTemplate$(DEVELOPMENT_TEAM)";


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves CocoaPods warning for potential problems with OTHER_LDFLAGS overrides.

```
[!] The `App [Debug]` target overrides the `OTHER_LDFLAGS` build setting defined in `Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig'. This can lead to problems with the CocoaPods installation

[!] The `App [Release]` target overrides the `OTHER_LDFLAGS` build setting defined in `Pods/Target Support Files/Pods-App/Pods-App.release.xcconfig'. This can lead to problems with the CocoaPods installation
```

### Description
<!-- Describe your changes in detail -->

Updated following Debug & Release `buildSettings` in `App.xcodeproj/project.pbxproj`

From:

```
OTHER_LDFLAGS = (
    "$(OTHER_LDFLAGS)",
    "-ObjC",
);
```

To:


```
OTHER_LDFLAGS = (
    "$(inherited)",
    "-ObjC",
);
```


### Testing
<!-- Please describe in detail how you tested your changes. -->

- Created a sample project
- Added the iOS platform with changes
- Added a plugin that has CocoaPods dependencies
- Confirmed that the warning message no longer displayed

Also ran a `cordova build` test, ran the application in an iOS simulator, and confirmed functionality that the CocoaPods dependencies supported.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
