### PR TITLE
fix(spm): keep `CordovaPlugins` deployment target synced across prepares

### DIFF
--- a/lib/SwiftPackage.js
+++ b/lib/SwiftPackage.js
@@ -44,8 +44,10 @@ package.targets.first?.dependencies.append(.product(name: "${plugin.id}", packag
         const fd = fs.openSync(this.path, 'r+');
         let packageContent = fs.readFileSync(fd, 'utf8');
 
-        packageContent = packageContent.replace(/\.iOS\(\.v[0-9]+\)/, `.iOS("${target}")`);
-        packageContent = packageContent.replace(/\.macCatalyst\(\.v[0-9]+\)/, `.macCatalyst("${target}")`);
+        // Support both enum-style (e.g. .iOS(.v13)) and string-style
+        // (e.g. .iOS("18.0")) deployment target declarations.
+        packageContent = packageContent.replace(/\.iOS\((?:\.v[0-9]+|"[0-9]+(?:\.[0-9]+)?")\)/, `.iOS("${target}")`);
+        packageContent = packageContent.replace(/\.macCatalyst\((?:\.v[0-9]+|"[0-9]+(?:\.[0-9]+)?")\)/, `.macCatalyst("${target}")`);
 
         fs.ftruncateSync(fd);
         fs.writeSync(fd, packageContent, 0, 'utf8');

--- a/tests/spec/SwiftPackage.spec.js
+++ b/tests/spec/SwiftPackage.spec.js
@@ -101,6 +101,19 @@ describe('SwiftPackage', () => {
             expect(content).toContain('.iOS("18.4")');
             expect(content).toContain('.macCatalyst("18.4")');
         });
+
+        it('should update deployment target when package already uses string syntax', () => {
+            pkg.updateDeploymentTarget('18.4');
+            pkg.updateDeploymentTarget('19.1');
+
+            const pkgPath = path.join(tmpDir.name, 'packages', 'cordova-ios-plugins', 'Package.swift');
+            const content = fs.readFileSync(pkgPath, 'utf8');
+
+            expect(content).toContain('.iOS("19.1")');
+            expect(content).toContain('.macCatalyst("19.1")');
+            expect(content).not.toContain('.iOS("18.4")');
+            expect(content).not.toContain('.macCatalyst("18.4")');
+        });
     });
 
     describe('addPlugin', () => {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- The deployment target update logic for `CordovaPlugins` only matched enum-style platform declarations (for example .iOS(.v13)). After the first sync converted the package to string-style declarations (for example .iOS("18.0")), later prepares no longer updated the value.
- Update SwiftPackage deployment target replacement to support both enum-style and string-style platform declarations for iOS and macCatalyst.
- Also add a regression test that runs deployment target updates twice and verifies the second value replaces the first.
- Closes #1683

Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
