### PR TITLE
fix(ionic): Add workaround for Ionic WebView plugin

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
@@ -148,4 +148,19 @@
     return [[self class] shouldOverrideLoadWithRequest:request navigationType:navigationType filterValue:[self filterUrl:request.URL]];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+// TODO: Remove in Cordova iOS 9
+// The Ionic Webview plugin calls this method by selector (rather than
+// shouldOverrideLoadWithRequest:navigationType:info: as defined above) and
+// apps using that plugin break by refusing to load content unless this
+// deprecated selector exists.
+- (BOOL)shouldOverrideLoadWithRequest:(NSURLRequest*)request navigationType:(CDVWebViewNavigationType)navigationType
+{
+    NSLog(@"Plugin called shouldOverrideLoadWithRequest:navigationType: which is deprecated and will be removed in Cordova iOS 9");
+
+    return [[self class] shouldOverrideLoadWithRequest:request navigationType:navigationType filterValue:[self filterUrl:request.URL]];
+}
+#pragma clang diagnostic pop
+
 @end


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes GH-1631.

### Description
<!-- Describe your changes in detail -->
Re-add an implementation of the deprecated `shouldOverrideLoadWithRequest:navigationType:` selector because the Ionic WebView plugin relies on it.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
