### PR TITLE
chore(workflow): more refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Node CI
+name: CI
 
 on:
   push:
@@ -95,7 +95,7 @@ jobs:
           CI: true
 
   test-node:
-    name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
+    name: NodeJS ${{ matrix.node-version }} Testing on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
 
       - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
-  darwin:
-    name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
+  test-native:
+    name: Native Testing on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     permissions:
@@ -61,11 +61,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x, 26.x]
-        os: [macos-26]
+        os: [macos-15, macos-26, macos-26-intel]
 
     env:
-      CDV_IOS_SIM: iPhone 17
+      CDV_IOS_SIM: ${{ matrix.os == 'macos-15' && 'iPhone 16e' || 'iPhone 17' }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -73,10 +72,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: latest
 
       - name: Environment Information
         run: |
@@ -91,19 +89,12 @@ jobs:
       - name: npm install and test
         timeout-minutes: 40
         run: |
-          npm i -g ios-deploy
-          npm cit
+          npm ci
+          npm run test:xcode
         env:
           CI: true
 
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: success()
-        with:
-          name: ${{ runner.os }} node.js ${{ matrix.node-version }} (darwin)
-          token: ${{ secrets.CORDOVA_CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
-  non-darwin:
+  test-node:
     name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
@@ -113,7 +104,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x, 26.x]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -121,8 +112,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -130,6 +120,11 @@ jobs:
         run: |
           node --version
           npm --version
+
+      - name: Setup ios-deploy for Darwin
+        if: runner.os == 'macOS'
+        run: |
+          npm i -g ios-deploy
 
       - name: npm install and test
         timeout-minutes: 40
@@ -143,6 +138,6 @@ jobs:
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: success()
         with:
-          name: ${{ runner.os }} node.js ${{ matrix.node-version }} (non-darwin)
+          name: ${{ runner.os }} node.js ${{ matrix.node-version }}
           token: ${{ secrets.CORDOVA_CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Refactor the workflow jobs to be about the area it tests not environment.

### Description
<!-- Describe your changes in detail -->

* Rename 'darwin' job to 'test-native'

The 'test-native' job will run only xcode tests.

It will run on the 'macos-15', 'macos-26', and 'macos-26-intel' environment.

It continues to setup node, but will only run again the 'latest' version. It is required for building 'cordova.js' which is still used in native testing.

* Rename 'non-darwin' job to 'test-node'

The 'test-node' job will run node tests & code coverage in all environments: 'ubuntu-latest', 'windows-latest', 'macos-latest'

A Darwin setup step was also added for installing 'ios-deploy'.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
