### PR TITLE
refactor(versions): Refactor version code for test reliability

### DIFF
--- a/lib/versions.js
+++ b/lib/versions.js
@@ -17,41 +17,69 @@
     under the License.
 */
 
-const execa = require('execa');
+const child_process = require('node:child_process');
 const semver = require('semver');
 const { CordovaError } = require('cordova-common');
 
+function spawnSync (cmd, args) {
+    const result = child_process.spawnSync(cmd, args, { encoding: 'utf8' });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    if (result.status !== 0) {
+        throw new CordovaError(result.stderr);
+    }
+
+    return result.stdout;
+}
+
 function fetchSdkVersionByType (sdkType) {
-    return execa('xcodebuild', ['-showsdks'])
-        .then(({ stdout }) => {
-            const regexSdk = new RegExp(`^${sdkType} \\d`);
+    const stdout = spawnSync('xcodebuild', ['-showsdks']);
 
-            const versions = stdout.split('\n')
-                .filter(line => line.trim().match(regexSdk))
-                .map(line => line.match(/\d+\.\d+/)[0])
-                .sort(exports.compareVersions);
+    const regexSdk = new RegExp(`^${sdkType} \\d`);
+    const versions = stdout.split('\n')
+        .filter(line => line.trim().match(regexSdk))
+        .map(line => line.match(/\d+\.\d+/)[0])
+        .sort(exports.compareVersions);
 
-            return versions[0];
-        });
+    if (!versions[0]) {
+        throw new CordovaError(`Could not determine ${sdkType} version from output:\n${stdout}`);
+    }
+
+    return versions[0];
 }
 
 exports.get_apple_ios_version = () => {
-    return fetchSdkVersionByType('iOS');
+    try {
+        return Promise.resolve(fetchSdkVersionByType('iOS'));
+    } catch (e) {
+        return Promise.reject(e);
+    }
 };
 
 exports.get_apple_osx_version = () => {
-    return fetchSdkVersionByType('macOS');
+    try {
+        return Promise.resolve(fetchSdkVersionByType('macOS'));
+    } catch (e) {
+        return Promise.reject(e);
+    }
 };
 
 exports.get_apple_xcode_version = () => {
-    return execa('xcodebuild', ['-version'])
-        .then(({ stdout }) => {
-            const versionMatch = /Xcode (.*)/.exec(stdout);
-            if (!versionMatch) {
-                throw new CordovaError('Could not determine Xcode version from output:\n' + stdout);
-            }
-            return versionMatch[1];
-        });
+    try {
+        const stdout = spawnSync('xcodebuild', ['-version']);
+
+        const versionMatch = /Xcode (.*)/.exec(stdout);
+        if (!versionMatch) {
+            throw new CordovaError(`Could not determine Xcode version from output:\n${stdout}`);
+        }
+
+        return Promise.resolve(versionMatch[1]);
+    } catch (e) {
+        return Promise.reject(e);
+    }
 };
 
 /**
@@ -60,8 +88,11 @@ exports.get_apple_xcode_version = () => {
  *                           or rejected in case of error
  */
 exports.get_ios_deploy_version = () => {
-    return execa('ios-deploy', ['--version'])
-        .then(({ stdout }) => stdout);
+    try {
+        return Promise.resolve(spawnSync('ios-deploy', ['--version']));
+    } catch (e) {
+        return Promise.reject(e);
+    }
 };
 
 /**
@@ -70,8 +101,11 @@ exports.get_ios_deploy_version = () => {
  *                           or rejected in case of error
  */
 exports.get_cocoapods_version = () => {
-    return execa('pod', ['--version'])
-        .then(({ stdout }) => stdout);
+    try {
+        return Promise.resolve(spawnSync('pod', ['--version']));
+    } catch (e) {
+        return Promise.reject(e);
+    }
 };
 
 /**

--- a/tests/spec/versions.spec.js
+++ b/tests/spec/versions.spec.js
@@ -17,10 +17,37 @@
  under the License.
  */
 
+const childProcess = require('node:child_process');
 const semver = require('semver');
 const versions = require('../../lib/versions');
 
