### PR TITLE
doc(CDVViewController): document `scrollViewDidChangeAdjustedContentInset:`

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -579,9 +579,8 @@ static UIColor *defaultBackgroundColor(void) {
 }
 
 /**
- * This is called initially when the WKWebView is initialized and also when viewport-fit is changed.
- * WebKit still doesn't expose _webView:didChangeSafeAreaShouldAffectObscuredInsets: as public API,
- * so we need to react based on the scrollView delegate.
+ * We use this delegate method on the web view's scrollView to detect when the safe area insets are changed
+ * by the viewport-fit value.
  */
 - (void)scrollViewDidChangeAdjustedContentInset:(UIScrollView *)scrollView
 {

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -578,6 +578,11 @@ static UIColor *defaultBackgroundColor(void) {
     }
 }
 
+/**
+ * This is called initially when the WKWebView is initialized and also when viewport-fit is changed.
+ * WebKit still doesn't expose _webView:didChangeSafeAreaShouldAffectObscuredInsets: as public API,
+ * so we need to react based on the scrollView delegate.
+ */
 - (void)scrollViewDidChangeAdjustedContentInset:(UIScrollView *)scrollView
 {
 #if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
@@ -586,6 +591,9 @@ static UIColor *defaultBackgroundColor(void) {
         return;
     }
 
+    // Detect changes on viewport-fit:
+    // viewport-fit=cover causes the contentInsetAdjustmentBehavior to be UIScrollViewContentInsetAdjustmentNever
+    //
     // On Mac Catalyst, Cordova may manually constrain the web view below the title bar.
     // In that case automatic scroll-view inset adjustment is disabled, so the synthetic
     // status bar view should be hidden.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Make clear that `scrollViewDidChangeAdjustedContentInset:` is called when the `WKWebView` is initialized and also when `viewport-fit` is changed.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
