### PR TITLE
fix(tests): Fix test warnings about nil UISceneSession

### DIFF
--- a/tests/CordovaLibTests/CDVSceneDelegateTests.m
+++ b/tests/CordovaLibTests/CDVSceneDelegateTests.m
@@ -63,6 +63,7 @@
 @interface CDVSceneDelegateTests : XCTestCase
 @property (nonatomic, strong) CDVSceneDelegate *sceneDelegate;
 @property (nonatomic, strong) UIScene *placeholderScene;
+@property (nonatomic, strong) UISceneSession *placeholderSession;
 @end
 
 @implementation CDVSceneDelegateTests
@@ -71,9 +72,14 @@
 {
     [super setUp];
     self.sceneDelegate = [[CDVSceneDelegate alloc] init];
+
     // The scene object is only stored and passed back through; it is never
     // messaged, so any non-nil placeholder cast to UIScene * is sufficient.
     self.placeholderScene = (UIScene *)[NSObject new];
+
+    // You can't construct a UISceneSession directly, but you can workaround
+    // that by indirectly sending +alloc to the class instance
+    self.placeholderSession = [[[UISceneSession class] alloc] init];
 }
 
 - (void)tearDown
@@ -82,6 +88,7 @@
     [self.sceneDelegate sceneDidDisconnect:self.placeholderScene];
     self.sceneDelegate = nil;
     self.placeholderScene = nil;
+    self.placeholderSession = nil;
     [super tearDown];
 }
 
@@ -103,7 +110,7 @@
     notFiredYet.inverted = YES;
 
     [self.sceneDelegate scene:self.placeholderScene
-          willConnectToSession:nil
+          willConnectToSession:self.placeholderSession
                        options:[self connectionOptionsForURL:launchURL]];
 
     // Before the page loads, the open-URL notification must not have fired.
@@ -117,7 +124,7 @@
     NSURL *launchURL = [NSURL URLWithString:@"testscheme://path?foo=bar"];
 
     [self.sceneDelegate scene:self.placeholderScene
-          willConnectToSession:nil
+          willConnectToSession:self.placeholderSession
                        options:[self connectionOptionsForURL:launchURL]];
 
     XCTNSNotificationExpectation *openURLFired = [[XCTNSNotificationExpectation alloc]
@@ -138,7 +145,7 @@
     CDVFakeSceneConnectionOptions *options = [CDVFakeSceneConnectionOptions optionsWithURLContexts:[NSSet set]];
 
     [self.sceneDelegate scene:self.placeholderScene
-          willConnectToSession:nil
+          willConnectToSession:self.placeholderSession
                        options:options];
 
     XCTNSNotificationExpectation *notFired = [[XCTNSNotificationExpectation alloc]
@@ -157,7 +164,7 @@
     NSURL *launchURL = [NSURL URLWithString:@"testscheme://path?foo=bar"];
 
     [self.sceneDelegate scene:self.placeholderScene
-          willConnectToSession:nil
+          willConnectToSession:self.placeholderSession
                        options:[self connectionOptionsForURL:launchURL]];
 
     [self.sceneDelegate sceneDidDisconnect:self.placeholderScene];


### PR DESCRIPTION

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `+alloc` method on UISceneSession isn't publicly exposed, so we need to do it indirectly by calling it on the class instance. We don't actually do anything with the session, we just need it not to be nil so it doesn't cause warnings.


### Description
<!-- Describe your changes in detail -->
Create a UISceneSession and pass it where required in test cases.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tests run with no warnings.


### Checklist

- [x] I've run the tests to see all new and existing tests pass