### PR TITLE
fix: add details for deprecation of `CDVWebViewProcessPoolFactory``

### DIFF
--- a/CordovaLib/include/Cordova/CDVWebViewProcessPoolFactory.h
+++ b/CordovaLib/include/Cordova/CDVWebViewProcessPoolFactory.h
@@ -22,8 +22,15 @@
 @class WKProcessPool;
 
 /**
- Apple deprecated the use of WKProcessPool since iOS 15.0 with the reason:
- Creating and using multiple instances of WKProcessPool no longer has any effect.
+   Apple has deprecated the WKProcessPool API, saying that it has no effect
+   in iOS 15 and newer. As such, the CDVWebViewProcessPoolFactory API is
+   marked as deprecated, but still exists to support iOS 13 and 14.
+
+   The CDVWebViewProcessPoolFactory API was also problematic because it
+   exposed WebKit-specific API types to the public API interface of Cordova,
+   potentially causing issues if those APIs need to change in the future. 
+   With this deprecation and eventual removal, Cordova is better insulated
+   from upstream WebView changes.
  @Metadata {
     @Available(Cordova, introduced: "6.2.0", deprecated: "8.0.0")
  }


### PR DESCRIPTION
- WKProcessPool is deprecated since iOS 15.0
- Add deprecation reason from Apple: `Creating and using multiple instances of WKProcessPool no longer has any effect.`

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
