### PR TITLE
fix(statusbar): Support setting alpha from the JS API

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVStatusBarInternal/CDVStatusBarInternal.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVStatusBarInternal/CDVStatusBarInternal.m
@@ -37,8 +37,9 @@
     NSInteger valueR = [[command argumentAtIndex:0 withDefault:@0] integerValue];
     NSInteger valueG = [[command argumentAtIndex:1 withDefault:@0] integerValue];
     NSInteger valueB = [[command argumentAtIndex:2 withDefault:@0] integerValue];
+    float valueA = [[command argumentAtIndex:3 withDefault:@1.f] floatValue];
 
-    UIColor *bgColor = [UIColor colorWithRed:valueR/255.f green:valueG/255.f blue:valueB/255.f alpha:1.f];
+    UIColor *bgColor = [UIColor colorWithRed:valueR/255.f green:valueG/255.f blue:valueB/255.f alpha:valueA];
     [self.viewController setStatusBarBackgroundColor:bgColor];
 }
 

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -64,7 +64,7 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
             return;
         }
 
-        var rgbVals = rgbStr.match(/\d+/g).map(function (v) { return parseInt(v, 10); });
+        var rgbVals = rgbStr.match(/[\d.]+/g).map(function (v, i) { return (i < 3) ? parseInt(v, 10) : parseFloat(v); });
         if (rgbVals.length < 3) {
             return;
         }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,8 @@ module.exports = defineConfig([
     globalIgnores([
         '**/coverage/',
         'templates/project/',
-        'tests/spec/fixtures/'
+        'tests/spec/fixtures/',
+        'tests/CordovaLibTests/'
     ]),
     ...nodeConfig,
     ...nodeTestConfig.map(config => ({

--- a/tests/CordovaLibTests/CDVStatusBarTests.m
+++ b/tests/CordovaLibTests/CDVStatusBarTests.m
@@ -1,0 +1,184 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <Cordova/Cordova.h>
+#import "CDVWebViewEngine.h"
+#import "CordovaApp-Swift.h"
+#import "CDVTestHelpers.h"
+
+@interface CDVStatusBarTests : XCTestCase
+
+@property AppDelegate* appDelegate;
+@property (nonatomic, strong) CDVWebViewEngine* plugin;
+@property (nonatomic, strong) CDVViewController* viewController;
+
+@end
+
+@implementation CDVStatusBarTests
+
+- (void)setUp {
+    [super setUp];
+
+    self.appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
+    [self.appDelegate createViewController];
+    self.viewController = self.appDelegate.testViewController;
+
+    self.plugin = (CDVWebViewEngine *)self.viewController.webViewEngine;
+}
+
+- (void)tearDown {
+    [self.appDelegate destroyViewController];
+    [super tearDown];
+}
+
+- (void) testStatusBarBackgroundColorNamedColor {
+    CGFloat rgba[4] = {0.f, 0.f, 0.f, 0.f};
+
+    [self.viewController loadStartPage];
+
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    __block XCTestExpectation *redExpectation = [self expectationWithDescription:@"red"];
+    [self.plugin evaluateJavaScript:@"window.statusbar.setBackgroundColor('red');" completionHandler:^(id _, NSError* error) {
+        XCTAssertNil(error);
+        [redExpectation fulfill];
+    }];
+    [self waitForExpectations:@[redExpectation] timeout:5];
+
+    [self.viewController.statusBarBackgroundColor getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
+    XCTAssertEqual(rgba[0], 1.f);
+    XCTAssertEqual(rgba[1], 0.f);
+    XCTAssertEqual(rgba[2], 0.f);
+    XCTAssertEqual(rgba[3], 1.f);
+}
+
+- (void) testStatusBarBackgroundColor3HexColor {
+    CGFloat rgba[4] = {0.f, 0.f, 0.f, 0.f};
+
+    [self.viewController loadStartPage];
+
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    __block XCTestExpectation *redExpectation = [self expectationWithDescription:@"red"];
+    [self.plugin evaluateJavaScript:@"window.statusbar.setBackgroundColor('#f00');" completionHandler:^(id _, NSError* error) {
+        XCTAssertNil(error);
+        [redExpectation fulfill];
+    }];
+    [self waitForExpectations:@[redExpectation] timeout:5];
+
+    [self.viewController.statusBarBackgroundColor getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
+    XCTAssertEqual(rgba[0], 1.f);
+    XCTAssertEqual(rgba[1], 0.f);
+    XCTAssertEqual(rgba[2], 0.f);
+    XCTAssertEqual(rgba[3], 1.f);
+}
+
+- (void) testStatusBarBackgroundColor6HexColor {
+    CGFloat rgba[4] = {0.f, 0.f, 0.f, 0.f};
+
+    [self.viewController loadStartPage];
+
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    __block XCTestExpectation *redExpectation = [self expectationWithDescription:@"red"];
+    [self.plugin evaluateJavaScript:@"window.statusbar.setBackgroundColor('#ff0000');" completionHandler:^(id _, NSError* error) {
+        XCTAssertNil(error);
+        [redExpectation fulfill];
+    }];
+    [self waitForExpectations:@[redExpectation] timeout:5];
+
+    [self.viewController.statusBarBackgroundColor getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
+    XCTAssertEqual(rgba[0], 1.f);
+    XCTAssertEqual(rgba[1], 0.f);
+    XCTAssertEqual(rgba[2], 0.f);
+    XCTAssertEqual(rgba[3], 1.f);
+}
+
+- (void) testStatusBarBackgroundColor8HexColor {
+    CGFloat rgba[4] = {0.f, 0.f, 0.f, 0.f};
+
+    [self.viewController loadStartPage];
+
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    __block XCTestExpectation *redExpectation = [self expectationWithDescription:@"red"];
+    [self.plugin evaluateJavaScript:@"window.statusbar.setBackgroundColor('#ff000080');" completionHandler:^(id _, NSError* error) {
+        XCTAssertNil(error);
+        [redExpectation fulfill];
+    }];
+    [self waitForExpectations:@[redExpectation] timeout:5];
+
+    [self.viewController.statusBarBackgroundColor getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
+    XCTAssertEqual(rgba[0], 1.f);
+    XCTAssertEqual(rgba[1], 0.f);
+    XCTAssertEqual(rgba[2], 0.f);
+    XCTAssertEqual(rgba[3], 0.5f);
+}
+
+- (void) testStatusBarBackgroundColorRGB {
+    CGFloat rgba[4] = {0.f, 0.f, 0.f, 0.f};
+
+    [self.viewController loadStartPage];
+
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    __block XCTestExpectation *redExpectation = [self expectationWithDescription:@"red"];
+    [self.plugin evaluateJavaScript:@"window.statusbar.setBackgroundColor('rgb(255, 0, 0)');" completionHandler:^(id _, NSError* error) {
+        XCTAssertNil(error);
+        [redExpectation fulfill];
+    }];
+    [self waitForExpectations:@[redExpectation] timeout:5];
+
+    [self.viewController.statusBarBackgroundColor getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
+    XCTAssertEqual(rgba[0], 1.f);
+    XCTAssertEqual(rgba[1], 0.f);
+    XCTAssertEqual(rgba[2], 0.f);
+    XCTAssertEqual(rgba[3], 1.f);
+}
+
+- (void) testStatusBarBackgroundColorRGBA {
+    CGFloat rgba[4] = {0.f, 0.f, 0.f, 0.f};
+
+    [self.viewController loadStartPage];
+
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    __block XCTestExpectation *redExpectation = [self expectationWithDescription:@"red"];
+    [self.plugin evaluateJavaScript:@"window.statusbar.setBackgroundColor('rgba(255, 0, 0, 0.25)');" completionHandler:^(id _, NSError* error) {
+        XCTAssertNil(error);
+        [redExpectation fulfill];
+    }];
+    [self waitForExpectations:@[redExpectation] timeout:5];
+
+    [self.viewController.statusBarBackgroundColor getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
+    XCTAssertEqual(rgba[0], 1.f);
+    XCTAssertEqual(rgba[1], 0.f);
+    XCTAssertEqual(rgba[2], 0.f);
+    XCTAssertEqual(rgba[3], 0.25f);
+}
+
+@end

--- a/tests/CordovaLibTests/CDVTestHelpers.h
+++ b/tests/CordovaLibTests/CDVTestHelpers.h
@@ -17,24 +17,13 @@
     under the License.
 */
 
-import WebKit
-import Cordova
+#import <WebKit/WebKit.h>
+#import <XCTest/XCTest.h>
 
-class DeviceReadyScriptHandler : NSObject, WKScriptMessageHandler {
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        NotificationCenter.default.post(name: NSNotification.Name("CDVTestingDeviceReadyFired"), object: nil)
-    }
-}
+extern const NSNotificationName CDVTestingDeviceReadyFired;
 
-class ViewController: CDVViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
+@interface TestNavigationDelegate : NSObject <WKNavigationDelegate>
+@property (nonatomic, copy) void (^didFinishNavigation)(WKWebView *, WKNavigation *);
 
-        if let wkWebView = self.webView as? WKWebView {
-            let controller = wkWebView.configuration.userContentController
-            let deviceReadyScriptHandler = DeviceReadyScriptHandler()
-
-            controller.add(deviceReadyScriptHandler, name: "cordovaTesting")
-        }
-    }
-}
+- (void)waitForDidFinishNavigation:(XCTestExpectation *)expectation;
+@end

--- a/tests/CordovaLibTests/CDVTestHelpers.m
+++ b/tests/CordovaLibTests/CDVTestHelpers.m
@@ -17,24 +17,25 @@
     under the License.
 */
 
-import WebKit
-import Cordova
+#import "CDVTestHelpers.h"
 
-class DeviceReadyScriptHandler : NSObject, WKScriptMessageHandler {
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        NotificationCenter.default.post(name: NSNotification.Name("CDVTestingDeviceReadyFired"), object: nil)
-    }
+const NSNotificationName CDVTestingDeviceReadyFired = @"CDVTestingDeviceReadyFired";
+
+@implementation TestNavigationDelegate
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
+{
+    if (_didFinishNavigation)
+        _didFinishNavigation(webView, navigation);
 }
 
-class ViewController: CDVViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
+- (void)waitForDidFinishNavigation:(XCTestExpectation *)expectation
+{
+    XCTAssertFalse(self.didFinishNavigation);
 
-        if let wkWebView = self.webView as? WKWebView {
-            let controller = wkWebView.configuration.userContentController
-            let deviceReadyScriptHandler = DeviceReadyScriptHandler()
-
-            controller.add(deviceReadyScriptHandler, name: "cordovaTesting")
-        }
-    }
+    __weak TestNavigationDelegate *weakSelf = self;
+    self.didFinishNavigation = ^(WKWebView *_view, WKNavigation *_nav) {
+        [expectation fulfill];
+        weakSelf.didFinishNavigation = nil;
+    };
 }
+@end

--- a/tests/CordovaLibTests/CDVWebViewEngineTest.m
+++ b/tests/CordovaLibTests/CDVWebViewEngineTest.m
@@ -23,8 +23,8 @@
 #import <Cordova/CDVWebViewProcessPoolFactory.h>
 #import <Cordova/CDVSettingsDictionary.h>
 #import <Cordova/CDVAvailability.h>
-
 #import "CordovaApp-Swift.h"
+#import "CDVTestHelpers.h"
 
 @interface CDVWebViewEngineTest : XCTestCase
 
@@ -41,40 +41,14 @@
 
 @end
 
-@interface TestNavigationDelegate : NSObject <WKNavigationDelegate>
-@property (nonatomic, copy) void (^didFinishNavigation)(WKWebView *, WKNavigation *);
-
-- (void)waitForDidFinishNavigation:(XCTestExpectation *)expectation;
-@end
-
 @interface WKWebView ()
 @property (nonatomic, readonly) pid_t _webProcessIdentifier;
-@end
-
-@implementation TestNavigationDelegate
-- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
-{
-    if (_didFinishNavigation)
-        _didFinishNavigation(webView, navigation);
-}
-
-- (void)waitForDidFinishNavigation:(XCTestExpectation *)expectation
-{
-    XCTAssertFalse(self.didFinishNavigation);
-
-    __weak TestNavigationDelegate *weakSelf = self;
-    self.didFinishNavigation = ^(WKWebView *_view, WKNavigation *_nav) {
-        [expectation fulfill];
-        weakSelf.didFinishNavigation = nil;
-    };
-}
 @end
 
 @implementation CDVWebViewEngineTest
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
 
     self.appDelegate = (AppDelegate*)[[UIApplication sharedApplication] delegate];
     [self.appDelegate createViewController];
@@ -86,7 +60,6 @@
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [self.appDelegate destroyViewController];
     [super tearDown];
 }

--- a/tests/CordovaLibTests/CordovaApp/config.xml
+++ b/tests/CordovaLibTests/CordovaApp/config.xml
@@ -46,9 +46,14 @@
     <preference name="Suppresses3DTouchGesture" value="false" />
     <!-- This settings is just used by the CDVViewControllerTest to assert which config file has been loaded -->
     <preference name="test_CDVConfigFile" value="config.xml" />
-    
+    <preference name="InspectableWebview" value="true" />
+
     <feature name="LocalStorage">
         <param name="ios-package" value="CDVLocalStorage"/>
+    </feature>
+    <feature name="Console">
+        <param name="ios-package" value="CDVLogger"/>
+        <param name="onload" value="true"/>
     </feature>
     <feature name="HandleOpenUrl">
         <param name="ios-package" value="CDVHandleOpenURL"/>
@@ -60,6 +65,10 @@
     </feature>
     <feature name="GestureHandler">
         <param name="ios-package" value="CDVGestureHandler"/>
+        <param name="onload" value="true"/>
+    </feature>
+    <feature name="StatusBarInternal">
+        <param name="ios-package" value="CDVStatusBarInternal"/>
         <param name="onload" value="true"/>
     </feature>
     <feature name="SwiftInit">

--- a/tests/CordovaLibTests/CordovaApp/www/index.html
+++ b/tests/CordovaLibTests/CordovaApp/www/index.html
@@ -66,10 +66,15 @@
 	for more details -jm */
 	function onDeviceReady()
 	{
-    // Used by unit tests to tell when the page is loaded.
-    window.pageIsLoaded = true;
+        // Used by unit tests to tell when the page is loaded.
+        window.pageIsLoaded = true;
+
 		// do your thing!
 		console.log("Cordova is working")
+
+        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.cordovaTesting) {
+            window.webkit.messageHandlers.cordovaTesting.postMessage(null);
+        }
 	}
     
     </script>

--- a/tests/CordovaLibTests/CordovaTests.xcodeproj/project.pbxproj
+++ b/tests/CordovaLibTests/CordovaTests.xcodeproj/project.pbxproj
@@ -27,17 +27,20 @@
 /* Begin PBXBuildFile section */
 		900A9F542CF0677F00FECE7A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900A9F532CF0677F00FECE7A /* ViewController.swift */; };
 		900A9F5A2CF0696300FECE7A /* SwiftInitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900A9F582CF0695D00FECE7A /* SwiftInitPlugin.swift */; };
+		9017CA502FD8206D00F540FC /* www in Resources */ = {isa = PBXBuildFile; fileRef = 9017CA4F2FD8206D00F540FC /* www */; };
+		9017CA532FD820B800F540FC /* cordova.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9017CA522FD820B800F540FC /* cordova.js */; };
 		902530FC29A6DC53004AF1CF /* CDVPluginInitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 902530FA29A6DC53004AF1CF /* CDVPluginInitTests.m */; };
 		905C8BA82CF0756E007EECEF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905C8BA72CF0756E007EECEF /* AppDelegate.swift */; };
 		9085EE302CF0617800603B73 /* Cordova.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0FA7CAC1E4BB6B30077B045 /* Cordova.framework */; };
 		90A775DD2C6F257500FC5BB0 /* CDVSettingsDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90A775DC2C6F256D00FC5BB0 /* CDVSettingsDictionaryTests.m */; };
 		90AE8F9C2EBF03F600FF0979 /* CDVWebViewEngineTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E23F90123E175AD006CD852 /* CDVWebViewEngineTest.m */; };
 		90AE8F9E2EBF0E0700FF0979 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AE8F9D2EBF0E0300FF0979 /* SceneDelegate.swift */; };
