### PR TITLE
fix(build): Target a generic iOS simulator for building

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -70,33 +70,6 @@ function createProjectObject (projectPath) {
     return projectFile.parse(locations);
 }
 
-/**
- * Returns a promise that resolves to the default simulator target; the logic here
- * matches what `cordova emulate ios` does.
- *
- * The return object has two properties: `name` (the Xcode destination name),
- * `identifier` (the simctl identifier), and `simIdentifier` (essentially the cordova emulate target)
- *
- * @return {Promise}
- */
-function getDefaultSimulatorTarget () {
-    events.emit('log', 'Select last emulator from list as default.');
-    return require('./listEmulatorBuildTargets').run()
-        .then(emulators => {
-            if (emulators.length === 0) {
-                return Promise.reject(new CordovaError('Could not find any iOS simulators. Use Xcode to install simulator devices for testing.'));
-            }
-
-            let targetEmulator = emulators[0];
-            emulators.forEach(emulator => {
-                if (emulator.name.indexOf('iPhone') === 0) {
-                    targetEmulator = emulator;
-                }
-            });
-            return targetEmulator;
-        });
-}
-
 function parseOptions (options) {
     options = options || {};
     options.argv = nopt({
@@ -154,14 +127,11 @@ module.exports.run = function (buildOpts) {
     }
 
     const projectPath = this.root;
-    let emulatorTarget = 'iOS Device';
 
     if (buildOpts.target && buildOpts.target.match(/mac/i)) {
         buildOpts.catalyst = true;
         buildOpts.device = true;
         buildOpts.emulator = false;
-
-        emulatorTarget = 'macOS Catalyst';
     }
 
     return Promise.resolve()
@@ -171,33 +141,6 @@ module.exports.run = function (buildOpts) {
                     if (devices.length > 0) {
                         // we explicitly set device flag in options
                         buildOpts.device = true;
-                    }
-                });
-            }
-        })
-        .then(() => {
-            // CB-12287: Determine the device we should target when building for a simulator
-            if (!buildOpts.device) {
-                let newTarget = buildOpts.target || '';
-
-                if (newTarget) {
-                    // only grab the device name, not the runtime specifier
-                    newTarget = newTarget.split(',')[0];
-                }
-                // a target was given to us, find the matching Xcode destination name
-                const promise = require('./listEmulatorBuildTargets').targetForSimIdentifier(newTarget);
-                return promise.then(theTarget => {
-                    if (!theTarget) {
-                        return getDefaultSimulatorTarget().then(defaultTarget => {
-                            emulatorTarget = defaultTarget.name;
-                            events.emit('warn', `No simulator found for "${newTarget}". Falling back to the default target.`);
-                            events.emit('log', `Building for "${emulatorTarget}" Simulator (${defaultTarget.identifier}, ${defaultTarget.simIdentifier}).`);
-                            return emulatorTarget;
-                        });
-                    } else {
-                        emulatorTarget = theTarget.name;
-                        events.emit('log', `Building for "${emulatorTarget}" Simulator (${theTarget.identifier}, ${theTarget.simIdentifier}).`);
-                        return emulatorTarget;
                     }
                 });
             }
@@ -243,18 +186,18 @@ module.exports.run = function (buildOpts) {
             return fs.promises.writeFile(path.join(projectPath, 'cordova', 'build-extras.xcconfig'), extraConfig, 'utf-8');
         }).then(() => {
             const configuration = buildOpts.release ? 'Release' : 'Debug';
+            const platform = buildOpts.catalyst ? 'maccatalyst' : (buildOpts.device ? 'iphoneos' : 'iphonesimulator');
 
             events.emit('log', `Building project: ${path.join(projectPath, 'App.xcworkspace')}`);
             events.emit('log', `\tConfiguration: ${configuration}`);
-            events.emit('log', `\tPlatform: ${buildOpts.device ? 'device' : 'emulator'}`);
-            events.emit('log', `\tTarget: ${emulatorTarget}`);
+            events.emit('log', `\tPlatform: ${platform}`);
 
-            const buildOutputDir = path.join(projectPath, 'build', `${configuration}-${(buildOpts.device ? 'iphoneos' : 'iphonesimulator')}`);
+            const buildOutputDir = path.join(projectPath, 'build', `${configuration}-${platform}`);
 
             // remove the build output folder before building
             fs.rmSync(buildOutputDir, { recursive: true, force: true });
 
-            const xcodebuildArgs = getXcodeBuildArgs(projectPath, configuration, emulatorTarget, buildOpts);
+            const xcodebuildArgs = getXcodeBuildArgs(projectPath, configuration, buildOpts);
             return execa('xcodebuild', xcodebuildArgs, { cwd: projectPath, stdio: 'inherit' });
         }).then(() => {
             if (!buildOpts.device || buildOpts.catalyst || buildOpts.noSign) {
@@ -323,11 +266,10 @@ module.exports.run = function (buildOpts) {
  * Returns array of arguments for xcodebuild
  * @param  {String}  projectPath    Path to project file. Will be used to set CWD for xcodebuild
  * @param  {String}  configuration  Configuration name: debug|release
- * @param  {String}  emulatorTarget Target for emulator (rather than default)
  * @param  {Object}  buildConfig    The build configuration options
  * @return {Array}                  Array of arguments that could be passed directly to spawn method
  */
-function getXcodeBuildArgs (projectPath, configuration, emulatorTarget, buildConfig = {}) {
+function getXcodeBuildArgs (projectPath, configuration, buildConfig = {}) {
     let options;
     let buildActions;
     let settings;
@@ -396,7 +338,7 @@ function getXcodeBuildArgs (projectPath, configuration, emulatorTarget, buildCon
         } else {
             options = options.concat([
                 '-sdk', customArgs.sdk || 'iphonesimulator',
-                '-destination', customArgs.destination || `platform=iOS Simulator,name=${emulatorTarget}`
+                '-destination', customArgs.destination || 'generic/platform=iOS Simulator'
             ]);
         }
 

--- a/tests/spec/build.spec.js
+++ b/tests/spec/build.spec.js
@@ -23,6 +23,8 @@ const rewire = require('rewire');
 const { CordovaError } = require('cordova-common');
 const build = rewire('../../lib/build');
 
+const realBuild = require('../../lib/build');
+
 describe('build', () => {
     const testProjectPath = path.join('/test', 'project', 'path');
 
@@ -31,7 +33,7 @@ describe('build', () => {
         build.__set__('__dirname', path.join('/test', 'dir'));
 
         it('should generate appropriate args if a single buildFlag is passed in', () => {
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', '', { device: true, buildFlag: '' });
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', { device: true, buildFlag: '' });
             expect(args).toEqual([
                 '-workspace',
                 'App.xcworkspace',
@@ -61,7 +63,7 @@ describe('build', () => {
                 '-resultBundlePath="/tmp/result bundle/file"'
             ];
 
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', '', { device: true, buildFlag: buildFlags });
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', { device: true, buildFlag: buildFlags });
             expect(args).toEqual([
                 '-workspace',
                 'TestWorkspaceFlag',
@@ -83,7 +85,7 @@ describe('build', () => {
         });
 
         it('should generate appropriate args for device', () => {
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', '', { device: true });
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', { device: true });
             expect(args).toEqual([
                 '-workspace',
                 'App.xcworkspace',
@@ -101,7 +103,7 @@ describe('build', () => {
         });
 
         it('should generate appropriate args for simulator', () => {
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', 'iPhone 5s', { device: false });
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', { device: false });
             expect(args).toEqual([
                 '-workspace',
                 'App.xcworkspace',
@@ -112,7 +114,7 @@ describe('build', () => {
                 '-sdk',
                 'iphonesimulator',
                 '-destination',
-                'platform=iOS Simulator,name=iPhone 5s',
+                'generic/platform=iOS Simulator',
                 'build'
             ]);
             expect(args.length).toEqual(11);
@@ -129,7 +131,7 @@ describe('build', () => {
                 'SHARED_PRECOMPS_DIR=TestSharedPrecompsDirFlag'
             ];
 
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', 'iPhone 5s', { device: false, buildFlag: buildFlags });
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', { device: false, buildFlag: buildFlags });
             expect(args).toEqual([
                 '-workspace',
                 'TestWorkspaceFlag',
@@ -153,7 +155,7 @@ describe('build', () => {
         it('should add matched flags that are not overriding for device', () => {
             const buildFlags = '-sdk TestSdkFlag';
 
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', '', { device: true, buildFlag: buildFlags });
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', { device: true, buildFlag: buildFlags });
             expect(args).toEqual([
                 '-workspace',
                 'App.xcworkspace',
@@ -175,7 +177,7 @@ describe('build', () => {
         it('should add matched flags that are not overriding for simulator', () => {
             const buildFlags = '-archivePath TestArchivePathFlag';
 
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', 'iPhone 5s', { device: false, buildFlag: buildFlags });
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', { device: false, buildFlag: buildFlags });
             expect(args).toEqual([
                 '-workspace',
                 'App.xcworkspace',
@@ -186,7 +188,7 @@ describe('build', () => {
                 '-sdk',
                 'iphonesimulator',
                 '-destination',
-                'platform=iOS Simulator,name=iPhone 5s',
+                'generic/platform=iOS Simulator',
                 'build',
                 '-archivePath',
                 'TestArchivePathFlag'
@@ -203,7 +205,7 @@ describe('build', () => {
                 authenticationKeyIssuerID: '00000000-0000-0000-0000-000000000000'
             };
 
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', '', buildOpts);
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', buildOpts);
             expect(args).toEqual([
                 '-workspace',
                 'App.xcworkspace',
@@ -232,7 +234,7 @@ describe('build', () => {
                 catalyst: true
             };
 
-            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', '', buildOpts);
+            const args = getXcodeBuildArgs(testProjectPath, 'TestConfiguration', buildOpts);
             expect(args).toEqual([
                 '-workspace',
                 'App.xcworkspace',
@@ -479,53 +481,23 @@ describe('build', () => {
         });
     });
 
-    describe('getDefaultSimulatorTarget method', () => {
-        it('should find iPhone X as the default simulator target.', () => {
-            const mockedEmulators = [{
-                name: 'iPhone 7',
-                identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-7',
-                simIdentifier: 'iPhone-7'
-            },
-            {
-                name: 'iPhone 8',
-                identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-8',
-                simIdentifier: 'iPhone-8'
-            },
-            {
-                name: 'iPhone X',
-                identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-X',
-                simIdentifier: 'iPhone-X'
-            }];
-
-            // This method will require a module that supports the run method.
-            build.__set__('require', () => ({
-                run: () => Promise.resolve(mockedEmulators)
-            }));
-
-            const getDefaultSimulatorTarget = build.__get__('getDefaultSimulatorTarget');
-
-            return getDefaultSimulatorTarget().then(actual => {
-                expect(actual).toEqual({
-                    name: 'iPhone X',
-                    identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-X',
-                    simIdentifier: 'iPhone-X'
-                });
-            });
+    describe('run method', () => {
+        it('should not accept debug and release options together', () => {
+            return expectAsync(realBuild.run({ debug: true, release: true }))
+                .toBeRejectedWithError(CordovaError, 'Cannot specify "debug" and "release" options together.');
         });
 
-        it('should handle the case of no simulators being available', () => {
-            // This method will require a module that supports the run method.
-            build.__set__('require', () => ({
-                run: () => Promise.resolve([])
-            }));
+        it('should not accept device and emulator options together', () => {
+            return expectAsync(realBuild.run({ device: true, emulator: true }))
+                .toBeRejectedWithError(CordovaError, 'Cannot specify "device" and "emulator" options together.');
+        });
 
-            const getDefaultSimulatorTarget = build.__get__('getDefaultSimulatorTarget');
+        it('should not accept a build config file that does not exist', () => {
+            spyOn(fs, 'existsSync').and.returnValue(false);
+            const buildConfig = './some/config/path';
 
-            return getDefaultSimulatorTarget().then(sim => {
-                return Promise.reject(new Error('Should not resolve if no simulators are present'));
-            }, (err) => {
-                expect(err).toBeInstanceOf(CordovaError);
-            });
+            return expectAsync(realBuild.run({ buildConfig: './some/config/path' }))
+                .toBeRejectedWithError(CordovaError, `Build config file does not exist: ${buildConfig}`);
         });
     });
 });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Should close https://github.com/apache/cordova-ios/issues/686


### Description
<!-- Describe your changes in detail -->
`cordova build ios --emulator` was trying to build for a specific simulator device (either provided with `--target` or falling back to a default simulator). This routinely caused problems for people when it decided to default to an old iOS runtime, or the wrong device type.

Xcode support building for a generic "Any iOS Simulator" target, so let's do that and only care about the specific device in `cordova run ios`.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Updated existing tests and confirmed they run.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
