### PR TITLE
chore: Xcode 26 fixes for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x]
-        os: [macos-15]
+        os: [macos-15, macos-26]
 
     steps:
       - uses: actions/checkout@v4
@@ -45,11 +45,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Use latest stable Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
 
       - name: Environment Information
         run: |

--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -754,6 +754,7 @@
 				PRODUCT_NAME = Cordova;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
 			name = Debug;
 		};
@@ -820,6 +821,7 @@
 				PRODUCT_NAME = Cordova;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/lib/build.js
+++ b/lib/build.js
@@ -190,7 +190,7 @@ module.exports.run = function (buildOpts) {
                     if (!theTarget) {
                         return getDefaultSimulatorTarget().then(defaultTarget => {
                             emulatorTarget = defaultTarget.name;
-                            events.emit('warn', `No simulator found for "${newTarget}. Falling back to the default target.`);
+                            events.emit('warn', `No simulator found for "${newTarget}". Falling back to the default target.`);
                             events.emit('log', `Building for "${emulatorTarget}" Simulator (${defaultTarget.identifier}, ${defaultTarget.simIdentifier}).`);
                             return emulatorTarget;
                         });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npm run coverage && npm run objc-tests",
     "coverage": "c8 jasmine --config=tests/spec/coverage.json",
     "e2e-tests": "jasmine tests/spec/create.spec.js",
-    "objc-tests": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -scheme CordovaTestApp -destination \"platform=iOS Simulator,name=${CDV_IOS_SIM:-iPhone SE (3rd generation)}\" -derivedDataPath \"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
+    "objc-tests": "xcodebuild -quiet test -workspace tests/cordova-ios.xcworkspace -scheme CordovaTestApp -destination \"platform=iOS Simulator,name=${CDV_IOS_SIM:-iPhone 16e}\" -derivedDataPath \"`mktemp -d 2>/dev/null || mktemp -d -t 'cordova-ios'`\"",
     "preobjc-tests": "killall Simulator || true",
     "unit-tests": "jasmine --config=tests/spec/unit.json",
     "lint": "eslint ."

--- a/templates/project/App.xcodeproj/project.pbxproj
+++ b/templates/project/App.xcodeproj/project.pbxproj
@@ -207,7 +207,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1540;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					90BD9B6B2C06907D000DEBAB = {
 						CreatedOnToolsVersion = 15.4;
@@ -350,6 +350,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
@@ -417,6 +418,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/templates/project/App.xcworkspace/xcshareddata/xcschemes/App.xcscheme
+++ b/templates/project/App.xcworkspace/xcshareddata/xcschemes/App.xcscheme
@@ -18,7 +18,7 @@
    under the License.
 -->
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "2600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -32,7 +32,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+               BlueprintIdentifier = "90BD9B6B2C06907D000DEBAB"
                BuildableName = "App.app"
                BlueprintName = "App"
                ReferencedContainer = "container:App.xcodeproj">
@@ -45,19 +45,17 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BlueprintIdentifier = "90BD9B6B2C06907D000DEBAB"
             BuildableName = "App.app"
             BlueprintName = "App"
             ReferencedContainer = "container:App.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -73,14 +71,12 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BlueprintIdentifier = "90BD9B6B2C06907D000DEBAB"
             BuildableName = "App.app"
             BlueprintName = "App"
             ReferencedContainer = "container:App.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -92,7 +88,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BlueprintIdentifier = "90BD9B6B2C06907D000DEBAB"
             BuildableName = "App.app"
             BlueprintName = "App"
             ReferencedContainer = "container:App.xcodeproj">

--- a/tests/spec/createAndBuild.spec.js
+++ b/tests/spec/createAndBuild.spec.js
@@ -81,8 +81,9 @@ function verifyBuild (tmpDir) {
     );
 
     const Api = require(path.join(tmpDir, 'cordova', 'Api.js'));
+    const target = process.env.CDV_IOS_SIM?.replace(/\s/g, '-') ?? 'iPhone-16e';
 
-    return expectAsync(new Api('ios', tmpDir).build({ emulator: true, buildFlag: ['-quiet'] }))
+    return expectAsync(new Api('ios', tmpDir).build({ emulator: true, buildFlag: ['-quiet'], target }))
         .toBeResolved();
 }
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
CI builds are failing due to Xcode version shenanigans


### Description
<!-- Describe your changes in detail -->
* Use the `CDV_IOS_SIM` environment variable to control the simulator version used for the spec tests as well as the integration tests
* Use a default of "iPhone 16e" for `CDV_IOS_SIM` (since that is available in both Xcode 16.4 and 26 with iOS 18 and 26 in GHA)
* Update the Xcode projects to the latest Xcode settings


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested locally with Xcode 26 and on GHA CI with Xcode 16.4 and 26


### Checklist

- [x] I've run the tests to see all new and existing tests pass