### PR TITLE
fix(ci): disable parallel testing for Xcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         timeout-minutes: 40
         run: |
           npm ci
-          npm run test:xcode
+          npm run test:xcode -- -parallel-testing-enabled NO
         env:
           CI: true
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- I had one failing action [`Native Testing on macos-26-intel`](https://github.com/apache/cordova-ios/actions/runs/31379639262/job/93426701230?pr=1689) for PR #1689 and analyzed it with AI. The actions runs `npm run test:xcode` which leaves Xcode’s parallel testing at its default so it creates Clone 1/Clone 2.
- Parallel testing is no disbaled which prevents Xcode from spawning Clone 2 and other parallel simulator clones, which is what timed out on macos-26-intel. It preserves parallel testing for local npm run test:xcode.

Generated-By: GPT-5.6 Terra

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
