### PR TITLE
chore(docs): pass new EventEmitter when creating iOS project instance

### DIFF
--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -62,11 +62,14 @@ const xcodeProject = xcode.project(pbxprojPath);
 
 ```js
 // New code
+const EventEmitter = require('node:events');
+const eventEmitter = new EventEmitter();
+
 const projectRoot = context.opts.projectRoot;
 const platformPath = path.join(projectRoot, 'platforms', 'ios');
 
 const cordova_ios = require('cordova-ios');
-const iosProject = new cordova_ios('ios', platformPath);
+const iosProject = new cordova_ios('ios', platformPath, eventEmitter);
 
 const xcodeProject = xcode.project(iosProject.locations.pbxproj);
 ```


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When a new EventEmitter is not passed into the project instance, it seems to stack with the existing emitter and can experience duplicate printout.

### Description
<!-- Describe your changes in detail -->

Pass in a new event emitter to prevent duplicate printouts.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
