### PR TITLE
fix(cache): Don't load local data from cache

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -323,7 +323,7 @@
             NSURL* readAccessUrl = [request.URL URLByDeletingLastPathComponent];
             return [(WKWebView*)_engineWebView loadFileURL:request.URL allowingReadAccessToURL:readAccessUrl];
         } else if (request.URL.fileURL) {
-            NSURL* startURL = [NSURL URLWithString:((CDVViewController *)self.viewController).startPage];
+            NSURL* startURL = [NSURL URLWithString:self.viewController.startPage];
             NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
             NSURL *url = [[NSURL URLWithString:self.CDV_ASSETS_URL] URLByAppendingPathComponent:request.URL.path];
             if ([request.URL.path isEqualToString:startFilePath]) {
@@ -335,7 +335,8 @@
             if(request.URL.fragment) {
                 url = [NSURL URLWithString:[@"#" stringByAppendingString:request.URL.fragment] relativeToURL:url];
             }
-            request = [NSURLRequest requestWithURL:url];
+            // We ignore any existing cached data, since we're already loading it from the filesystem
+            request = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:request.timeoutInterval];
         }
         return [(WKWebView*)_engineWebView loadRequest:request];
     } else { // can't load, print out error


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I'm hoping this will resolve the underlying problem from #1451 & #1471 with a smaller scope of change. 


### Description
<!-- Describe your changes in detail -->
In this case, we only set the cache policy to ignore the local cache when we know that it's being loaded from the filesystem with a custom app scheme.

We can't override the cache policy for the file scheme, and it seems better to use the existing default cache policy for things being loaded over http or https schemes.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
