### PR TITLE
refactor(statusbar): Refactor the status bar hiding code

### DIFF
--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -45,6 +45,7 @@ static UIColor *defaultBackgroundColor(void) {
     UIColor *_statusBarBackgroundColor;
     UIColor *_statusBarWebViewColor;
     UIColor *_statusBarDefaultColor;
+    BOOL _statusBarHidden;
     CDVSettingsDictionary* _settings;
 }
 
@@ -598,7 +599,11 @@ static UIColor *defaultBackgroundColor(void) {
     // On Mac Catalyst, Cordova may manually constrain the web view below the title bar.
     // In that case automatic scroll-view inset adjustment is disabled, so the synthetic
     // status bar view should be hidden.
-    self.statusBarBackground.hidden = (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever);
+    if (_statusBarHidden) {
+        self.statusBarBackground.hidden = true;
+    } else {
+        self.statusBarBackground.hidden = (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever);
+    }
 #endif
 }
 
@@ -607,7 +612,7 @@ static UIColor *defaultBackgroundColor(void) {
 {
     // The CDVStatusBar plugin overrides this in a category extension, and
     // should bypass this implementation entirely
-    return self.statusBarBackground.alpha < 0.0001f;
+    return _statusBarHidden;
 }
 #endif
 
@@ -905,7 +910,11 @@ static UIColor *defaultBackgroundColor(void) {
 - (void)showStatusBar:(BOOL)visible
 {
 #if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
-    [self.statusBarBackground setAlpha:(visible ? 1 : 0)];
+    _statusBarHidden = !visible;
+
+    UIScrollView *scrollView = [self.webView performSelector:@selector(scrollView)];
+    [self scrollViewDidChangeAdjustedContentInset:scrollView];
+
     [self setNeedsStatusBarAppearanceUpdate];
 #endif
 }

--- a/tests/CordovaLibTests/CDVStatusBarTests.m
+++ b/tests/CordovaLibTests/CDVStatusBarTests.m
@@ -170,7 +170,7 @@ andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
     [self evaluateJavaScript:@"window.statusbar.setBackgroundColor('#ffffff');"
 andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
                      timeout:5];
-    
+
     // Since iOS 18.5, the system automatically determines the status bar style based on the background color of the status bar
     // Check this
     if (@available(iOS 18.5, *)) {
@@ -186,5 +186,33 @@ andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
 
     XCTAssertEqual(self.viewController.preferredStatusBarStyle, UIStatusBarStyleLightContent);
 }
+
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
+- (void) testStatusBarHidden {
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self.viewController loadStartPage];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    XCTAssertEqual([self.viewController prefersStatusBarHidden], false);
+
+    [self evaluateJavaScript:@"window.statusbar.visible = false;"
+andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
+                     timeout:5];
+
+    XCTAssertEqual([self.viewController prefersStatusBarHidden], true);
+}
+
+- (void) testTransparentStatusBarBackgroundIsNotHidden {
+    XCTestExpectation *loadExpectation = [[XCTNSNotificationExpectation alloc] initWithName:CDVTestingDeviceReadyFired];
+    [self.viewController loadStartPage];
+    [self waitForExpectations:@[loadExpectation] timeout:5];
+
+    [self evaluateJavaScript:@"window.statusbar.setBackgroundColor('transparent');"
+andWaitForCordovaCommandQueueWithWebViewEngine:self.plugin
+                     timeout:5];
+
+    XCTAssertEqual([self.viewController prefersStatusBarHidden], false);
+}
+#endif
 
 @end


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The use of background colour alpha to determine whether status bar content was visible was confusing, so make it its own boolean.


### Description
<!-- Describe your changes in detail -->
Added an internal `_statusBarHidden` boolean to CDVViewController to control whether the status bar content is visible or not.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Added test cases to confirm the behaviour.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change