### PR TITLE
feat!: Add CDVSceneDelegate class as an extension point

### DIFF
--- a/CordovaLib/Classes/Public/CDVAppDelegate.m
+++ b/CordovaLib/Classes/Public/CDVAppDelegate.m
@@ -19,7 +19,7 @@
 
 #import <Cordova/CDVAppDelegate.h>
 #import <Cordova/CDVAvailability.h>
-#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVPluginNotifications.h>
 #import <Cordova/CDVViewController.h>
 
 @implementation CDVAppDelegate

--- a/CordovaLib/Classes/Public/CDVSceneDelegate.m
+++ b/CordovaLib/Classes/Public/CDVSceneDelegate.m
@@ -1,0 +1,50 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+#import <Cordova/CDVSceneDelegate.h>
+#import <Cordova/CDVPluginNotifications.h>
+
+@implementation CDVSceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    // If the app was launched from a URL, that should also fire the CDVPluginOpenURLNotification
+    [self scene:scene openURLContexts:connectionOptions.URLContexts];
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+    for (UIOpenURLContext *context in URLContexts) {
+        NSMutableDictionary *options = [[NSMutableDictionary alloc] init];
+        [options setValue:context.options.sourceApplication forKey:@"sourceApplication"];
+        [options setValue:context.options.annotation forKey:@"annotation"];
+        [options setValue:@(context.options.openInPlace) forKey:@"openInPlace"];
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140500
+        if (@available(iOS 14.5, *)) {
+            [options setValue:context.options.eventAttribution forKey:@"eventAttribution"];
+        }
+#endif
+
+        [[NSNotificationCenter defaultCenter] postNotificationName:CDVPluginHandleOpenURLNotification object:context.URL userInfo:options];
+
+    }
+}
+
+@end

--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -93,6 +93,12 @@
 		9036843E2C6EB06500A3338C /* CDVAllowList.m in Sources */ = {isa = PBXBuildFile; fileRef = 9036843C2C6EB06500A3338C /* CDVAllowList.m */; };
 		9036843F2C6EB06500A3338C /* CDVAllowList.m in Sources */ = {isa = PBXBuildFile; fileRef = 9036843C2C6EB06500A3338C /* CDVAllowList.m */; };
 		903684402C6EB06500A3338C /* CDVAllowList.h in Headers */ = {isa = PBXBuildFile; fileRef = 9036843B2C6EB06500A3338C /* CDVAllowList.h */; };
+		9044ED4C2E67F80E003B58ED /* CDVSceneDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9044ED4B2E67F80E003B58ED /* CDVSceneDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9044ED4D2E67F80E003B58ED /* CDVSceneDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9044ED4B2E67F80E003B58ED /* CDVSceneDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9044ED4F2E67F821003B58ED /* CDVSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9044ED4E2E67F821003B58ED /* CDVSceneDelegate.m */; };
+		9044ED502E67F821003B58ED /* CDVSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9044ED4E2E67F821003B58ED /* CDVSceneDelegate.m */; };
+		9044ED532E67FEBB003B58ED /* CDVPluginNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 9044ED522E67FEBB003B58ED /* CDVPluginNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9044ED542E67FEBB003B58ED /* CDVPluginNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 9044ED522E67FEBB003B58ED /* CDVPluginNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9047732F2C7A57E900373636 /* CDVURLSchemeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9047732D2C7A57E900373636 /* CDVURLSchemeHandler.h */; };
 		904773302C7A57E900373636 /* CDVURLSchemeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9047732E2C7A57E900373636 /* CDVURLSchemeHandler.m */; };
 		904773312C7A57E900373636 /* CDVURLSchemeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9047732D2C7A57E900373636 /* CDVURLSchemeHandler.h */; };
@@ -207,6 +213,9 @@
 		902D0BC12AEB64EB009C68E5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		9036843B2C6EB06500A3338C /* CDVAllowList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVAllowList.h; sourceTree = "<group>"; };
 		9036843C2C6EB06500A3338C /* CDVAllowList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVAllowList.m; sourceTree = "<group>"; };
+		9044ED4B2E67F80E003B58ED /* CDVSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVSceneDelegate.h; sourceTree = "<group>"; };
+		9044ED4E2E67F821003B58ED /* CDVSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVSceneDelegate.m; sourceTree = "<group>"; };
+		9044ED522E67FEBB003B58ED /* CDVPluginNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVPluginNotifications.h; sourceTree = "<group>"; };
 		9047732D2C7A57E900373636 /* CDVURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVURLSchemeHandler.h; sourceTree = "<group>"; };
 		9047732E2C7A57E900373636 /* CDVURLSchemeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVURLSchemeHandler.m; sourceTree = "<group>"; };
 		9068B5322C6DFE2000B13532 /* CDVSettingsDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVSettingsDictionary.h; sourceTree = "<group>"; };
@@ -349,6 +358,7 @@
 				7ED95D1E1AB9029B008C4574 /* CDVPlugin+Resources.m */,
 				7ED95D201AB9029B008C4574 /* CDVPlugin.m */,
 				7ED95D221AB9029B008C4574 /* CDVPluginResult.m */,