+		90B2907E2FD805A2000A7F60 /* CDVStatusBarTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90B2907D2FD8059D000A7F60 /* CDVStatusBarTests.m */; };
+		90B290812FD808DE000A7F60 /* CDVTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 90B290802FD808DD000A7F60 /* CDVTestHelpers.m */; };
 		90D08FEB2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 90D08FEA2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m */; };
 		90D08FED2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D08FEC2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift */; };
 		C0FA7CA11E4BB6420077B045 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = F8EB14D0165FFD3200616F39 /* config.xml */; };
 		C0FA7CA21E4BB6420077B045 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7EF33BD61911ABA20048544E /* Default-568h@2x.png */; };
-		C0FA7CA41E4BB6420077B045 /* www in Resources */ = {isa = PBXBuildFile; fileRef = 30F8AE1C152129DA006625B3 /* www */; };
 		C0FA7CA51E4BB6420077B045 /* config-custom.xml in Resources */ = {isa = PBXBuildFile; fileRef = 5C4C91771C2ACF130055AFC3 /* config-custom.xml */; };
 		C0FA7CB51E4BBBBE0077B045 /* CDVAllowListTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 30356213141049E1006C2D43 /* CDVAllowListTests.m */; };
 		C0FA7CB61E4BBBBE0077B045 /* CDVPluginResultJSONSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 686357B9141002F200DF4CF2 /* CDVPluginResultJSONSerializationTests.m */; };
