### PR TITLE
fix(statusbar): inject script block to compute color

### DIFF
--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -23,6 +23,10 @@ var exec = require('cordova/exec');
 var statusBarVisible = true;
 var statusBar = {};
 
+// This <script> element is explicitly used by Cordova's statusbar for computing color. (Do not use this element)
+const statusBarScript = document.createElement('script');
+document.head.appendChild(statusBarScript);
+
 Object.defineProperty(statusBar, 'visible', {
     configurable: false,
     enumerable: true,
@@ -54,9 +58,8 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
     enumerable: false,
     writable: false,
     value: function (value) {
-        var script = document.querySelector('script[src$="cordova.js"]');
-        script.style.color = value;
-        var rgbStr = window.getComputedStyle(script).getPropertyValue('color');
+        statusBarScript.style.color = value;
+        var rgbStr = window.getComputedStyle(statusBarScript).getPropertyValue('color');
 
         if (!rgbStr.match(/^rgb/)) {
             return;


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
People flagged some issues with how we were retrieving the cordova.js script tag, so injecting our own for styling purposes seems like the best option. This now matches the behaviour on Android.

/fyi @Chuckytuh @OS-kepatotorica
