### PR TITLE
refactor!: Deprecate CDVWebViewProcessPoolFactory

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -83,7 +83,10 @@
         configuration = _configuration;
     } else {
         configuration = [[WKWebViewConfiguration alloc] init];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         configuration.processPool = [[CDVWebViewProcessPoolFactory sharedFactory] sharedProcessPool];
+#pragma clang diagnostic pop
     }
     
     if (settings == nil) {

--- a/CordovaLib/Classes/Public/CDVWebViewProcessPoolFactory.m
+++ b/CordovaLib/Classes/Public/CDVWebViewProcessPoolFactory.m
@@ -20,6 +20,10 @@
 #import <WebKit/WebKit.h>
 #import <Cordova/CDVWebViewProcessPoolFactory.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 static CDVWebViewProcessPoolFactory *factory = nil;
 
 @implementation CDVWebViewProcessPoolFactory
@@ -46,3 +50,5 @@ static CDVWebViewProcessPoolFactory *factory = nil;
     return _sharedPool;
 }
 @end
+
+#pragma clang diagnostic pop

--- a/CordovaLib/CordovaLib.docc/CordovaLib.md
+++ b/CordovaLib/CordovaLib.docc/CordovaLib.md
@@ -65,6 +65,7 @@ For more information about Apache Cordova, visit [https://cordova.apache.org](ht
 
 - ``IsAtLeastiOSVersion``
 - ``CDVScreenOrientationDelegate``
+- ``CDVWebViewProcessPoolFactory``
 - ``CDVCommandStatus_NO_RESULT`` <!-- Swift alias -->
 - ``CDVCommandStatus_OK`` <!-- Swift alias -->
 - ``CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION`` <!-- Swift alias -->

--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -241,6 +241,12 @@ self.commandDelegate.send(CDVPluginResult(status: .ok), callbackId: command.call
 
 These aliases were introduced in and are backwards compatible with all existing versions since Cordova iOS 5.0.0. See ``CDVCommandStatus`` for a list of the enum values.
 
+### Deprecating CDVWebViewProcessPoolFactory
+
+Apple has deprecated the `WKProcessPool` API, saying that it has no effect in iOS 15 and newer. As such, the `CDVWebViewProcessPoolFactory` API is marked as deprecated, but still exists to support iOS 13 and 14.
+
+The `CDVWebViewProcessPoolFactory` API was also problematic because it exposed WebKit-specific API types to the public API interface of Cordova, potentially causing issues if those APIs need to change in the future. With this deprecation and eventual removal, Cordova is better insulated from upstream WebView changes.
+
 ## Public API Removals
 The following classes were previously exposed as part of the Cordova iOS public API, but were only used as internal implementation details. To better establish the public/private API boundary within Cordova iOS, they have been removed from the public API in Cordova iOS 8.
 

--- a/CordovaLib/include/Cordova/CDVWebViewProcessPoolFactory.h
+++ b/CordovaLib/include/Cordova/CDVWebViewProcessPoolFactory.h
@@ -17,8 +17,16 @@
  under the License.
  */
 
+#import <Cordova/CDVAvailabilityDeprecated.h>
+
 @class WKProcessPool;
 
+/**
+ @Metadata {
+    @Available(Cordova, introduced: "6.2.0", deprecated: "8.0.0")
+ }
+ */
+CDV_DEPRECATED(8.0.0, "WebKit WKProcessPool is deprecated in iOS")
 @interface CDVWebViewProcessPoolFactory : NSObject
 @property (nonatomic, retain) WKProcessPool* sharedPool;
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
WKProcessPool has been marked as deprecated by Apple: https://developer.apple.com/documentation/webkit/wkprocesspool

> Creating and using multiple instances of WKProcessPool no longer has any effect.


### Description
<!-- Describe your changes in detail -->
Mark CDVWebViewProcessPoolFactory as deprecated in Cordova-iOS 8.

I guess technically since this is just a deprecation it's not a breaking change, but it makes sense to do this in a major version just to be safe. I'm not removing it because of plugins and it might still be needed on iOS 13 through 15, and we still technically support those.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass and CordovaLib builds without any warnings


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I've updated the documentation if necessary
