### PR TITLE
fix(xcode): Ensure we do NFD normalization on PRODUCT_NAME

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -290,7 +290,7 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     }
 
     const pkg = platformConfig.getAttribute('ios-CFBundleIdentifier') || platformConfig.packageName();
-    const name = platformConfig.name();
+    const name = platformConfig.name().normalize('NFD');
     const version = platformConfig.version();
     const displayName = platformConfig.shortName();
     const CFBundleVersion = platformConfig.getAttribute('ios-CFBundleVersion') || default_CFBundleVersion(version);


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
iOS uses NFD normalization for Unicode accented characters, and we want to ensure consistency throughout the project and build process.

I'm hoping this might fix GH-1590 (but don't have a way to confirm that).


### Description
<!-- Describe your changes in detail -->
Apply NFD normalization to the `name` from config.xml before setting the `PRODUCT_NAME` value in the Xcode project.


### Testing
<!-- Please describe in detail how you tested your changes. -->
All existing tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
