### PR TITLE
chore(doc): document deprecation of `CDVPluginResult.associatedObject` with samples

### DIFF
--- a/CordovaLib/CordovaLib.docc/upgrading-8.md
+++ b/CordovaLib/CordovaLib.docc/upgrading-8.md
@@ -187,6 +187,43 @@ result?.setKeepCallbackAs(true)
 self.commandDelegate.send(result, callbackId: callback)
 ```
 
+### Deprecating `CDVPluginResult.associatedObject`
+
+The `associatedObject` property on ``CDVPluginResult`` is now deprecated.
+
+Historically, this was commonly used as a lifetime-retention helper for legacy
+ Objective-C patterns such as constructing a string with
+ `initWithBytesNoCopy:...`, where the created `NSString` could depend on an
+ external `NSData` buffer remaining alive.
+
+In modern plugin code, prefer APIs that do not rely on external buffer
+ lifetimes.
+
+```objc
+// Old code
+NSString* payload = [[NSString alloc] initWithBytesNoCopy:(void*)[data bytes]
+                                                   length:[data length]
+                                                 encoding:NSUTF8StringEncoding
+                                             freeWhenDone:NO];
+CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                             messageAsString:payload];
+result.associatedObject = data;
+```
+
+```objc
+// New code
+NSString* payload = [[NSString alloc] initWithData:data
+                                           encoding:NSUTF8StringEncoding];
+CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                             messageAsString:payload];
+```
+
+For binary payloads, prefer message constructors that accept `NSData` directly,
+ such as `resultWithStatus:messageAsArrayBuffer:`.
+
+If you must retain auxiliary state, keep it in your plugin instance until after
+ sending the result, rather than attaching it to `CDVPluginResult`.
+
 ## Other Major Changes
 ### Deprecating AppDelegate category extensions
 

--- a/CordovaLib/include/Cordova/CDVPluginResult.h
+++ b/CordovaLib/include/Cordova/CDVPluginResult.h
@@ -131,6 +131,27 @@ NS_ASSUME_NONNULL_BEGIN
  }
  */
 @property (nonatomic, strong) NSNumber *keepCallback;
+/**
+ Deprecated helper previously used to retain an auxiliary object for the lifetime
+ of this plugin result.
+
+ A common legacy usage was retaining an `NSData` object when constructing a
+ `NSString` with `initWithBytesNoCopy:...`, where the string depended on the
+ original byte buffer remaining valid.
+
+ Prefer APIs that do not require external lifetime management (for example,
+ `[[NSString alloc] initWithData:encoding:]` or a message constructor that
+ accepts `NSData` directly, such as
+ ``resultWithStatus:messageAsArrayBuffer:``).
+
+ If you still need to retain additional state, hold it in your plugin instance
+ until after `sendPluginResult:callbackId:` returns rather than attaching it to
+ ``CDVPluginResult``.
+
+ @Metadata {
+     @Available(Cordova, introduced: "4.5.0", deprecated: "8.0.0")
+ }
+ */
 @property (nonatomic, strong) id associatedObject CDV_DEPRECATED(8.0.0, "");
 
 - (instancetype)init;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I tried to fix deprecation warnings on the file plugin and get a deprecation warning for assigning CDVPluginResult.associatedObject with no context. I made a research with AI and these are the results here.

- Document in plugin's upgrade guide `CordovaLib/CordovaLib.docc/upgrading-8.md`
- Document  on `CordovaLib/include/Cordova/CDVPluginResult.h`

Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
