### PR TITLE
test: Fix some warnings from NSKeyedUnarchiver in tests

### DIFF
--- a/tests/CordovaLibTests/CDVSettingsDictionaryTests.m
+++ b/tests/CordovaLibTests/CDVSettingsDictionaryTests.m
@@ -80,8 +80,14 @@ static NSDictionary *testSettings;
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:dict requiringSecureCoding:YES error:&err];
     XCTAssertNil(err);
 
+    NSSet<Class> *classes = [NSSet setWithArray:@[
+      CDVSettingsDictionary.class,
+      NSNumber.class,
+      NSString.class,
+    ]];
+
     err = nil;
-    id result = [NSKeyedUnarchiver unarchivedObjectOfClass:[CDVSettingsDictionary class] fromData:data error:&err];
+    id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:&err];
     XCTAssertNil(err);
 
     XCTAssertTrue([dict isEqualToDictionary:result], @"Not equal to creating dictionary");


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Objective C tests were warning about deserializing NSStrings with NSKeyedUnarchiver when the allowed class list contained only CDVSettingsDictionary.


### Description
<!-- Describe your changes in detail -->
Add NSString, NSNumber, and CDVSettingsDictionary as allowed classes for deserializing in the test.

This has no impact on application or library code, it's only related to testing.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran ObjC tests and confirmed they all pass with no warnings about NSKeyedUnarchiver


### Checklist

- [x] I've run the tests to see all new and existing tests pass
