### PR TITLE
chore: Silence some iOS deprecation warnings

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.m
@@ -221,7 +221,11 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
     NSString *type;
     [url getResourceValue:&type forKey:NSURLTypeIdentifierKey error:nil];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassMIMEType);
+#pragma clang diagnostic pop
 }
 
 - (nullable NSData *)readFromFileHandle:(NSFileHandle *)handle upTo:(NSUInteger)length error:(NSError **)err

--- a/CordovaLib/Classes/Public/CDVAppDelegate.m
+++ b/CordovaLib/Classes/Public/CDVAppDelegate.m
@@ -40,6 +40,9 @@
     return YES;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 // this happens while we are running ( in the background, or from within our own app )
 // only valid if Info.plist specifies a protocol to handle
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
@@ -64,12 +67,10 @@
         [openURLData setValue:options[UIApplicationOpenURLOptionsAnnotationKey] forKey:@"annotation"];
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:openURLData]];
-#pragma clang diagnostic pop
 
     return YES;
 }
+#pragma clang diagnostic pop
 
 @end


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
These don't cause issues yet, but if someone bumps the deployment-target higher these will start showing up as warnings.


### Description
<!-- Describe your changes in detail -->
* Silence deprecation warnings about iOS <15 `UTTypeCopyPreferredTagWithClass` usage
* Silence deprecation warnings in iOS >26 about UIApplicationDelegate's `application:openURI:options:` method


### Testing
<!-- Please describe in detail how you tested your changes. -->
Confirmed that a sample app built while targeting iOS SDK 26 with no deprecation warnings (aside from WKProcessPool, which is being handled in #1558)


### Checklist

- [x] I've run the tests to see all new and existing tests pass
