### PR TITLE
chore!: update template defaults

### DIFF
--- a/lib/Podfile.js
+++ b/lib/Podfile.js
@@ -68,7 +68,7 @@ Podfile.prototype.__parseForDeclarations = function (text) {
     // split by \n
     const arr = text.split('\n');
 
-    // getting lines between "platform :ios, '13.0'"" and "target 'HelloCordova'" do
+    // getting lines between "platform :ios, '13.0'"" and "target 'Hello Cordova'" do
     const declarationsPreRE = /platform :ios,\s+'[^']+'/;
     const declarationsPostRE = /target\s+'[^']+'\s+do/;
     const declarationRE = /^\s*[^#]/;

--- a/lib/create.js
+++ b/lib/create.js
@@ -36,16 +36,20 @@ const ROOT = path.join(__dirname, '..');
  * @returns {Promise<void>} resolves when the project has been created
  */
 exports.createProject = async (project_path, package_name, project_name, opts, root_config) => {
-    package_name = package_name || 'my.cordova.project';
-    project_name = project_name || 'CordovaExample';
+    opts = opts || {};
 
-    // check that project path doesn't exist
+    project_path = path.relative(process.cwd(), project_path);
+
+    // Check if project already exists
     if (fs.existsSync(project_path)) {
         throw new CordovaError('Project already exists');
     }
 
+    package_name = package_name || 'org.apache.cordova.hellocordova';
+    project_name = project_name || 'Hello Cordova';
+
     events.emit('log', 'Creating Cordova project for the iOS platform:');
-    events.emit('log', `\tPath: ${path.relative(process.cwd(), project_path)}`);
+    events.emit('log', `\tPath: ${project_path}`);
     events.emit('log', `\tPackage: ${package_name}`);
     events.emit('log', `\tName: ${project_name}`);
 

--- a/templates/cordova/defaults.xml
+++ b/templates/cordova/defaults.xml
@@ -18,7 +18,7 @@
  under the License.
 -->
 <widget xmlns     = "http://www.w3.org/ns/widgets"
-        id        = "io.cordova.helloCordova"
+        id        = "org.apache.cordova.hellocordova"
         version   = "2.0.0">
 
     <!-- Preferences for iOS -->

--- a/templates/project/App/config.xml
+++ b/templates/project/App/config.xml
@@ -18,9 +18,9 @@
  under the License.
 -->
 <widget xmlns     = "http://www.w3.org/ns/widgets"
-        id        = "io.cordova.helloCordova"
+        id        = "org.apache.cordova.hellocordova"
         version   = "2.0.0">
-    <name>HelloCordova</name>
+    <name>Hello Cordova</name>
 
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/CordovaLibTests/CordovaApp/config.xml
+++ b/tests/CordovaLibTests/CordovaApp/config.xml
@@ -18,7 +18,7 @@
  under the License.
 -->
 <widget xmlns     = "http://www.w3.org/ns/widgets"
-        id        = "io.cordova.helloCordova"
+        id        = "org.apache.cordova.hellocordova"
         version   = "2.0.0">
     <name>Hello Cordova</name>
 

--- a/tests/spec/unit/create.spec.js
+++ b/tests/spec/unit/create.spec.js
@@ -148,7 +148,7 @@ describe('create', () => {
 
     it('should copy config.xml into the newly created project', () => {
         const configPath = path.join(__dirname, 'fixtures', 'test-config-3.xml');
-        const packageName = 'io.cordova.hellocordova.ios';
+        const packageName = 'org.apache.cordova.hellocordova.ios';
         const projectName = 'Hello Cordova';
 
         return verifyCreatedProject(tmpDir, packageName, projectName, false, configPath)

--- a/tests/spec/unit/fixtures/dummyProj/config.xml
+++ b/tests/spec/unit/fixtures/dummyProj/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/icon-support/configs/multi.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/multi.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/icon-support/configs/none.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/none.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/icon-support/configs/single-only.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/single-only.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/icon-support/configs/single-variants.xml
+++ b/tests/spec/unit/fixtures/icon-support/configs/single-variants.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/ios-config-xml/cordova/defaults.xml
+++ b/tests/spec/unit/fixtures/ios-config-xml/cordova/defaults.xml
@@ -18,7 +18,7 @@
  under the License.
 -->
 <widget xmlns     = "http://www.w3.org/ns/widgets"
-        id        = "io.cordova.helloCordova"
+        id        = "org.apache.cordova.hellocordova"
         version   = "2.0.0">
 
     <!-- Preferences for iOS -->

--- a/tests/spec/unit/fixtures/ios-packageswift-config-xml/cordova/defaults.xml
+++ b/tests/spec/unit/fixtures/ios-packageswift-config-xml/cordova/defaults.xml
@@ -18,7 +18,7 @@
  under the License.
 -->
 <widget xmlns     = "http://www.w3.org/ns/widgets"
-        id        = "io.cordova.helloCordova"
+        id        = "org.apache.cordova.hellocordova"
         version   = "2.0.0">
 
     <!-- Preferences for iOS -->

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/legacy-only.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/legacy-only.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-and-legacy.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-and-legacy.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-only.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/modern-only.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/launch-storyboard-support/configs/none.xml
+++ b/tests/spec/unit/fixtures/launch-storyboard-support/configs/none.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-false.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-false.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="*" allows-arbitrary-loads-for-media="false" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-for-media-true.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="*" allows-arbitrary-loads-for-media="true" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-false.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-false.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="*" allows-arbitrary-loads-in-media="false" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-media-true.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="*" allows-arbitrary-loads-in-media="true" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-web-content-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-arbitrary-loads-in-web-content-true.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="*" allows-arbitrary-loads-in-web-content="true" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/allows-local-networking-true.xml
+++ b/tests/spec/unit/fixtures/prepare/allows-local-networking-true.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="*" allows-local-networking="true" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/no-privacy-manifest.xml
+++ b/tests/spec/unit/fixtures/prepare/no-privacy-manifest.xml
@@ -18,6 +18,6 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
 </widget>

--- a/tests/spec/unit/fixtures/prepare/privacy-manifest.xml
+++ b/tests/spec/unit/fixtures/prepare/privacy-manifest.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <platform name="ios">
         <privacy-manifest>

--- a/tests/spec/unit/fixtures/prepare/set-origin-with-mixed-nsallows.xml
+++ b/tests/spec/unit/fixtures/prepare/set-origin-with-mixed-nsallows.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/wildcard-navigation-with-mixed-nsallows.xml
+++ b/tests/spec/unit/fixtures/prepare/wildcard-navigation-with-mixed-nsallows.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <allow-navigation href="http://cordova.apache.org" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/wildcard-navigation.xml
+++ b/tests/spec/unit/fixtures/prepare/wildcard-navigation.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <allow-navigation href="*" />
 </widget>

--- a/tests/spec/unit/fixtures/prepare/wildcard-with-mixed-nsallows.xml
+++ b/tests/spec/unit/fixtures/prepare/wildcard-with-mixed-nsallows.xml
@@ -18,7 +18,7 @@
   under the License.
 -->
 
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>SampleApp</name>
     <access origin="*" allows-arbitrary-loads-in-web-content="true" allows-arbitrary-loads-in-media="true" allows-local-networking="true" />
 </widget>

--- a/tests/spec/unit/fixtures/resource-file-support/config.xml
+++ b/tests/spec/unit/fixtures/resource-file-support/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/test-config-2.xml
+++ b/tests/spec/unit/fixtures/test-config-2.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/test-config-3.xml
+++ b/tests/spec/unit/fixtures/test-config-3.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="org.apache.cordova.hellocordova.android" id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.

--- a/tests/spec/unit/fixtures/test-config.xml
+++ b/tests/spec/unit/fixtures/test-config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.apache.cordova.hellocordova" ios-CFBundleIdentifier="org.apache.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Supersedes and closes https://github.com/apache/cordova-ios/pull/1100


### Description
<!-- Describe your changes in detail -->
* Updated package id/namespace to `org.apache.cordova.hellocordova`
* Use "Hello Cordova" as the default app name


### Testing
<!-- Please describe in detail how you tested your changes. -->
All existing tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass

/fyi @ath0mas 
