### PR TITLE
White Screen of Death issue | Enhance WebView reload detection to handle empty title strings

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -297,7 +297,7 @@
 
 - (BOOL)shouldReloadWebView:(NSURL*)location title:(NSString*)title
 {
-    BOOL title_is_nil = (title == nil);
+    BOOL title_is_nil = (title == nil) || [title isEqualToString:@""];
     BOOL location_is_blank = [[location absoluteString] isEqualToString:@"about:blank"];
 
     BOOL reload = (title_is_nil || location_is_blank);


### PR DESCRIPTION
Improves white screen of death prevention by checking for both nil and empty string titles when determining if WebView needs reloading.
This catches more edge cases where the WebView enters a broken state but has an empty title instead of nil.