### PR TITLE
fix(statusbar): keep built-in status bar view visibility in sync with the JS API

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -746,8 +746,6 @@ static UIColor *defaultBackgroundColor(void) {
     [self.statusBar.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor].active = YES;
     [self.statusBar.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
     [self.statusBar.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-
-    self.statusBar.hidden = YES;
 #endif
 }
 
@@ -890,6 +888,7 @@ static UIColor *defaultBackgroundColor(void) {
 - (void)showStatusBar:(BOOL)visible
 {
 #if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
+    self.statusBar.hidden = !visible;
     [self.statusBar setAlpha:(visible ? 1 : 0)];
     [self setNeedsStatusBarAppearanceUpdate];
 #endif

--- a/tests/CordovaLibTests/CDVStatusBarTests.m
+++ b/tests/CordovaLibTests/CDVStatusBarTests.m
@@ -21,6 +21,7 @@
 #import <XCTest/XCTest.h>
 #import <Cordova/Cordova.h>
 #import "CDVWebViewEngine.h"
+#import "CDVViewController+Private.h"
 #import "CordovaApp-Swift.h"
 #import "CDVTestHelpers.h"
 
@@ -160,6 +161,21 @@ andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
     XCTAssertEqual(rgba[1], 0.f);
     XCTAssertEqual(rgba[2], 0.f);
     XCTAssertEqual(rgba[3], 0.25f);
+}
+
+- (void) testStatusBarVisibility {
+    UIView *statusBar = [self.viewController valueForKey:@"statusBar"];
+    XCTAssertNotNil(statusBar);
+
+    [self.viewController showStatusBar:NO];
+    XCTAssertTrue(self.viewController.prefersStatusBarHidden);
+    XCTAssertTrue(statusBar.hidden);
+    XCTAssertEqual(statusBar.alpha, 0.f);
+
+    [self.viewController showStatusBar:YES];
+    XCTAssertFalse(self.viewController.prefersStatusBarHidden);
+    XCTAssertFalse(statusBar.hidden);
+    XCTAssertEqual(statusBar.alpha, 1.f);
 }
 
 @end


### PR DESCRIPTION
## What
The built-in status bar view (which paints StatusBarBackgroundColor from config.xml) was created with `hidden = YES`, and its `hidden` flag was only ever updated by the `scrollViewDidChangeAdjustedContentInset:` delegate callback. `showStatusBar:` (the `window.statusbar.visible` / `StatusBarInternal.setVisible` path) only toggled the view's `alpha`, so when the scroll-view delegate callback does not fire the status bar view stays hidden regardless of the JS API or config.xml, making the status bar appear unresponsive (apache/cordova-ios#1693, broken on iOS 27). This change creates the status bar view visible and makes `showStatusBar:` drive `hidden` together with `alpha`, keeping the two visibility controls coherent, and adds a regression test asserting the view's `hidden`/`alpha` and `prefersStatusBarHidden` state after both show and hide calls.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #1693