@@ -62,6 +65,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		9017CA512FD8208E00F540FC /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(SRCROOT)/CordovaApp/www";
+			dstSubfolderSpec = 0;
+			files = (
+				9017CA532FD820B800F540FC /* cordova.js in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C0FA7CDE1E4BC5020077B045 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -79,7 +92,6 @@
 		30356213141049E1006C2D43 /* CDVAllowListTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVAllowListTests.m; sourceTree = "<group>"; };
 		30610C9119AD9B95000B3781 /* CDVCommandDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVCommandDelegateTests.m; sourceTree = "<group>"; };
 		30D1B08B15A2B36D0060C291 /* CDVBase64Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVBase64Tests.m; sourceTree = "<group>"; };
-		30F8AE1C152129DA006625B3 /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = "<group>"; };
 		4E23F90123E175AD006CD852 /* CDVWebViewEngineTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVWebViewEngineTest.m; sourceTree = "<group>"; };
 		5C4C91751C2ACE450055AFC3 /* CDVViewControllerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVViewControllerTest.m; sourceTree = "<group>"; };
 		5C4C91771C2ACF130055AFC3 /* config-custom.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "config-custom.xml"; sourceTree = "<group>"; };
@@ -89,11 +101,16 @@
 		7EF33BD61911ABA20048544E /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		900A9F532CF0677F00FECE7A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		900A9F582CF0695D00FECE7A /* SwiftInitPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftInitPlugin.swift; sourceTree = "<group>"; };
+		9017CA4F2FD8206D00F540FC /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = "<group>"; };
+		9017CA522FD820B800F540FC /* cordova.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = cordova.js; path = ../../templates/project/www/cordova.js; sourceTree = "<group>"; };
 		902530FA29A6DC53004AF1CF /* CDVPluginInitTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVPluginInitTests.m; sourceTree = "<group>"; };
 		905C8BA72CF0756E007EECEF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9085EE2F2CF05B5900603B73 /* CordovaTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CordovaTests.xctestplan; sourceTree = "<group>"; };
 		90A775DC2C6F256D00FC5BB0 /* CDVSettingsDictionaryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVSettingsDictionaryTests.m; sourceTree = "<group>"; };
 		90AE8F9D2EBF0E0300FF0979 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		90B2907D2FD8059D000A7F60 /* CDVStatusBarTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVStatusBarTests.m; sourceTree = "<group>"; };
+		90B2907F2FD808CD000A7F60 /* CDVTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDVTestHelpers.h; sourceTree = "<group>"; };
+		90B290802FD808DD000A7F60 /* CDVTestHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVTestHelpers.m; sourceTree = "<group>"; };
 		90D08FEA2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDVURLSchemeHandlerTest.m; sourceTree = "<group>"; };
 		90D08FEC2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDVSettingsDictionarySwiftTests.swift; sourceTree = "<group>"; };
 		C0FA7CAA1E4BB6420077B045 /* CordovaApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CordovaApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -137,6 +154,7 @@
 		0867D691FE84028FC02AAC07 /* CordovaLib */ = {
 			isa = PBXGroup;
 			children = (
+				9017CA522FD820B800F540FC /* cordova.js */,
 				9085EE2F2CF05B5900603B73 /* CordovaTests.xctestplan */,
 				7EF33BD61911ABA20048544E /* Default-568h@2x.png */,
 				F8EB14D0165FFD3200616F39 /* config.xml */,
@@ -164,7 +182,7 @@
 				905C8BA72CF0756E007EECEF /* AppDelegate.swift */,
 				900A9F532CF0677F00FECE7A /* ViewController.swift */,
 				900A9F592CF0695D00FECE7A /* Plugins */,
-				30F8AE1C152129DA006625B3 /* www */,
+				9017CA4F2FD8206D00F540FC /* www */,
 			);
 			path = CordovaApp;
 			sourceTree = "<group>";
@@ -189,6 +207,9 @@
 		EB3B34F4161B585D003DBE7D /* CordovaTests */ = {
 			isa = PBXGroup;
 			children = (
+				90B290802FD808DD000A7F60 /* CDVTestHelpers.m */,
+				90B2907F2FD808CD000A7F60 /* CDVTestHelpers.h */,
+				90B2907D2FD8059D000A7F60 /* CDVStatusBarTests.m */,
 				90D08FEC2F4E690700A9838F /* CDVSettingsDictionarySwiftTests.swift */,
 				90D08FEA2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m */,
 				90A775DC2C6F256D00FC5BB0 /* CDVSettingsDictionaryTests.m */,
@@ -214,10 +235,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C0FA7CA71E4BB6420077B045 /* Build configuration list for PBXNativeTarget "CordovaApp" */;
 			buildPhases = (
+				9017CA512FD8208E00F540FC /* CopyFiles */,
 				C0FA7C9A1E4BB6420077B045 /* Sources */,
 				C0FA7C9E1E4BB6420077B045 /* Frameworks */,
 				C0FA7CA01E4BB6420077B045 /* Resources */,
-				C0FA7CA61E4BB6420077B045 /* Copy cordova.js into www directory */,
 				C0FA7CDE1E4BC5020077B045 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -288,9 +309,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9017CA502FD8206D00F540FC /* www in Resources */,
 				C0FA7CA11E4BB6420077B045 /* config.xml in Resources */,
 				C0FA7CA21E4BB6420077B045 /* Default-568h@2x.png in Resources */,
-				C0FA7CA41E4BB6420077B045 /* www in Resources */,
 				C0FA7CA51E4BB6420077B045 /* config-custom.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -304,27 +325,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		C0FA7CA61E4BB6420077B045 /* Copy cordova.js into www directory */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"",
-				"$(SRCROOT)/../../templates/project/www/cordova.js",
-			);
-			name = "Copy cordova.js into www directory";
-			outputPaths = (
-				$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/www/cordova.js,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cp ../../templates/project/www/cordova.js \"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/www/cordova.js\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C0FA7C9A1E4BB6420077B045 /* Sources */ = {
@@ -350,6 +350,8 @@
 				C0FA7CB91E4BBBBE0077B045 /* CDVBase64Tests.m in Sources */,
 				90A775DD2C6F257500FC5BB0 /* CDVSettingsDictionaryTests.m in Sources */,
 				C0FA7CBA1E4BBBBE0077B045 /* CDVFakeFileManager.m in Sources */,
+				90B2907E2FD805A2000A7F60 /* CDVStatusBarTests.m in Sources */,
+				90B290812FD808DE000A7F60 /* CDVTestHelpers.m in Sources */,
 				C0FA7CBB1E4BBBBE0077B045 /* CDVViewControllerTest.m in Sources */,
 				90D08FEB2F4E63CA00A9838F /* CDVURLSchemeHandlerTest.m in Sources */,
 				C0FA7CBC1E4BBBBE0077B045 /* CDVInvokedUrlCommandTests.m in Sources */,
@@ -581,6 +583,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
@@ -619,6 +622,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = (

--- a/tests/CordovaLibTests/CordovaTests.xctestplan
+++ b/tests/CordovaLibTests/CordovaTests.xctestplan
@@ -29,6 +29,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:CordovaLibTests\/CordovaTests.xcodeproj",
         "identifier" : "C0FA7CB11E4BBBBE0077B045",


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Closes GH-1659
- The supported format is any valid [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value) value, for e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`

### Description
<!-- Describe your changes in detail -->
Use the alpha value from JS for the status bar background if it is provided, otherwise fallback to opaque (matching the current behaviour)


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
