### PR TITLE
fix(visionOS): Fix CordovaLib visionOS errors

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -577,20 +577,24 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)scrollViewDidChangeAdjustedContentInset:(UIScrollView *)scrollView
 {
+#ifndef TARGET_OS_VISION
     if (self.webView.hidden) {
         self.statusBar.hidden = true;
         return;
     }
 
     self.statusBar.hidden = (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever);
+#endif
 }
 
+#ifndef TARGET_OS_VISION
 - (BOOL)prefersStatusBarHidden
 {
     // The CDVStatusBar plugin overrides this in a category extension, and
     // should bypass this implementation entirely
     return self.statusBar.alpha < 0.0001f;
 }
+#endif
 
 #pragma mark - View Setup
 
@@ -727,6 +731,7 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)createStatusBarView
 {
+#ifndef TARGET_OS_VISION
     // If cordova-plugin-statusbar is loaded, we'll let it handle the status
     // bar to avoid introducing conflict
     if (NSClassFromString(@"CDVStatusBar") != nil)
@@ -743,6 +748,7 @@ static UIColor *defaultBackgroundColor(void) {
     [self.statusBar.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
 
     self.statusBar.hidden = YES;
+#endif
 }
 
 - (void)loadStartPage
@@ -883,8 +889,10 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)showStatusBar:(BOOL)visible
 {
+#ifndef TARGET_OS_VISION
     [self.statusBar setAlpha:(visible ? 1 : 0)];
     [self setNeedsStatusBarAppearanceUpdate];
+#endif
 }
 
 - (void)parseSettingsWithParser:(id <NSXMLParserDelegate>)delegate


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
visionOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
While testing the minimum version stuff, I discovered that CordovaLib wasn't compiling for visionOS due to some of the status bar code (since visionOS doesn't have a status bar). Although we don't really treat visionOS as a supported target platform, it's nice to have it not be broken.


### Description
<!-- Describe your changes in detail -->


Wrap the status bar code in conditionals so that we don't run that code on visionOS. The other spots where we try to set the background colour of the status bar are safe because self.statusBar will be nil and it's safe to send messages to nil.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Compiled CordovaLib for visionOS with no errors.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
