### PR TITLE
fix(actions): fix `CDVURLSchemeHandlerTest` warnings

### DIFF
--- a/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m
+++ b/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m
@@ -88,7 +88,7 @@
 
 @interface CDVTestURLSchemeTask : NSObject <WKURLSchemeTask>
 
-@property (nonatomic, strong) NSURLRequest* request;
+@property (nonatomic, copy) NSURLRequest* request;
 @property (nonatomic, strong) NSMutableArray<NSData *>* receivedData;
 @property (nonatomic, strong, nullable) NSURLResponse* response;
 @property (nonatomic, strong, nullable) NSError* error;
@@ -140,6 +140,7 @@
 
 @property AppDelegate* appDelegate;
 @property (nonatomic, strong) CDVViewController* viewController;
+@property (nonatomic, strong) WKWebView* testWebView;
 
 @end
 
@@ -152,10 +153,12 @@
     self.appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
     [self.appDelegate createViewController];
     self.viewController = self.appDelegate.testViewController;
+    self.testWebView = [[WKWebView alloc] initWithFrame:CGRectZero];
 }
 
 - (void)tearDown
 {
+    self.testWebView = nil;
     [self.appDelegate destroyViewController];
     [super tearDown];
 }
@@ -186,7 +189,7 @@
     CDVURLSchemeHandler *handler = [[CDVURLSchemeHandler alloc] initWithViewController:self.viewController];
     CDVTestURLSchemeTask *task = [[CDVTestURLSchemeTask alloc] initWithURL:[NSURL URLWithString:@"app://localhost/index.html"]];
 
-    [handler webView:nil startURLSchemeTask:task];
+    [handler webView:self.testWebView startURLSchemeTask:task];
 
     XCTAssertEqual(task.responseCount, 1u);
     XCTAssertNotNil(task.response);
@@ -203,8 +206,8 @@
     CDVURLSchemeHandler *handler = [[CDVURLSchemeHandler alloc] initWithViewController:self.viewController];
     CDVTestURLSchemeTask *task = [[CDVTestURLSchemeTask alloc] initWithURL:[NSURL URLWithString:@"app://localhost/index.html"]];
 
-    [handler webView:nil startURLSchemeTask:task];
-    [handler webView:nil stopURLSchemeTask:task];
+    [handler webView:self.testWebView startURLSchemeTask:task];
+    [handler webView:self.testWebView stopURLSchemeTask:task];
 
     XCTAssertEqual(task.responseCount, 1u);
     XCTAssertEqual(task.finishedCount, 0u);
@@ -231,7 +234,7 @@
     CDVURLSchemeHandler *handler = [[CDVURLSchemeHandler alloc] initWithViewController:self.viewController];
     CDVTestURLSchemeTask *task = [[CDVTestURLSchemeTask alloc] initWithURL:[NSURL URLWithString:@"app://localhost/does-not-exist.html"]];
 
-    [handler webView:nil startURLSchemeTask:task];
+    [handler webView:self.testWebView startURLSchemeTask:task];
 
     XCTAssertEqual(task.responseCount, 0u);
     XCTAssertEqual(task.failedCount, 1u);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- There were a property attribute mismatch: `copy` must be used instead of `strong` for `request` property
- Nonnull nil argument warnings fixed: Added a real `WKWebView` test instance in `setUp` and cleared it in `tearDown`
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->

Generated warnings:

