### PR TITLE
chore: Bump patch level for ongoing dev work

### DIFF
--- a/CordovaLib/Info.plist
+++ b/CordovaLib/Info.plist
@@ -35,7 +35,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>8.0.1</string>
+	<string>8.0.2-dev.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-ios",
-  "version": "8.0.1",
+  "version": "8.0.2-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-ios",
-      "version": "8.0.1",
+      "version": "8.0.2-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "bplist-parser": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "8.0.1",
+  "version": "8.0.2-dev.0",
   "description": "cordova-ios release",
   "types": "./types/index.d.ts",
   "main": "lib/Api.js",


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Bump version to reflect that ongoing work is for a future release