### PR TITLE
fix(scheme): Fix /_app_file_/ URLs not working

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVURLSchemeHandler.m
@@ -197,7 +197,7 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
     if ([url.path hasPrefix:@"/_app_file_"]) {
         NSString *path = [url.path stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
-        filePath = [resDir URLByAppendingPathComponent:path];
+        filePath = [NSURL fileURLWithPath:path relativeToURL:resDir];
     } else {
         if ([url.path isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
             filePath = [resDir URLByAppendingPathComponent:self.viewController.startPage];

--- a/tests/CordovaLibTests/CDVSettingsDictionarySwiftTests.swift
+++ b/tests/CordovaLibTests/CDVSettingsDictionarySwiftTests.swift
@@ -18,6 +18,7 @@
  */
 
 import XCTest
+import Cordova
 
 let testSettings = [
     "disallowoverscroll": true

--- a/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m
+++ b/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m
@@ -1,0 +1,71 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+#import <XCTest/XCTest.h>
+#import "CDVURLSchemeHandler.h"
+
+#import "CordovaApp-Swift.h"
+
+@interface CDVURLSchemeHandler (Testing)
+- (NSURL *)fileURLForRequestURL:(NSURL *)url;
+@end
+
+@interface CDVURLSchemeHandlerTest : XCTestCase
+
+@property AppDelegate* appDelegate;
+@property (nonatomic, strong) CDVViewController* viewController;
+
+@end
+
+@implementation CDVURLSchemeHandlerTest
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
+    [self.appDelegate createViewController];
+    self.viewController = self.appDelegate.testViewController;
+}
+
+- (void)tearDown
+{
+    [self.appDelegate destroyViewController];
+    [super tearDown];
+}
+
+- (void)testFileURLForRequestURL
+{
+    CDVURLSchemeHandler *handler = [[CDVURLSchemeHandler alloc] initWithViewController:self.viewController];
+    NSURL *resDir = [[NSBundle mainBundle] URLForResource:self.viewController.webContentFolderName withExtension:nil];
+    NSURL *result = nil;
+
+    NSURL *appFileURL = [NSURL URLWithString:@"app://localhost/_app_file_/etc/hosts"];
+    result = [handler fileURLForRequestURL:appFileURL];
+
+    XCTAssertEqualObjects([result absoluteString], @"file:///etc/hosts");
+
+    NSURL *resourceURL = [NSURL URLWithString:@"app://localhost/img/cordova.png"];
+    result = [handler fileURLForRequestURL:resourceURL];
+
+    NSString *expected = [NSString stringWithFormat:@"%@img/cordova.png", [resDir absoluteString]];
+    XCTAssertEqualObjects([result absoluteString], expected);
+}
+
+@end

--- a/tests/CordovaLibTests/CordovaTests.xcodeproj/project.pbxproj
+++ b/tests/CordovaLibTests/CordovaTests.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		90A775DD2C6F257500FC5BB0 /* CDVSettingsDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90A775DC2C6F256D00FC5BB0 /* CDVSettingsDictionaryTests.m */; };
 		90AE8F9C2EBF03F600FF0979 /* CDVWebViewEngineTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E23F90123E175AD006CD852 /* CDVWebViewEngineTest.m */; };
 		90AE8F9E2EBF0E0700FF0979 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AE8F9D2EBF0E0300FF0979 /* SceneDelegate.swift */; };
+		90D08FEB2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 90D08FEA2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m */; };
+		90D08FED2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D08FEC2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift */; };
 		C0FA7CA11E4BB6420077B045 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = F8EB14D0165FFD3200616F39 /* config.xml */; };
 		C0FA7CA21E4BB6420077B045 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7EF33BD61911ABA20048544E /* Default-568h@2x.png */; };
 		C0FA7CA41E4BB6420077B045 /* www in Resources */ = {isa = PBXBuildFile; fileRef = 30F8AE1C152129DA006625B3 /* www */; };
@@ -92,6 +94,8 @@
 		9085EE2F2CF05B5900603B73 /* CordovaTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CordovaTests.xctestplan; sourceTree = "<group>"; };
 		90A775DC2C6F256D00FC5BB0 /* CDVSettingsDictionaryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVSettingsDictionaryTests.m; sourceTree = "<group>"; };
 		90AE8F9D2EBF0E0300FF0979 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		90D08FEA2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVURLSchemeHandlerTest.m; sourceTree = "<group>"; };
+		90D08FEC2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDVSettingsDictionarySwiftTests.swift; sourceTree = "<group>"; };
 		C0FA7CAA1E4BB6420077B045 /* CordovaApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CordovaApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0FA7CAC1E4BB6B30077B045 /* Cordova.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cordova.framework; path = "../Debug-iphonesimulator/Cordova.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0FA7CC71E4BBBBE0077B045 /* CordovaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CordovaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -185,6 +189,8 @@
 		EB3B34F4161B585D003DBE7D /* CordovaTests */ = {
 			isa = PBXGroup;
 			children = (
+				90D08FEC2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift */,
+				90D08FEA2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m */,
 				90A775DC2C6F256D00FC5BB0 /* CDVSettingsDictionaryTests.m */,
 				902530FA29A6DC53004AF1CF /* CDVPluginInitTests.m */,
 				4E23F90123E175AD006CD852 /* CDVWebViewEngineTest.m */,
@@ -340,10 +346,12 @@
 				90AE8F9C2EBF03F600FF0979 /* CDVWebViewEngineTest.m in Sources */,
 				C0FA7CB61E4BBBBE0077B045 /* CDVPluginResultJSONSerializationTests.m in Sources */,
 				902530FC29A6DC53004AF1CF /* CDVPluginInitTests.m in Sources */,
+				90D08FED2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift in Sources */,
 				C0FA7CB91E4BBBBE0077B045 /* CDVBase64Tests.m in Sources */,
 				90A775DD2C6F257500FC5BB0 /* CDVSettingsDictionaryTests.m in Sources */,
 				C0FA7CBA1E4BBBBE0077B045 /* CDVFakeFileManager.m in Sources */,
 				C0FA7CBB1E4BBBBE0077B045 /* CDVViewControllerTest.m in Sources */,
+				90D08FEB2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m in Sources */,
 				C0FA7CBC1E4BBBBE0077B045 /* CDVInvokedUrlCommandTests.m in Sources */,
 				C0FA7CBF1E4BBBBE0077B045 /* CDVCommandDelegateTests.m in Sources */,
 			);
@@ -592,6 +600,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CordovaApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CordovaApp";
 				USER_HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../CordovaLib/Classes/Private/**",
@@ -627,6 +636,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.cordova.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CordovaApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CordovaApp";
 				USER_HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../CordovaLib/Classes/Private/**",


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1607.


### Description
<!-- Describe your changes in detail -->
During refactoring of the URLSchemeTask handler for cordova-ios 8, an error was introduced where `/_app_file_` URLs were treated as being relative to the resources directory rather than as filesystem paths.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added Xcode unit test to confirm correct URLs are returned by the scheme handler.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))