### PR TITLE
doc(statusbar): Hide/Show mechanism for Mac Catalyst by `HideDesktopTitlebar`

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -421,6 +421,9 @@ static UIColor *defaultBackgroundColor(void) {
 
         if ([self.webView respondsToSelector:@selector(scrollView)]) {
             UIScrollView *scrollView = [self.webView performSelector:@selector(scrollView)];
+            // The web view is already constrained below the Mac Catalyst title bar,
+            // so disable UIKit's automatic safe-area inset adjustment. The status
+            // bar view is hidden for this mode in scrollViewDidChangeAdjustedContentInset:.
             scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
         }
     }
@@ -583,6 +586,9 @@ static UIColor *defaultBackgroundColor(void) {
         return;
     }
 
+    // On Mac Catalyst, Cordova may manually constrain the web view below the title bar.
+    // In that case automatic scroll-view inset adjustment is disabled, so the synthetic
+    // status bar view should be hidden.
     self.statusBar.hidden = (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever);
 #endif
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- On Mac Catalyst when `HideDesktopTitlebar` is `false`, `scrollView.contentInsetAdjustmentBehavior` will be set to `UIScrollViewContentInsetAdjustmentNever`, which hides the status bar in `scrollViewDidChangeAdjustedContentInset:`. This what not obvious, when insepcting the line `self.statusBar.hidden = (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever);` on `scrollViewDidChangeAdjustedContentInset:`

Generated-By: Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
