### PR TITLE
feat(statusbar): change dark/light appearance according to background color

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -209,6 +209,7 @@ static UIColor *defaultBackgroundColor(void) {
     }
 
     [self.statusBarBackground setBackgroundColor:self.statusBarBackgroundColor];
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)setStatusBarWebViewColor:(UIColor *)color
@@ -216,6 +217,7 @@ static UIColor *defaultBackgroundColor(void) {
     _statusBarWebViewColor = color;
 
     [self.statusBarBackground setBackgroundColor:self.statusBarBackgroundColor];
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 // Only for testing
@@ -906,6 +908,20 @@ static UIColor *defaultBackgroundColor(void) {
     [self.statusBarBackground setAlpha:(visible ? 1 : 0)];
     [self setNeedsStatusBarAppearanceUpdate];
 #endif
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    CGFloat red = 0.f;
+    CGFloat green = 0.f;
+    CGFloat blue = 0.f;
+
+    if (![self.statusBarBackgroundColor getRed:&red green:&green blue:&blue alpha:nil]) {
+        return UIStatusBarStyleDefault;
+    }
+
+    CGFloat luminance = 0.299f * red + 0.587f * green + 0.114f * blue;
+    return luminance > 0.5f ? UIStatusBarStyleDarkContent : UIStatusBarStyleLightContent;
 }
 
 - (void)parseSettingsWithParser:(id <NSXMLParserDelegate>)delegate

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -912,6 +912,12 @@ static UIColor *defaultBackgroundColor(void) {
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
+    // Since iOS 18.5, the system automatically determines the status bar style based on the background color of the status bar
+    // so let the system handle it
+    if (@available(iOS 18.5, *)) {
+        return [super preferredStatusBarStyle];
+    }
+
     CGFloat red = 0.f;
     CGFloat green = 0.f;
     CGFloat blue = 0.f;

--- a/tests/CordovaLibTests/CDVStatusBarTests.m
+++ b/tests/CordovaLibTests/CDVStatusBarTests.m
@@ -170,6 +170,13 @@ andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
     [self evaluateJavaScript:@"window.statusbar.setBackgroundColor('#ffffff');"
 andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
                      timeout:5];
+    
+    // Since iOS 18.5, the system automatically determines the status bar style based on the background color of the status bar
+    // Check this
+    if (@available(iOS 18.5, *)) {
+        XCTAssertEqual(self.viewController.preferredStatusBarStyle, [UIViewController new].preferredStatusBarStyle);
+        return;
+    }
 
     XCTAssertEqual(self.viewController.preferredStatusBarStyle, UIStatusBarStyleDarkContent);
 

--- a/tests/CordovaLibTests/CDVStatusBarTests.m
+++ b/tests/CordovaLibTests/CDVStatusBarTests.m
@@ -162,4 +162,22 @@ andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
     XCTAssertEqual(rgba[3], 0.25f);
 }
 
+- (void)testStatusBarAppearanceFollowsBackgroundColor {
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self.viewController loadStartPage];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    [self evaluateJavaScript:@"window.statusbar.setBackgroundColor('#ffffff');"
+andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
+                     timeout:5];
+
+    XCTAssertEqual(self.viewController.preferredStatusBarStyle, UIStatusBarStyleDarkContent);
+
+    [self evaluateJavaScript:@"window.statusbar.setBackgroundColor('#000000');"
+andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
+                     timeout:5];
+
+    XCTAssertEqual(self.viewController.preferredStatusBarStyle, UIStatusBarStyleLightContent);
+}
+
 @end


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Since iOS 18.5 the system handles automatically the status bar appearance according to the underlying color, but before we would have to handle it by ourselves.

### Description
<!-- Describe your changes in detail -->

- Adds a luminance check to the set background color and sets the status bar appearance accordingly
- This is only done when older than 18.5. Since iOS 18.5 the system automatically handles the appearance.
- Added test `testStatusBarAppearanceFollowsBackgroundColor`

Generated-By: GPT-5.6 Terra

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
