### PR TITLE
chore: Fix improperly ignored deprecation warning

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVIntentAndNavigationFilter/CDVIntentAndNavigationFilter.m
@@ -149,7 +149,7 @@
 }
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 // TODO: Remove in Cordova iOS 9
 // The Ionic Webview plugin calls this method by selector (rather than
 // shouldOverrideLoadWithRequest:navigationType:info: as defined above) and


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Follow-up from #1632


### Description
<!-- Describe your changes in detail -->
We need to ignore the warning about implementing a deprecated method, not about using a deprecated declaration.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Confirm that no deprecation warning is printed when running tests.


### Checklist

- [x] I've run the tests to see all new and existing tests pass