### PR TITLE
test: Silence 2 test case warnings

### DIFF
--- a/tests/CordovaLibTests/CDVPluginResultJSONSerializationTests.m
+++ b/tests/CordovaLibTests/CDVPluginResultJSONSerializationTests.m
@@ -149,6 +149,7 @@
     XCTAssertTrue([quotedString isEqualToString:[[result argumentsAsJSON] cdv_JSONFragment]]);
 }
 
+#ifndef __clang_analyzer__ // Silence a static analyzer warning about passing nil to messageAsString:
 - (void)testSerializingMessageAsStringThatIsNil
 {
     NSString* nilString = nil;
@@ -156,5 +157,6 @@
 
     XCTAssertTrue([[NSNull null] isEqual:[[result argumentsAsJSON] cdv_JSONFragment]]);
 }
+#endif
 
 @end

--- a/tests/CordovaLibTests/CDVSceneDelegateTests.m
+++ b/tests/CordovaLibTests/CDVSceneDelegateTests.m
@@ -40,7 +40,7 @@
     return context;
 }
 - (NSURL *)URL { return self.fakeURL; }
-- (UISceneOpenURLOptions *)options { return nil; }
+- (UISceneOpenURLOptions *)options { return [[[UISceneOpenURLOptions class] alloc] init]; }
 @end
 
 @interface CDVFakeSceneConnectionOptions : UISceneConnectionOptions


### PR DESCRIPTION

### Platforms affected
iOS

### Description
<!-- Describe your changes in detail -->
We've annotated CDVPluginResult messageAsString: to only accept a non-nil argument, but this test is specifically intended to make sure that if it does get a nil argument it doesn't blow up. The static analyzer (rightfully) complains about passing nil to a method that requires non-nil, but we'll just silence that in this specific case.

UIOpenURLContext requires that options return a non-nil object, so use the same hack to default construct a UISceneOpenURLOptions that we did for UISceneSession.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tests pass locally.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change