### PR TITLE
fix: proper macro check for `TARGET_OS_VISION`

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -403,7 +403,7 @@ static UIColor *defaultBackgroundColor(void) {
 {
     [super viewDidAppear:animated];
 
-#if TARGET_OS_MACCATALYST
+#if defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST
     BOOL hideTitlebar = [self.settings cordovaBoolSettingForKey:@"HideDesktopTitlebar" defaultValue:NO];
     if (hideTitlebar) {
         UIWindowScene *scene = self.view.window.windowScene;
@@ -577,7 +577,7 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)scrollViewDidChangeAdjustedContentInset:(UIScrollView *)scrollView
 {
-#if !TARGET_OS_VISION
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
     if (self.webView.hidden) {
         self.statusBar.hidden = true;
         return;
@@ -587,7 +587,7 @@ static UIColor *defaultBackgroundColor(void) {
 #endif
 }
 
-#if !TARGET_OS_VISION
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
 - (BOOL)prefersStatusBarHidden
 {
     // The CDVStatusBar plugin overrides this in a category extension, and
@@ -731,7 +731,7 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)createStatusBarView
 {
-#if !TARGET_OS_VISION
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
     // If cordova-plugin-statusbar is loaded, we'll let it handle the status
     // bar to avoid introducing conflict
     if (NSClassFromString(@"CDVStatusBar") != nil)
@@ -889,7 +889,7 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)showStatusBar:(BOOL)visible
 {
-#if !TARGET_OS_VISION
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
     [self.statusBar setAlpha:(visible ? 1 : 0)];
     [self setNeedsStatusBarAppearanceUpdate];
 #endif

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -577,7 +577,7 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)scrollViewDidChangeAdjustedContentInset:(UIScrollView *)scrollView
 {
-#ifndef TARGET_OS_VISION
+#if !TARGET_OS_VISION
     if (self.webView.hidden) {
         self.statusBar.hidden = true;
         return;
@@ -587,7 +587,7 @@ static UIColor *defaultBackgroundColor(void) {
 #endif
 }
 
-#ifndef TARGET_OS_VISION
+#if !TARGET_OS_VISION
 - (BOOL)prefersStatusBarHidden
 {
     // The CDVStatusBar plugin overrides this in a category extension, and
@@ -731,7 +731,7 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)createStatusBarView
 {
-#ifndef TARGET_OS_VISION
+#if !TARGET_OS_VISION
     // If cordova-plugin-statusbar is loaded, we'll let it handle the status
     // bar to avoid introducing conflict
     if (NSClassFromString(@"CDVStatusBar") != nil)
@@ -889,7 +889,7 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (void)showStatusBar:(BOOL)visible
 {
-#ifndef TARGET_OS_VISION
+#if !TARGET_OS_VISION
     [self.statusBar setAlpha:(visible ? 1 : 0)];
     [self setNeedsStatusBarAppearanceUpdate];
 #endif


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- `TARGET_OS_VISION` is defined by Apple’s headers as a macro with a value, so `#ifndef TARGET_OS_VISION` is the wrong test. On iPhone it is typically defined as 0, which still makes `#ifndef` false. That means the guarded code gets excluded even though you are not on visionOS.
- Test the macro by `#if !TARGET_OS_VISION` instead of `#ifndef TARGET_OS_VISION`
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->

- During testing the status bar, I could no longer set the status bar background color, though `viewport-fit=contain` was set in `<meta name="viewport" content="...">`. After doing some analyzes with Copilot, I saw the added changes for checking `TARGET_OS_VISION` and commented them out. After that, the status bar was visible again with the set background color. GPT helped me to make a proper check of the macro.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Setting the status bar background color by preference `StatusBarBackgroundColor` and `<meta name="theme-color" content="#ffff00">` on a iOS 26.5 simulator.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
