### PR TITLE
chore: ignore SPM dependency resolution `Package.resolved`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,12 @@ npm-debug.log
 .nyc_output/
 **/www/cordova.js
 
-# Swift Package Manager (SPM) build artifacts
+# Swift Package Manager (SPM)
+# Build artifacts
 .build/
+# Dependency resolution
+Package.resolved
 
 # ASF release workspace
 .asf-release/
 !.asf-release/.gitkeep
-
-# Swift Package Manager lockfile
-Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ npm-debug.log
 # ASF release workspace
 .asf-release/
 !.asf-release/.gitkeep
+
+# Swift Package Manager lockfile
+Package.resolved


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I had two untracked files after using the git version:
- tests/spec/fixtures/org.test.plugins.swiftpackagecocoapodplugin/Package.resolved
- tests/spec/fixtures/org.test.plugins.swiftpackageplugin/Package.resolved

I think they should not be checked in.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
