### PR TITLE
fix(actions): IPhone 16e not found on macOS 26 for latest OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             node-version: 24.x
 
     env:
-      CDV_IOS_SIM: iPhone 16e
+      CDV_IOS_SIM: ${{ matrix.os == 'macos-26' && 'iPhone 17' || 'iPhone 16e' }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- xcodebuild is called with destination: platform=iOS Simulator, name=iPhone 16e. Xcode interprets that as OS:latest, so it looks for iPhone 16e on the latest simulator runtime. On macos-26, latest runtime is 26.4.1, and there is no iPhone 16e for 26.4.1 (only iPhone 17e, iPhone 17, etc.). Therefore xcodebuild exits with: Unable to find a device matching the provided destination specifier npm exits with code 70 because npm run test:xcode failed.
- iPhone 17 is now used for macOS 26 and iPhone 16e otherwise
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