+const xcodeSdksOutput = `
+DriverKit SDKs:
+        DriverKit 25.2                  -sdk driverkit25.2
+
+iOS SDKs:
+        iOS 26.2                        -sdk iphoneos26.2
+
+iOS Simulator SDKs:
+        Simulator - iOS 26.2            -sdk iphonesimulator26.2
+
+macOS SDKs:
+        macOS 15.7                      -sdk macosx15.7
+
+visionOS SDKs:
+        visionOS 26.2                   -sdk xros26.2
+
+visionOS Simulator SDKs:
+        Simulator - visionOS 26.2       -sdk xrsimulator26.2
+`;
+
 describe('versions', () => {
+    let spawnMock;
+
+    beforeEach(() => {
+        spawnMock = spyOn(childProcess, 'spawnSync');
+    });
+
     describe('compareVersions method', () => {
         it('calls semver.compare, given valid semver', () => {
             const testVersions = ['1.0.0', '1.1.0'];
@@ -51,51 +78,145 @@ describe('versions', () => {
                 versions.compareVersions('10.1-beta.1', '10.1')
             ).toBe(0);
         });
+
+        it('throws when given an invalid version', () => {
+            expect(() => versions.compareVersions('10.1', 'random string')).toThrowError(TypeError, 'Invalid Version: random string');
+        });
     });
 
-    // These tests can not run on windows.
-    if (process.platform === 'darwin') {
-        describe('get_apple_ios_version method', () => {
-            it('should have found ios version.', () => {
-                return versions.get_apple_ios_version().then(version => {
-                    expect(version).not.toBeUndefined();
-                });
-            }, 10000);
-        });
+    describe('get_apple_ios_version', () => {
+        it('should have found iOS version', () => {
+            spawnMock.and.returnValue({ status: 0, stdout: xcodeSdksOutput });
 
-        describe('get_apple_osx_version method', () => {
-            it('should have found osx version.', () => {
-                return versions.get_apple_osx_version().then(version => {
-                    expect(version).not.toBeUndefined();
-                });
+            return versions.get_apple_ios_version().then(version => {
+                expect(spawnMock).toHaveBeenCalledWith('xcodebuild', ['-showsdks'], jasmine.anything());
+                expect(version).toEqual('26.2');
             });
         });
 
-        describe('get_tool_version method', () => {
-            it('should not have found tool by name.', () => {
-                return versions.get_tool_version('unknown').then(
-                    () => fail('expected promise rejection'),
-                    error => expect(error.message).toContain('is not valid tool name')
-                );
-            }, 10000);
+        it('should fail if iOS SDK cannot be found', () => {
+            spawnMock.and.returnValue({ status: 0, stdout: '' });
 
-            it('should find xcodebuild version.', () => {
-                return versions.get_tool_version('xcodebuild').then((version) => {
-                    expect(version).not.toBe(undefined);
-                });
-            }, 10000);
-
-            it('should find ios-deploy version.', () => {
-                return versions.get_tool_version('ios-deploy').then((version) => {
-                    expect(version).not.toBe(undefined);
-                });
-            }, 10000);
-
-            it('should find pod version.', () => {
-                return versions.get_tool_version('pod').then((version) => {
-                    expect(version).not.toBe(undefined);
-                });
-            }, 20000); // The first invocation of `pod` can be quite slow
+            return versions.get_apple_ios_version().then(
+                _ => fail(),
+                err => expect(err.message).toMatch(/Could not determine iOS version/)
+            );
         });
-    }
+
+        it('should fail if the command return an error', () => {
+            spawnMock.and.returnValue({ error: new Error('Bad Command') });
+
+            return versions.get_apple_ios_version().then(
+                _ => fail(),
+                err => expect(err.message).toMatch(/Bad Command/)
+            );
+        });
+
+        it('should fail if the command return a non-zero status code', () => {
+            spawnMock.and.returnValue({ status: 1, stderr: 'Error message' });
+
+            return versions.get_apple_ios_version().then(
+                _ => fail(),
+                err => expect(err.message).toMatch(/Error message/)
+            );
+        });
+
+        it('should fail if xcodebuild cannot be found', () => {
+            spawnMock.and.throwError(new Error('ENOENT'));
+
+            return versions.get_apple_ios_version().then(
+                _ => fail(),
+                err => expect(err.message).toMatch(/ENOENT/)
+            );
+        });
+    });
+
+    describe('get_apple_osx_version', () => {
+        it('should have found macOS version', () => {
+            spawnMock.and.returnValue({ status: 0, stdout: xcodeSdksOutput });
+
+            return versions.get_apple_osx_version().then(version => {
+                expect(spawnMock).toHaveBeenCalledWith('xcodebuild', ['-showsdks'], jasmine.anything());
+                expect(version).toEqual('15.7');
+            });
+        });
+
+        it('should fail if macOS SDK cannot be found', () => {
+            spawnMock.and.returnValue({ status: 0, stdout: '' });
+
+            return versions.get_apple_osx_version().then(
+                _ => fail(),
+                err => expect(err.message).toMatch(/Could not determine macOS version/)
+            );
+        });
+    });
+
+    describe('get_tool_version', () => {
+        it('should not have found tool by name.', () => {
+            return versions.get_tool_version('unknown').then(
+                _ => fail('expected promise rejection'),
+                err => expect(err.message).toContain('is not valid tool name')
+            );
+        });
+
+        describe('xcodebuild', () => {
+            it('should find xcodebuild version', () => {
+                spawnMock.and.returnValue({ status: 0, stdout: 'Xcode 16.4' });
+
+                return versions.get_tool_version('xcodebuild').then((version) => {
+                    expect(spawnMock).toHaveBeenCalledWith('xcodebuild', ['-version'], jasmine.anything());
+                    expect(version).toEqual('16.4');
+                });
+            });
+
+            it('should fail if the version cannot be parsed', () => {
+                spawnMock.and.returnValue({ status: 0, stdout: 'Not a version' });
+
+                return versions.get_tool_version('xcodebuild').then(
+                    _ => fail(),
+                    err => expect(err.message).toMatch(/Could not determine Xcode version/)
+                );
+            });
+        });
+
+        describe('ios-deploy', () => {
+            it('should find ios-deploy version', () => {
+                spawnMock.and.returnValue({ status: 0, stdout: '1.12.2' });
+
+                return versions.get_tool_version('ios-deploy').then((version) => {
+                    expect(spawnMock).toHaveBeenCalledWith('ios-deploy', ['--version'], jasmine.anything());
+                    expect(version).toEqual('1.12.2');
+                });
+            });
+
+            it('should fail if ios-deploy cannot be found', () => {
+                spawnMock.and.throwError(new Error('ENOENT'));
+
+                return versions.get_tool_version('ios-deploy').then(
+                    _ => fail(),
+                    err => expect(err.message).toMatch(/ENOENT/)
+                );
+            });
+        });
+
+        describe('pod', () => {
+            it('should find ios-deploy version', () => {
+                spawnMock.and.returnValue({ status: 0, stdout: '1.16.2' });
+
+                return versions.get_tool_version('pod').then((version) => {
+                    expect(spawnMock).toHaveBeenCalledWith('pod', ['--version'], jasmine.anything());
+                    expect(version).toEqual('1.16.2');
+                });
+            });
+
+            it('should fail if pod cannot be found', () => {
+                spawnMock.and.throwError(new Error('ENOENT'));
+
+                return versions.get_tool_version('pod').then(
+                    _ => fail(),
+                    err => expect(err.message).toMatch(/ENOENT/)
+                );
+            });
+        });
+    });
 });


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The tests around version checks have been very flaky in CI, in large part due to them actually shelling out to invoke `xcodebuild` commands.

The tests also rely on the developer machine having all the tools being searched for, which prevents the code from being tested on Windows and Linux.


### Description
<!-- Describe your changes in detail -->
* Move from `execa` to `child_process.spawnSync` for the version checks since we are reasonably sure they are running on macOS and won't hit shell issues
* Mock the call to `spawnSync` for testing so no system calls actually take place in tests


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added new unit tests using mocked calls to test all cases.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change