### PR TITLE
fix(spm): Set deployment target in Package.swift

### DIFF
--- a/lib/SwiftPackage.js
+++ b/lib/SwiftPackage.js
@@ -40,6 +40,18 @@ package.targets.first?.dependencies.append(.product(name: "${plugin.id}", packag
 `;
     }
 
+    updateDeploymentTarget (target) {
+        const fd = fs.openSync(this.path, 'r+');
+        let packageContent = fs.readFileSync(fd, 'utf8');
+
+        packageContent = packageContent.replace(/\.iOS\(\.v[0-9]+\)/, `.iOS("${target}")`);
+        packageContent = packageContent.replace(/\.macCatalyst\(\.v[0-9]+\)/, `.macCatalyst("${target}")`);
+
+        fs.ftruncateSync(fd);
+        fs.writeSync(fd, packageContent, 0, 'utf8');
+        fs.closeSync(fd);
+    }
+
     addPlugin (plugin, opts = {}) {
         let pluginPath = path.relative(path.dirname(this.path), path.join(this.root, 'packages', plugin.id));
         if (opts.link) {

--- a/lib/create.js
+++ b/lib/create.js
@@ -22,6 +22,7 @@ const fs = require('node:fs');
 const { ConfigParser, CordovaError, events, xmlHelpers } = require('cordova-common');
 const xcode = require('xcode');
 const pkg = require('../package');
+const { SwiftPackage } = require('./SwiftPackage');
 
 const ROOT = path.join(__dirname, '..');
 
@@ -134,6 +135,9 @@ class ProjectCreator {
         const deploymentTarget = this.options.rootConfig.getPreference('deployment-target', 'ios');
         if (deploymentTarget) {
             xcodeproj.updateBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', deploymentTarget);
+
+            const swiftPackage = new SwiftPackage(this.project.path);
+            swiftPackage.updateDeploymentTarget(deploymentTarget);
         }
 
         // Update the CordovaLib Swift package reference path

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -31,6 +31,7 @@ const PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 const FileUpdater = require('cordova-common').FileUpdater;
 const projectFile = require('./projectFile');
 const Podfile = require('./Podfile').Podfile;
+const { SwiftPackage } = require('./SwiftPackage');
 const check_reqs = require('./check_reqs');
 const PlatformConfigParser = require('./PlatformConfigParser');
 const versions = require('./versions');
@@ -349,6 +350,12 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
         projectFile.purgeProjectFileCache(locations.root);
         return podfileFile.install(check_reqs.check_cocoapods)
             .then(() => podsjsonFile.setSwiftVersionForCocoaPodsLibraries(locations.root));
+    }
+
+    const pkgPath = path.join(locations.root, 'packages', 'cordova-ios-plugins', 'Package.swift');
+    if (deploymentTarget && fs.existsSync(pkgPath)) {
+        const swiftPackage = new SwiftPackage(locations.root);
+        swiftPackage.updateDeploymentTarget(deploymentTarget);
     }
 
     return Promise.resolve();

--- a/tests/spec/SwiftPackage.spec.js
+++ b/tests/spec/SwiftPackage.spec.js
@@ -83,6 +83,26 @@ describe('SwiftPackage', () => {
             });
     });
 
+    describe('updateDeploymentTarget', () => {
+        let pkg;
+        beforeEach(() => {
+            fs.mkdirSync(path.join(tmpDir.name, 'packages', 'cordova-ios-plugins'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir.name, 'packages', 'cordova-ios-plugins', 'Package.swift'), fixturePackage, 'utf8');
+
+            pkg = new SwiftPackage(tmpDir.name);
+        });
+
+        it('should update the deployment target to the specified version', () => {
+            pkg.updateDeploymentTarget('18.4');
+
+            const pkgPath = path.join(tmpDir.name, 'packages', 'cordova-ios-plugins', 'Package.swift');
+            const content = fs.readFileSync(pkgPath, 'utf8');
+
+            expect(content).toContain('.iOS("18.4")');
+            expect(content).toContain('.macCatalyst("18.4")');
+        });
+    });
+
     describe('addPlugin', () => {
         const my_plugin = {
             id: 'my-plugin',

--- a/tests/spec/create.spec.js
+++ b/tests/spec/create.spec.js
@@ -99,6 +99,10 @@ function verifyProjectDeploymentTarget (tmpDir, expectedTarget) {
 
     const actualDeploymentTarget = xcodeproj.getBuildProperty('IPHONEOS_DEPLOYMENT_TARGET');
     expect(actualDeploymentTarget).toBe(expectedTarget);
+
+    const pkgPath = path.join(tmpDir, 'packages', 'cordova-ios-plugins', 'Package.swift');
+    const pkgContent = fs.readFileSync(pkgPath, 'utf8');
+    expect(pkgContent).toContain(`.iOS("${expectedTarget}")`);
 }
 
 /**


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1608.


### Description
<!-- Describe your changes in detail -->
Ensure we set the deployment target in the plugins Package.swift file to match the deployment-target preference on project creation and when preparing.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added unit tests.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))