### PR TITLE
fix(wkwebview): retain UIDelegate to restore alert/confirm/prompt

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.h
@@ -22,9 +22,10 @@
 
 @interface CDVWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol, WKScriptMessageHandler, WKNavigationDelegate>
 
-// The canonical WKUIDelegate used by this engine.
-// Exposed as readonly for inspection, while the engine retains it internally
-// because WKWebView.UIDelegate is weak.
+// WKUIDelegate reference for this engine, which can also be set via `updateWithInfo:`
+// by a plugin. Additionally it is a helper property to retain the UIDelegate, since
+// WKWebView.UIDelegate is weak and would otherwise be deallocated after assignment
+// which would cause JavaScript alert/confirm/prompt handling to stop working.
 @property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
 
 - (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.h
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.h
@@ -22,6 +22,9 @@
 
 @interface CDVWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol, WKScriptMessageHandler, WKNavigationDelegate>
 
+// The canonical WKUIDelegate used by this engine.
+// Exposed as readonly for inspection, while the engine retains it internally
+// because WKWebView.UIDelegate is weak.
 @property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
 
 - (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -43,8 +43,9 @@
 @property (nonatomic, readwrite) NSString *CDV_ASSETS_URL;
 @property (nonatomic, readwrite) Boolean cdvIsFileScheme;
 @property (nullable, nonatomic, strong, readwrite) WKWebViewConfiguration *configuration;
-// WKWebView.UIDelegate is weak; retain the assigned delegate to keep
-// JavaScript alert/confirm/prompt callbacks available.
+// Canonical WKUIDelegate reference for this engine, including delegates
+// provided via updateWithInfo(). We retain it because WKWebView.UIDelegate is
+// weak and otherwise JavaScript alert/confirm/prompt handling can stop working.
 @property (nonatomic, strong, readwrite) id <WKUIDelegate> uiDelegate;
 
 @end
@@ -273,7 +274,8 @@
     // CDVWebViewUIDelegate instance. This gives library consumers a way to
     // override the UI delegate and customize behaviour if needed.
     if ([self.viewController conformsToProtocol:@protocol(WKUIDelegate)]) {
-        wkWebView.UIDelegate = (id<WKUIDelegate>)self.viewController;
+        self.uiDelegate = (id<WKUIDelegate>)self.viewController;
+        wkWebView.UIDelegate = self.uiDelegate;
     } else {
         CDVWebViewUIDelegate *uiDelegate = [[CDVWebViewUIDelegate alloc] initWithViewController:self.viewController];
 
@@ -281,8 +283,9 @@
         uiDelegate.mediaPermissionGrantType = [self parsePermissionGrantType:[settings cordovaSettingForKey:@"MediaPermissionGrantType"]];
         uiDelegate.allowNewWindows = [settings cordovaBoolSettingForKey:@"AllowNewWindows" defaultValue:NO];
 
-        // WKWebView.UIDelegate is weak, so we must retain our default delegate
-        // to keep JavaScript alert/confirm/prompt handlers alive.
+        // Assigning to self.uiDelegate keeps a strong reference to the delegate,
+        // since WKWebView.UIDelegate is weak and would cause the delegate to be
+        // deallocated
         self.uiDelegate = uiDelegate;
         wkWebView.UIDelegate = self.uiDelegate;
     }
@@ -434,7 +437,9 @@
     }
 
     if (uiDelegate && [uiDelegate conformsToProtocol:@protocol(WKUIDelegate)]) {
-        wkWebView.UIDelegate = uiDelegate;
+        // Keep a strong reference to the delegate, since WKWebView.UIDelegate is weak
+        self.uiDelegate = uiDelegate;
+        wkWebView.UIDelegate = self.uiDelegate;
     }
 
     if (settings && [settings isKindOfClass:[CDVSettingsDictionary class]]) {

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -43,6 +43,9 @@
 @property (nonatomic, readwrite) NSString *CDV_ASSETS_URL;
 @property (nonatomic, readwrite) Boolean cdvIsFileScheme;
 @property (nullable, nonatomic, strong, readwrite) WKWebViewConfiguration *configuration;
+// WKWebView.UIDelegate is weak; retain the assigned delegate to keep
+// JavaScript alert/confirm/prompt callbacks available.
+@property (nonatomic, strong, readwrite) id <WKUIDelegate> uiDelegate;
 
 @end
 
@@ -278,7 +281,10 @@
         uiDelegate.mediaPermissionGrantType = [self parsePermissionGrantType:[settings cordovaSettingForKey:@"MediaPermissionGrantType"]];
         uiDelegate.allowNewWindows = [settings cordovaBoolSettingForKey:@"AllowNewWindows" defaultValue:NO];
 
-        wkWebView.UIDelegate = uiDelegate;
+        // WKWebView.UIDelegate is weak, so we must retain our default delegate
+        // to keep JavaScript alert/confirm/prompt handlers alive.
+        self.uiDelegate = uiDelegate;
+        wkWebView.UIDelegate = self.uiDelegate;
     }
 
     if ([self.viewController conformsToProtocol:@protocol(WKNavigationDelegate)]) {
@@ -301,6 +307,7 @@
 {
     WKWebView* wkWebView = (WKWebView*)_engineWebView;
     [wkWebView.configuration.userContentController removeScriptMessageHandlerForName:CDV_BRIDGE_NAME];
+    self.uiDelegate = nil;
     _engineWebView = nil;
 
     [super dispose];

--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -43,9 +43,6 @@
 @property (nonatomic, readwrite) NSString *CDV_ASSETS_URL;
 @property (nonatomic, readwrite) Boolean cdvIsFileScheme;
 @property (nullable, nonatomic, strong, readwrite) WKWebViewConfiguration *configuration;
-// Canonical WKUIDelegate reference for this engine, including delegates
-// provided via updateWithInfo(). We retain it because WKWebView.UIDelegate is
-// weak and otherwise JavaScript alert/confirm/prompt handling can stop working.
 @property (nonatomic, strong, readwrite) id <WKUIDelegate> uiDelegate;
 
 @end

--- a/tests/CordovaLibTests/CDVWebViewEngineTests.swift
+++ b/tests/CordovaLibTests/CDVWebViewEngineTests.swift
@@ -38,6 +38,17 @@ class ScriptHandlingViewController: ViewController, WKScriptMessageHandler {
 }
 
 class CDVWebViewEngineTests: XCTestCase {
+    @MainActor func testWebViewUIDelegateIsRetained() {
+        let vc = ViewController()
+        vc.webContentFolderName = "www"
+        vc.startPage = "index.html"
+
+        vc.loadViewIfNeeded()
+
+        let uiDelegate = (vc.webViewEngine as AnyObject).value(forKey: "uiDelegate")
+        XCTAssertNotNil(uiDelegate)
+    }
+
     @MainActor func testViewControllerScriptMessageHandler() {
         let vc = ScriptHandlingViewController()
         vc.webContentFolderName = "www"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Fixes a regression introduced by #1664 where the property `uiDelegate` was removed from `CDVWebViewEngine`.
- `WKWebView.UIDelegate` is weak, so the default `CDVWebViewUIDelegate` could be deallocated after assignment, which breaks JavaScript alert/confirm/prompt handling.
- Retain the delegate in `CDVWebViewEngine` by a strong property `uiDelegate` and clear it during dispose.
- The property is not only for retaining the UIDelegate, it's also part of the exposed CDVWebViewEngine API as readonly, so callers can inspect what delegate is currently installed. It can also be set through `updateWithInfo:` by a plugin. This is documented in [guides/Setting Delegates, Preferences and Script Message Handlers in the WebView.md](https://github.com/apache/cordova-ios/blob/master/guides/Setting%20Delegates%2C%20Preferences%20and%20Script%20Message%20Handlers%20in%20the%20WebView.md)
- Add a regression test that verifies the web view engine keeps a non-nil uiDelegate.
- Fixes #1684

Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
