### PR TITLE
Simplify Objective-C scrollView access in upgrading-8.md

### DIFF
--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -132,8 +132,6 @@ UIScrollView *scrollView = self.webView.scrollView;
 // New code (Objective-C)
 #import <objc/message.h>
 
-UIScrollView *scrollView;
-
 if ([self.webView respondsToSelector:@selector(scrollView)]) {
     UIScrollView *scrollView = [self.webView performSelector:@selector(scrollView)];
 }

--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -125,18 +125,17 @@ You can still access the `scrollView` property of the web view by dynamically in
 
 ```objc
 // Old code
-UIScrollView *scroller = self.webView.scrollView;
+UIScrollView *scrollView = self.webView.scrollView;
 ```
 
 ```objc
 // New code (Objective-C)
 #import <objc/message.h>
 
-UIScrollView *scroller;
-SEL scrollViewSelector = NSSelectorFromString(@"scrollView");
+UIScrollView *scrollView;
 
-if ([self.webView respondsToSelector:scrollViewSelector]) {
-    scroller = ((id (*)(id, SEL))objc_msgSend)(self.webView, scrollViewSelector);
+if ([self.webView respondsToSelector:@selector(scrollView)]) {
+    UIScrollView *scrollView = [self.webView performSelector:@selector(scrollView)];
 }
 ```
 

--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -130,8 +130,6 @@ UIScrollView *scrollView = self.webView.scrollView;
 
 ```objc
 // New code (Objective-C)
-#import <objc/message.h>
-
 if ([self.webView respondsToSelector:@selector(scrollView)]) {
     UIScrollView *scrollView = [self.webView performSelector:@selector(scrollView)];
 }


### PR DESCRIPTION
Simplified code examples for accessing scrollView property dynamically in Objective-C.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
The code example for objective-c to access the deprecated scrollview was to complex and can be made easier.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
