### PR TITLE
fix(webview): Ensure scheme task is always finished

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.m
@@ -179,12 +179,15 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
         plugin = [self.handlerMap objectForKey:urlSchemeTask];
     }
 
-    if (![plugin isEqual:[NSNull null]] && [plugin respondsToSelector:@selector(stopSchemeTask:)]) {
-        [plugin stopSchemeTask:urlSchemeTask];
-    }
-
     @synchronized(self.handlerMap) {
         [self.handlerMap removeObjectForKey:urlSchemeTask];
+    }
+
+    if ([plugin isEqual:[NSNull null]]) {
+        // NSNull means we own this task, so we need to mark it as finished
+        [urlSchemeTask didFinish];
+    } else if ([plugin respondsToSelector:@selector(stopSchemeTask:)]) {
+        [plugin stopSchemeTask:urlSchemeTask];
     }
 }
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1605.


### Description
<!-- Describe your changes in detail -->
Ensure that we always mark a scheme task that we are handling as being completed when it is cancelled.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
