### PR TITLE
chore: set swift-tools-version to 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /**
     Licensed to the Apache Software Foundation (ASF) under one

--- a/templates/project/packages/cordova-ios-plugins/Package.swift
+++ b/templates/project/packages/cordova-ios-plugins/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/spec/fixtures/ios-config-xml/CordovaPlugins/Package.swift
+++ b/tests/spec/fixtures/ios-config-xml/CordovaPlugins/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/spec/fixtures/ios-packageswift-config-xml/CordovaPlugins/Package.swift
+++ b/tests/spec/fixtures/ios-packageswift-config-xml/CordovaPlugins/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/spec/fixtures/ios-packageswift-config-xml/packages/cordova-ios-plugins/Package.swift
+++ b/tests/spec/fixtures/ios-packageswift-config-xml/packages/cordova-ios-plugins/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/spec/fixtures/ios-packageswift-config-xml/packages/cordova-ios/Package.swift
+++ b/tests/spec/fixtures/ios-packageswift-config-xml/packages/cordova-ios/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/spec/fixtures/org.test.plugins.swiftpackagecocoapodplugin/Package.swift
+++ b/tests/spec/fixtures/org.test.plugins.swiftpackagecocoapodplugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/spec/fixtures/org.test.plugins.swiftpackageplugin/Package.swift
+++ b/tests/spec/fixtures/org.test.plugins.swiftpackageplugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/spec/fixtures/test-Package.swift
+++ b/tests/spec/fixtures/test-Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 /*
  Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
Since we require Xcode 15.0 or newer, we can safely set the swift-tools-version to 5.9.