### PR TITLE
chore: Remove compileBitcode from export options

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -263,7 +263,7 @@ module.exports.run = function (buildOpts) {
 
             const project = createProjectObject(projectPath);
             const bundleIdentifier = project.getPackageName();
-            const exportOptions = { ...buildOpts.exportOptions, compileBitcode: false, method: 'development' };
+            const exportOptions = { ...buildOpts.exportOptions, method: 'development' };
 
             if (buildOpts.packageType) {
                 exportOptions.method = buildOpts.packageType;


### PR DESCRIPTION
BREAKING_CHANGE

cordova-ios 8 removed `ENABLE_BITCODE = NO` from the iOS template, but we are still setting it to false in the export options.

I think we should remove that since it's not recommended and Apple removed the setting from Xcode on version 16.

It's breaking as some old plugins probably still require it, but they should most likely already be broken when building for testing since the template doesn't include `ENABLE_BITCODE = NO` anymore. 

Also I don't see it on `xcodebuild -help` output for Xcode 16/26, so it's most likely removed and have no effect.