### PR TITLE
fix(spm): Ensure the deployment target always gets set

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -336,6 +336,12 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
 
     project.write();
 
+    const pkgPath = path.join(locations.root, 'packages', 'cordova-ios-plugins', 'Package.swift');
+    if (deploymentTarget && fs.existsSync(pkgPath)) {
+        const swiftPackage = new SwiftPackage(locations.root);
+        swiftPackage.updateDeploymentTarget(deploymentTarget);
+    }
+
     // If we have a Podfile, we want to update the deployment target there too
     const podPath = path.join(locations.root, Podfile.FILENAME);
     if (deploymentTarget && fs.existsSync(podPath)) {
@@ -350,12 +356,6 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
         projectFile.purgeProjectFileCache(locations.root);
         return podfileFile.install(check_reqs.check_cocoapods)
             .then(() => podsjsonFile.setSwiftVersionForCocoaPodsLibraries(locations.root));
-    }
-
-    const pkgPath = path.join(locations.root, 'packages', 'cordova-ios-plugins', 'Package.swift');
-    if (deploymentTarget && fs.existsSync(pkgPath)) {
-        const swiftPackage = new SwiftPackage(locations.root);
-        swiftPackage.updateDeploymentTarget(deploymentTarget);
     }
 
     return Promise.resolve();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1615.


### Description
<!-- Describe your changes in detail -->
The block of code to update the version in the Podfile contains a return statement, meaning that in some cases the Package.swift file was never getting updated. Reorder the code so it always updates the Package.swift first.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))