### PR TITLE
fix(xcode): Fix library search paths for target

### DIFF
--- a/lib/plugman/pluginHandlers.js
+++ b/lib/plugman/pluginHandlers.js
@@ -291,7 +291,9 @@ function installHelper (type, obj, plugin_dir, project_dir, plugin_id, options, 
         const opt = { weak: obj.weak };
         const project_relative = path.join(path.basename(project.xcode_path), project_ref);
         project.xcode.addFramework(project_relative, opt);
-        project.xcode.addToLibrarySearchPaths({ path: project_ref });
+
+        const searchPath = `"$(SRCROOT)/$(TARGET_NAME)/${path.dirname(project_ref)}"`;
+        project.xcode.addToLibrarySearchPaths(searchPath);
     } else {
         project.xcode.addSourceFile(project_ref, obj.compilerFlags ? { compilerFlags: obj.compilerFlags } : {});
     }

--- a/tests/spec/Plugman/pluginHandler.spec.js
+++ b/tests/spec/Plugman/pluginHandler.spec.js
@@ -89,6 +89,7 @@ describe('ios plugin handler', () => {
 
             beforeEach(() => {
                 spyOn(dummyProject.xcode, 'addSourceFile');
+                dummyProject.xcode.updateBuildProperty('PRODUCT_NAME', '"TestCordovaApp"', null, 'App');
             });
 
             it('Test 001 : should throw if source-file src cannot be found', () => {
@@ -136,6 +137,15 @@ describe('ios plugin handler', () => {
                 install(source[0], dummyPluginInfo, dummyProject);
                 expect(dummyProject.xcode.addFramework)
                     .toHaveBeenCalledWith(path.join('App', 'Plugins', dummy_id, 'SourceWithFramework.m'), { weak: false });
+            });
+
+            it('should update library search paths when element has framework=true set', () => {
+                const source = copyArray(valid_source).filter(s => s.framework);
+
+                spyOn(dummyProject.xcode, 'addFramework');
+                install(source[0], dummyPluginInfo, dummyProject);
+
+                expect(dummyProject.xcode.getBuildProperty('LIBRARY_SEARCH_PATHS', undefined, 'App')).toContain(`"$(SRCROOT)/$(TARGET_NAME)/Plugins/${dummy_id}"`);
             });
 
             it('should not add source files for SPM plugins', () => {


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1617.


### Description
<!-- Describe your changes in detail -->
Ensure we add a library search path that uses the target name instead of the product name. For now, we continue to add the one with the product name (which is what node-xcode does by default).


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added unit test to confirm correct path value.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))