```log
/Users/runner/work/cordova-ios/cordova-ios/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m:91:45: warning: 'copy' attribute on property 'request' does not match the property inherited from 'WKURLSchemeTask' [-Wproperty-attribute-mismatch]
91 | @property (nonatomic, strong) NSURLRequest* request;
| ^
/Users/runner/work/cordova-ios/cordova-ios/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m:189:22: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
189 | [handler webView:nil startURLSchemeTask:task];
| ^~~
In module 'Foundation' imported from /var/folders/dy/3g4vbvsx7lx51x77m3_b20cc0000gn/T/tmp.wNNaaFzTxC/Build/Intermediates.noindex/CordovaTests.build/Debug-iphonesimulator/CordovaApp.build/DerivedSources/CordovaApp-Swift.h:28:
In module 'CoreFoundation' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:6:
In module 'Darwin' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:75:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/MacTypes.h:96:19: note: expanded from macro 'nil'
96 | #define nil __DARWIN_NULL
| ^~~~~~~~~~~~~
In module '_DarwinFoundation2' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/string.h:58:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
52 | #define __DARWIN_NULL NULL
| ^~~~
In module '_Builtin_stddef' imported from /Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stddef.h:89:
/Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
26 | #define NULL ((void*)0)
| ^~~~~~~~~~
/Users/runner/work/cordova-ios/cordova-ios/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m:206:22: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
206 | [handler webView:nil startURLSchemeTask:task];
| ^~~
In module 'Foundation' imported from /var/folders/dy/3g4vbvsx7lx51x77m3_b20cc0000gn/T/tmp.wNNaaFzTxC/Build/Intermediates.noindex/CordovaTests.build/Debug-iphonesimulator/CordovaApp.build/DerivedSources/CordovaApp-Swift.h:28:
In module 'CoreFoundation' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:6:
In module 'Darwin' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:75:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/MacTypes.h:96:19: note: expanded from macro 'nil'
96 | #define nil __DARWIN_NULL
| ^~~~~~~~~~~~~
In module '_DarwinFoundation2' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/string.h:58:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
52 | #define __DARWIN_NULL NULL
| ^~~~
In module '_Builtin_stddef' imported from /Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stddef.h:89:
/Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
26 | #define NULL ((void*)0)
| ^~~~~~~~~~
/Users/runner/work/cordova-ios/cordova-ios/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m:207:22: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
207 | [handler webView:nil stopURLSchemeTask:task];
| ^~~
In module 'Foundation' imported from /var/folders/dy/3g4vbvsx7lx51x77m3_b20cc0000gn/T/tmp.wNNaaFzTxC/Build/Intermediates.noindex/CordovaTests.build/Debug-iphonesimulator/CordovaApp.build/DerivedSources/CordovaApp-Swift.h:28:
In module 'CoreFoundation' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:6:
In module 'Darwin' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:75:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/MacTypes.h:96:19: note: expanded from macro 'nil'
96 | #define nil __DARWIN_NULL
| ^~~~~~~~~~~~~
In module '_DarwinFoundation2' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/string.h:58:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
52 | #define __DARWIN_NULL NULL
| ^~~~
In module '_Builtin_stddef' imported from /Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stddef.h:89:
/Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
26 | #define NULL ((void*)0)
| ^~~~~~~~~~
/Users/runner/work/cordova-ios/cordova-ios/tests/CordovaLibTests/CDVURLSchemeHandlerTest.m:234:22: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
234 | [handler webView:nil startURLSchemeTask:task];
| ^~~
In module 'Foundation' imported from /var/folders/dy/3g4vbvsx7lx51x77m3_b20cc0000gn/T/tmp.wNNaaFzTxC/Build/Intermediates.noindex/CordovaTests.build/Debug-iphonesimulator/CordovaApp.build/DerivedSources/CordovaApp-Swift.h:28:
In module 'CoreFoundation' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:6:
In module 'Darwin' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:75:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/MacTypes.h:96:19: note: expanded from macro 'nil'
96 | #define nil __DARWIN_NULL
| ^~~~~~~~~~~~~
In module '_DarwinFoundation2' imported from /Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/string.h:58:
/Applications/Xcode_26.2.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
52 | #define __DARWIN_NULL NULL
| ^~~~
In module '_Builtin_stddef' imported from /Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stddef.h:89:
/Applications/Xcode_26.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
26 | #define NULL ((void*)0)
| ^~~~~~~~~~
5 warnings generated.
```

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
