### PR TITLE
fix(openURL): Use correct property name for readyState

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVHandleOpenURL/CDVHandleOpenURL.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVHandleOpenURL/CDVHandleOpenURL.m
@@ -64,7 +64,7 @@
     };
 
     if (!pageLoaded) {
-        NSString* jsString = @"document.readystate";
+        NSString* jsString = @"document.readyState";
         [self.webViewEngine evaluateJavaScript:jsString
                              completionHandler:^(id object, NSError* error) {
             if ((error == nil) && [object isKindOfClass:[NSString class]]) {


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1580.


### Description
<!-- Describe your changes in detail -->
Fix the property name from `document.readystate` to `document.readyState` for checking if the page has loaded.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
