### PR TITLE
release(8.1.1): updated release notes & version

### DIFF
--- a/CordovaLib/Info.plist
+++ b/CordovaLib/Info.plist
@@ -35,7 +35,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>8.1.1-dev.0</string>
+	<string>8.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -23,11 +23,34 @@
 
 Cordova is a framework that enables developers to include the Cordova API in their iOS application projects easily, and also create new Cordova-based iOS application projects through the command-line.
 
+### 8.1.1
+
+**Fixes:**
+
+* fix: dont call nativeFetchMessages if not implemented ([#1643](https://github.com/apache/cordova-ios/pull/1643)) [[355f39be](https://github.com/apache/cordova-ios/commit/355f39be)]
+* fix: proper macro check for `TARGET_OS_VISION` ([#1667](https://github.com/apache/cordova-ios/pull/1667)) [[fefb9316](https://github.com/apache/cordova-ios/commit/fefb9316)]
+* fix(statusbar): Support setting alpha from the JS API ([#1661](https://github.com/apache/cordova-ios/pull/1661)) [[410ada64](https://github.com/apache/cordova-ios/commit/410ada64)]
+* fix(visionOS): Fix CordovaLib visionOS errors ([#1665](https://github.com/apache/cordova-ios/pull/1665)) [[25486db2](https://github.com/apache/cordova-ios/commit/25486db2)]
+* fix(wkwebview): fix ViewController being the ScriptMessageHandler ([#1664](https://github.com/apache/cordova-ios/pull/1664)) [[5669c2c9](https://github.com/apache/cordova-ios/commit/5669c2c9)]
+* fix: add missing availability macros and add tests to ensure it's set ([#1662](https://github.com/apache/cordova-ios/pull/1662)) [[49230b01](https://github.com/apache/cordova-ios/commit/49230b01)]
+
+**Others:**
+
+* chore: ignore SPM dependency resolution `Package.resolved` ([#1666](https://github.com/apache/cordova-ios/pull/1666)) [[0f404b10](https://github.com/apache/cordova-ios/commit/0f404b10)]
+* chore: release notes for 8.1.0 [[3d52d7b3](https://github.com/apache/cordova-ios/commit/3d52d7b3)]
+* chore: bump version to 8.1.1-dev.0 [[a2f0cc54](https://github.com/apache/cordova-ios/commit/a2f0cc54)]
+* chore(ci): update & clean workflow ([#1673](https://github.com/apache/cordova-ios/pull/1673)) [[4994749e](https://github.com/apache/cordova-ios/commit/4994749e)]
+* chore(deps-dev): bump js-yaml from 4.1.1 to 4.3.0 ([#1672](https://github.com/apache/cordova-ios/pull/1672)) [[bd0c99b4](https://github.com/apache/cordova-ios/commit/bd0c99b4)]
+* chore(deps-dev): bump tmp from 0.2.6 to 0.2.7 ([#1668](https://github.com/apache/cordova-ios/pull/1668)) [[c20cdc93](https://github.com/apache/cordova-ios/commit/c20cdc93)]
+* chore(deps-dev): bump tmp from 0.2.5 to 0.2.6 ([#1657](https://github.com/apache/cordova-ios/pull/1657)) [[7db38623](https://github.com/apache/cordova-ios/commit/7db38623)]
+* chore(workflow): more refactoring ([#1674](https://github.com/apache/cordova-ios/pull/1674)) [[eb65a51e](https://github.com/apache/cordova-ios/commit/eb65a51e)]
+
 ### 8.1.0 (May 26, 2026)
+
 **Fixes:**
 
 * [GH-1653](https://github.com/apache/cordova-ios/pull/1653) fix(actions): fix CDVURLSchemeHandlerTest warnings
-* [GH-1652](https://github.com/apache/cordova-ios/pull/1652) fix(actions): IPhone 16e not found on macOS 26 for latest OS
+* [GH-1652](https://github.com/apache/cordova-ios/pull/1652) fix(actions): iPhone 16e not found on macOS 26 for latest OS
 * [GH-1640](https://github.com/apache/cordova-ios/pull/1640) fix: `NSInternalInconsistencyException: "No response has been sent for this task"` - second attempt
 * [GH-1637](https://github.com/apache/cordova-ios/pull/1637) fix(build): Target a generic **iOS** simulator for building
 * [GH-1632](https://github.com/apache/cordova-ios/pull/1632) fix(ionic): Add workaround for Ionic WebView plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-ios",
-  "version": "8.1.1-dev.0",
+  "version": "8.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-ios",
-      "version": "8.1.1-dev.0",
+      "version": "8.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "bplist-parser": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "8.1.1-dev.0",
+  "version": "8.1.1",
   "description": "cordova-ios release",
   "types": "./types/index.d.ts",
   "main": "lib/Api.js",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

8.1.1 Release Draft

> [!NOTE]
> [CDVAvailability.h](https://github.com/apache/cordova-ios/blob/chore/draft-8.1.1/CordovaLib/include/Cordova/CDVAvailability.h#L89-L102) is already bumped.