+				9044ED4E2E67F821003B58ED /* CDVSceneDelegate.m */,
 				9068B5352C6E007400B13532 /* CDVSettingsDictionary.m */,
 				7ED95D251AB9029B008C4574 /* CDVTimer.m */,
 				4E23F8F523E16E96006CD852 /* CDVWebViewProcessPoolFactory.m */,
@@ -391,7 +401,9 @@
 				7ED95D1B1AB9029B008C4574 /* CDVInvokedUrlCommand.h */,
 				7ED95D1D1AB9029B008C4574 /* CDVPlugin+Resources.h */,
 				7ED95D1F1AB9029B008C4574 /* CDVPlugin.h */,
+				9044ED522E67FEBB003B58ED /* CDVPluginNotifications.h */,
 				7ED95D211AB9029B008C4574 /* CDVPluginResult.h */,
+				9044ED4B2E67F80E003B58ED /* CDVSceneDelegate.h */,
 				7ED95D231AB9029B008C4574 /* CDVScreenOrientationDelegate.h */,
 				9068B5322C6DFE2000B13532 /* CDVSettingsDictionary.h */,
 				7ED95D241AB9029B008C4574 /* CDVTimer.h */,
@@ -425,7 +437,9 @@
 				C0C01EBB1E39131A0056E6CB /* CDV.h in Headers */,
 				C0C01EBC1E39131A0056E6CB /* CDVAppDelegate.h in Headers */,
 				9068B5332C6DFE2000B13532 /* CDVSettingsDictionary.h in Headers */,
+				9044ED532E67FEBB003B58ED /* CDVPluginNotifications.h in Headers */,
 				C0C01EBD1E39131A0056E6CB /* CDVAvailability.h in Headers */,
+				9044ED4D2E67F80E003B58ED /* CDVSceneDelegate.h in Headers */,
 				C0C01EBE1E39131A0056E6CB /* CDVAvailabilityDeprecated.h in Headers */,
 				C0C01EBF1E39131A0056E6CB /* CDVCommandDelegate.h in Headers */,
 				C0C01EC01E39131A0056E6CB /* CDVCommandDelegateImpl.h in Headers */,
@@ -467,7 +481,9 @@
 				7ED95D361AB9029B008C4574 /* CDVAppDelegate.h in Headers */,
 				7ED95D381AB9029B008C4574 /* CDVAvailability.h in Headers */,
 				9068B5342C6DFE2000B13532 /* CDVSettingsDictionary.h in Headers */,
+				9044ED542E67FEBB003B58ED /* CDVPluginNotifications.h in Headers */,
 				7ED95D391AB9029B008C4574 /* CDVAvailabilityDeprecated.h in Headers */,
+				9044ED4C2E67F80E003B58ED /* CDVSceneDelegate.h in Headers */,
 				7ED95D3A1AB9029B008C4574 /* CDVCommandDelegate.h in Headers */,
 				7ED95D3B1AB9029B008C4574 /* CDVCommandDelegateImpl.h in Headers */,
 				7ED95D3D1AB9029B008C4574 /* CDVCommandQueue.h in Headers */,
@@ -599,6 +615,7 @@
 				902B30742C6C5A7E00C6804C /* CordovaLib.docc in Sources */,
 				9052DE742150D040008E83D4 /* CDVConfigParser.m in Sources */,
 				9052DE752150D040008E83D4 /* CDVInvokedUrlCommand.m in Sources */,
+				9044ED502E67F821003B58ED /* CDVSceneDelegate.m in Sources */,
 				9052DE762150D040008E83D4 /* CDVPlugin+Resources.m in Sources */,
 				9068B5362C6E007400B13532 /* CDVSettingsDictionary.m in Sources */,
 				9052DE772150D040008E83D4 /* CDVPlugin.m in Sources */,
@@ -632,6 +649,7 @@
 				902B30752C6C5A7E00C6804C /* CordovaLib.docc in Sources */,
 				7ED95D401AB9029B008C4574 /* CDVConfigParser.m in Sources */,
 				7ED95D421AB9029B008C4574 /* CDVInvokedUrlCommand.m in Sources */,
+				9044ED4F2E67F821003B58ED /* CDVSceneDelegate.m in Sources */,
 				7ED95D441AB9029B008C4574 /* CDVPlugin+Resources.m in Sources */,
 				9068B5372C6E007400B13532 /* CDVSettingsDictionary.m in Sources */,
 				7ED95D461AB9029B008C4574 /* CDVPlugin.m in Sources */,

--- a/CordovaLib/include/Cordova/CDVPlugin.h
+++ b/CordovaLib/include/Cordova/CDVPlugin.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <Cordova/CDVAvailabilityDeprecated.h>
+#import <Cordova/CDVPluginNotifications.h>
 #import <Cordova/CDVPluginResult.h>
 #import <Cordova/CDVCommandDelegate.h>
 #import <Cordova/CDVSettingsDictionary.h>
