### PR TITLE
doc(statusbar.js): document `visible` property and `setBackgroundColor` method

### DIFF
--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -52,6 +52,13 @@ Object.defineProperty(statusBar, 'visible', {
     }
 });
 
+/**
+ * Sets the background color of the status bar, which will visually only have an impact,
+ * if the status bar is visible. The supported format is any valid CSS color value,
+ * like `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
+ * If cordova-plugin-statusbar is installed, the call will be forwarded to
+ * `window.StatusBar.backgroundColorByHexString`, which will not support an alpha value.
+ */
 Object.defineProperty(statusBar, 'setBackgroundColor', {
     configurable: false,
     enumerable: false,

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -26,6 +26,10 @@ var statusBar = {};
 const statusBarScript = document.createElement('script');
 document.head.appendChild(statusBarScript);
 
+/**
+ * Sets the visibility of the status bar. If cordova-plugin-statusbar is used
+ * the call will be forwarded to `window.StatusBar.show` or `window.StatusBar.hide` of the plugin.
+ */
 Object.defineProperty(statusBar, 'visible', {
     configurable: false,
     enumerable: true,

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -58,9 +58,9 @@ Object.defineProperty(statusBar, 'visible', {
 /**
  * Sets the background color of the visible status bar.
  * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
- * 
+ *
  * Note: Runtime support for all valid CSS color formats is fully functional since cordova-ios 8.1.1.
- * 
+ *
  * Note: This is intended for special cases only, and not a recommended API. The recommended way
  * to set the background colour of the status bar is with the `<meta name="theme-color">` tag.
  */

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -59,7 +59,7 @@ Object.defineProperty(statusBar, 'visible', {
 /**
  * Sets the background color of the visible status bar.
  * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
- * 
+ *
  * If cordova-plugin-statusbar is installed, calls are forwarded to the plugin API:
  * `window.StatusBar.backgroundColorByHexString`
  * See {@link https://s.apache.org/cdv-plugin-statusbar} for cordova-plugin-statusbar details.

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -58,9 +58,7 @@ Object.defineProperty(statusBar, 'visible', {
 /**
  * Sets the background color of the visible status bar.
  * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
- *
- * Note: Runtime support for all valid CSS color formats is fully functional since cordova-ios 8.1.1.
- *
+ * Alpha is supported since cordova-ios 8.1.1.
  * Note: This is intended for special cases only, and not a recommended API. The recommended way
  * to set the background colour of the status bar is with the `<meta name="theme-color">` tag.
  */

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -60,6 +60,9 @@ Object.defineProperty(statusBar, 'visible', {
  * Sets the background color of the visible status bar.
  * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
  *
+ * Note: Runtime support for all valid CSS color formats is fully functional since
+ * cordova-ios 8.1.1.
+ *
  * If cordova-plugin-statusbar is installed, calls are forwarded to the plugin API:
  * `window.StatusBar.backgroundColorByHexString`
  * See {@link https://s.apache.org/cdv-plugin-statusbar} for cordova-plugin-statusbar details.

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -27,23 +27,22 @@ const statusBarScript = document.createElement('script');
 document.head.appendChild(statusBarScript);
 
 /**
- * Sets the visibility of the status bar. If cordova-plugin-statusbar is used
- * the call will be forwarded to `window.StatusBar.show` or `window.StatusBar.hide` of the plugin.
+ * Hides or shows the system status bar. No status bar will be visible at all when false is passed.
  */
 Object.defineProperty(statusBar, 'visible', {
     configurable: false,
     enumerable: true,
     get: function () {
+        // If cordova-plugin-statusbar is installed fallback to it for compatibility reasons
         if (window.StatusBar) {
-            // Let the CDVStatusBar plugin handle it
             return window.StatusBar.isVisible;
         }
 
         return statusBarVisible;
     },
     set: function (value) {
+        // If cordova-plugin-statusbar is installed fallback to it for compatibility reasons
         if (window.StatusBar) {
-            // Let the CDVStatusBar plugin handle it
             if (value) {
                 window.StatusBar.show();
             } else {
@@ -59,13 +58,11 @@ Object.defineProperty(statusBar, 'visible', {
 /**
  * Sets the background color of the visible status bar.
  * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
- *
- * Note: Runtime support for all valid CSS color formats is fully functional since
- * cordova-ios 8.1.1.
- *
- * If cordova-plugin-statusbar is installed, calls are forwarded to the plugin API:
- * `window.StatusBar.backgroundColorByHexString`
- * See {@link https://s.apache.org/cdv-plugin-statusbar} for cordova-plugin-statusbar details.
+ * 
+ * Note: This is intended for special cases only, and not a recommended API. The recommended way
+ * to set the background colour of the status bar is with the `<meta name="theme-color">` tag.
+ * 
+ * Note: Runtime support for all valid CSS color formats is fully functional since cordova-ios 8.1.1.
  */
 Object.defineProperty(statusBar, 'setBackgroundColor', {
     configurable: false,
@@ -84,6 +81,7 @@ Object.defineProperty(statusBar, 'setBackgroundColor', {
             return;
         }
 
+        // If cordova-plugin-statusbar is installed fallback to it for compatibility reasons
         if (window.StatusBar) {
             window.StatusBar.backgroundColorByHexString('#' + rgbVals[0].toString(16).padStart(2, '0') + rgbVals[1].toString(16).padStart(2, '0') + rgbVals[2].toString(16).padStart(2, '0'));
         } else {

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -57,11 +57,12 @@ Object.defineProperty(statusBar, 'visible', {
 });
 
 /**
- * Sets the background color of the status bar, which will visually only have an impact,
- * if the status bar is visible. The supported format is any valid CSS color value,
- * like `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
- * If cordova-plugin-statusbar is installed, the call will be forwarded to
- * `window.StatusBar.backgroundColorByHexString`, which will not support an alpha value.
+ * Sets the background color of the visible status bar.
+ * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
+ * 
+ * If cordova-plugin-statusbar is installed, calls are forwarded to the plugin API:
+ * `window.StatusBar.backgroundColorByHexString`
+ * See {@link https://s.apache.org/cdv-plugin-statusbar} for cordova-plugin-statusbar details.
  */
 Object.defineProperty(statusBar, 'setBackgroundColor', {
     configurable: false,

--- a/cordova-js-src/plugin/ios/statusbar.js
+++ b/cordova-js-src/plugin/ios/statusbar.js
@@ -59,10 +59,10 @@ Object.defineProperty(statusBar, 'visible', {
  * Sets the background color of the visible status bar.
  * Supports valid CSS color values, e.g. `rebeccapurple`, `#RRGGBBAA`, `rgb(255 0 153)`.
  * 
+ * Note: Runtime support for all valid CSS color formats is fully functional since cordova-ios 8.1.1.
+ * 
  * Note: This is intended for special cases only, and not a recommended API. The recommended way
  * to set the background colour of the status bar is with the `<meta name="theme-color">` tag.
- * 
- * Note: Runtime support for all valid CSS color formats is fully functional since cordova-ios 8.1.1.
  */
 Object.defineProperty(statusBar, 'setBackgroundColor', {
     configurable: false,


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Document `visible` property
  - Make clear that this hides the system status bar completely when `false` is set.
- Document `setBackgroundColor`
  - Document that the supported format for `setBackgroundColor` is any valid CSS color and adding some examples.
  - Add minimum cordova-ios version for full CSS color formats support which is 8.1.1
  - Mention that `setBackgroundColor` is intended for special cases only, and not a recommended API. The recommended way to set the background colour of the status bar is with the `<meta name="theme-color">` tag.
- The comments don't make references to the status bar plugin, because that is likely to add to developer confusion about whether the status bar plugin is required or not. If people are using the status bar plugin, they should be calling its APIs. We added the fallback for compatibility reasons, not to encourage mixing the two.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
