### PR TITLE
fix: ignore spm build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ coverage/
 npm-debug.log
 .nyc_output/
 **/www/cordova.js
+
+# Swift Package Manager (SPM) build artifacts
+.build/


### PR DESCRIPTION
- The Swift Package Manager (SPM)  creates a `.build` directory, which must not be checked in to git

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
