### PR TITLE
fix: forward NSUserActivity to plugins via CDVSceneDelegate

### DIFF
--- a/CordovaLib/Classes/Public/CDVPlugin.m
+++ b/CordovaLib/Classes/Public/CDVPlugin.m
@@ -44,6 +44,7 @@
 
 const NSNotificationName CDVPageDidLoadNotification = @"CDVPageDidLoadNotification";
 const NSNotificationName CDVPluginHandleOpenURLNotification = @"CDVPluginHandleOpenURLNotification";
+const NSNotificationName CDVPluginContinueUserActivityNotification = @"CDVPluginContinueUserActivityNotification";
 const NSNotificationName CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification = @"CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification";
 const NSNotificationName CDVPluginResetNotification = @"CDVPluginResetNotification";
 const NSNotificationName CDVViewWillAppearNotification = @"CDVViewWillAppearNotification";

--- a/CordovaLib/Classes/Public/CDVSceneDelegate.m
+++ b/CordovaLib/Classes/Public/CDVSceneDelegate.m
@@ -47,4 +47,9 @@
     }
 }
 
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDVPluginContinueUserActivityNotification object:userActivity];
+}
+
 @end

--- a/CordovaLib/include/Cordova/CDVPluginNotifications.h
+++ b/CordovaLib/include/Cordova/CDVPluginNotifications.h
@@ -22,6 +22,7 @@
 
 extern const NSNotificationName CDVPageDidLoadNotification;
 extern const NSNotificationName CDVPluginHandleOpenURLNotification;
+extern const NSNotificationName CDVPluginContinueUserActivityNotification;
 extern const NSNotificationName CDVPluginResetNotification;
 extern const NSNotificationName CDVViewWillAppearNotification;
 extern const NSNotificationName CDVViewDidAppearNotification;


### PR DESCRIPTION
## Summary

`CDVSceneDelegate` was missing an implementation of `scene:continueUserActivity:`, which is the `UIWindowSceneDelegate` method iOS calls when an `NSUserActivity` event (i.e. a Universal Link with `NSUserActivityTypeBrowsingWeb`) is delivered to the active scene.

As a result, Universal Links were silently dropped when tapped inside `SFSafariViewController` on cordova-ios 8.x. On cordova-ios 7.x this worked because the activity was delivered to `AppDelegate.application(_:continue:restorationHandler:)` directly, before SceneDelegate was introduced.

## Changes

- **`CDVSceneDelegate.m`** — add `scene:continueUserActivity:` implementation that posts `CDVPluginContinueUserActivityNotification` via `NSNotificationCenter`, consistent with the existing URL-handling pattern.
- **`CDVPluginNotifications.h`** — declare the new `CDVPluginContinueUserActivityNotification` constant.
- **`CDVPlugin.m`** — define the new notification constant.

Plugins can now observe `CDVPluginContinueUserActivityNotification` to receive Universal Links and other `NSUserActivity` events.

Fixes #1654

Generated-By: Claude Sonnet 4.6