@@ -43,18 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) UIScrollView* scrollView CDV_DEPRECATED(8, "Check for a scrollView property on the view object at runtime and invoke it dynamically.");
 @end
 #endif
-
-extern const NSNotificationName CDVPageDidLoadNotification;
-extern const NSNotificationName CDVPluginHandleOpenURLNotification;
-extern const NSNotificationName CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification CDV_DEPRECATED(8, "Find sourceApplication and annotations in the userInfo of the CDVPluginHandleOpenURLNotification notification.");
-extern const NSNotificationName CDVPluginResetNotification;
-extern const NSNotificationName CDVViewWillAppearNotification;
-extern const NSNotificationName CDVViewDidAppearNotification;
-extern const NSNotificationName CDVViewWillDisappearNotification;
-extern const NSNotificationName CDVViewDidDisappearNotification;
-extern const NSNotificationName CDVViewWillLayoutSubviewsNotification;
-extern const NSNotificationName CDVViewDidLayoutSubviewsNotification;
-extern const NSNotificationName CDVViewWillTransitionToSizeNotification;
 
 NS_ASSUME_NONNULL_END
 

--- a/CordovaLib/include/Cordova/CDVPluginNotifications.h
+++ b/CordovaLib/include/Cordova/CDVPluginNotifications.h
@@ -1,0 +1,34 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Cordova/CDVAvailabilityDeprecated.h>
+
+extern const NSNotificationName CDVPageDidLoadNotification;
+extern const NSNotificationName CDVPluginHandleOpenURLNotification;
+extern const NSNotificationName CDVPluginResetNotification;
+extern const NSNotificationName CDVViewWillAppearNotification;
+extern const NSNotificationName CDVViewDidAppearNotification;
+extern const NSNotificationName CDVViewWillDisappearNotification;
+extern const NSNotificationName CDVViewDidDisappearNotification;
+extern const NSNotificationName CDVViewWillLayoutSubviewsNotification;
+extern const NSNotificationName CDVViewDidLayoutSubviewsNotification;
+extern const NSNotificationName CDVViewWillTransitionToSizeNotification;
+
+extern const NSNotificationName CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification CDV_DEPRECATED(8, "Find sourceApplication and annotations in the userInfo of the CDVPluginHandleOpenURLNotification notification.");

--- a/CordovaLib/include/Cordova/CDVSceneDelegate.h
+++ b/CordovaLib/include/Cordova/CDVSceneDelegate.h
@@ -1,0 +1,53 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ UI scene delegate class with some additional Cordova-specific behavior.
+
+ The scene delegate object manages your app’s window behaviors. Your app should
+ include its own SceneDelegate class which is a subclass of `CDVSceneDelegate`.
+
+ `CDVSceneDelegate` provides an extension point for Cordova plugins to safely
+ add behavior to the app by building on system events such as URL handling and
+ scene/window management.
+
+ See `UIWindowSceneDelegate` for more details about app delegates.
+
+ @Metadata {
+   @Available(Cordova, introduced: "8.0.0")
+ }
+*/
+@interface CDVSceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+/**
+ The application window for the current UI scene.
+
+ @Metadata {
+   @Available(Cordova, introduced: "8.0.0")
+ }
+*/
+@property (strong, nonatomic) UIWindow *window;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CordovaLib/include/Cordova/Cordova.h
+++ b/CordovaLib/include/Cordova/Cordova.h
@@ -22,7 +22,9 @@
 #import <Cordova/CDVAvailability.h>
 #import <Cordova/CDVAvailabilityDeprecated.h>
 #import <Cordova/CDVAppDelegate.h>
+#import <Cordova/CDVSceneDelegate.h>
 #import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVPluginNotifications.h>
 #import <Cordova/CDVPluginResult.h>
 #import <Cordova/CDVViewController.h>
 #import <Cordova/CDVCommandDelegate.h>

--- a/templates/project/App/SceneDelegate.swift
+++ b/templates/project/App/SceneDelegate.swift
@@ -17,9 +17,8 @@
  under the License.
 */
 
-import UIKit
+import Cordova
 
-class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    var window: UIWindow?
+class SceneDelegate: CDVSceneDelegate {
 }
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In cordova-ios 8 we've added a SceneDelegate to the generated template app, and in iOS 26 Apple starting to make UISceneDelegates mandatory.

In light of that, and deprecations around UIApplicationDelegate URL handling, it makes sense to have a Cordova UISceneDelegate class that does URL handling and exists as an extension point for plugins.


### Description
<!-- Describe your changes in detail -->
* Added `CDVSceneDelegate` as public API
* Changed the template to extend from `CDVSceneDelegate`
* Implemented URL handling in `CDVSceneDelegate` to fire `CDVPluginHandleOpenURLNotification`
* Refactored plugin notifications out into their own header file


### Testing
<!-- Please describe in detail how you tested your changes. -->
Sample application builds and runs.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] I've updated the documentation if necessary
