### PR TITLE
docs: Add note about CDVPluginResult Swift nullability

### DIFF
--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -167,6 +167,26 @@ import Foundation
 import UIKit
 ```
 
+### `CDVPluginResult` Swift optionality
+
+The `CDVPluginResult` constructors have been annotated as returning a non-null object, which means the constructor in Swift no longer returns an optional value that needs to be unwrapped. However, this means that attempts to unwrap the value will now be errors.
+
+In most cases, you shouldn't need to worry about the optionality of the result before passing it to `commandDelegate.send` but if you are setting other options then you might need to explicitly store as an optional for backwards compatibility:
+
+```swift
+// Old code (Swift)
+let result = CDVPluginResult(status: .ok, messageAs: "some value")!
+result.setKeepCallbackAs(true)
+self.commandDelegate.send(result, callbackId: callback)
+```
+
+```swift
+// New code (Swift)
+let result: CDVPluginResult? = CDVPluginResult(status: .ok, messageAs: "some value")
+result?.setKeepCallbackAs(true)
+self.commandDelegate.send(result, callbackId: callback)
+```
+
 ## Other Major Changes
 ### Deprecating AppDelegate category extensions
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1574.


### Description
<!-- Describe your changes in detail -->
Added a note to the Cordova iOS 8 upgrade guide about `CDVPluginResult` nullability changing and how that potentially impacts Swift plugins that try to force unwrap results.

### Checklist

- [x] I've updated the documentation if necessary
